### PR TITLE
Add withSetup DSL for deferred test inputs (#57)

### DIFF
--- a/core/src/main/scala/pl/iterators/baklava/BaklavaTestFrameworkDsl.scala
+++ b/core/src/main/scala/pl/iterators/baklava/BaklavaTestFrameworkDsl.scala
@@ -173,7 +173,9 @@ trait BaklavaTestFrameworkDsl[RouteType, ToRequestBodyType[_], FromResponseBodyT
     Headers,
     HeadersProvided
   ] = {
-    val headersToInclude          = provideHeaders.apply(requestContext.headersDefinition, headersProvided)
+    val headersToInclude = provideHeaders.apply(requestContext.headersDefinition, headersProvided)
+    // TODO: this security logic is duplicated in multiple places and messy and NEEDS TESTS
+    // TODO: e.g. cookie concatenation by hand?!
     val additionalSecurityHeaders = security match {
       case AppliedSecurity(_: HttpBearer, params) => Map("Authorization" -> s"Bearer ${params("token")}")
       case AppliedSecurity(_: HttpBasic, params)  =>

--- a/core/src/main/scala/pl/iterators/baklava/BaklavaTestFrameworkDsl.scala
+++ b/core/src/main/scala/pl/iterators/baklava/BaklavaTestFrameworkDsl.scala
@@ -251,6 +251,103 @@ trait BaklavaTestFrameworkDsl[RouteType, ToRequestBodyType[_], FromResponseBodyT
     )
   }
 
+  private[baklava] def validateResponseAndStore[
+      RequestBody,
+      ResponseBody,
+      PathParameters,
+      PathParametersProvided,
+      QueryParameters,
+      QueryParametersProvided,
+      Headers,
+      HeadersProvided
+  ](
+      body: RequestBody,
+      requestContext: BaklavaRequestContext[
+        RequestBody,
+        PathParameters,
+        PathParametersProvided,
+        QueryParameters,
+        QueryParametersProvided,
+        Headers,
+        HeadersProvided
+      ],
+      responseContext: BaklavaResponseContext[ResponseBody, HttpRequest, HttpResponse],
+      requestBodySchema: Schema[RequestBody],
+      responseBodySchema: Schema[ResponseBody],
+      statusCode: BaklavaHttpStatus,
+      expectedResponseHeaders: Seq[Header[?]],
+      strictHeaderCheck: Boolean
+  ): Unit = {
+    body match {
+      case b: FormOf[_] =>
+        val allFields      = requestBodySchema.properties.keys.toList
+        val requiredFields = requestBodySchema.properties
+          .filter(_._2.required)
+          .keys
+          .toList
+
+        val missingFields = requiredFields.filterNot(f => b.fields.exists(_._1 == f))
+        if (missingFields.nonEmpty) {
+          throw new BaklavaAssertionException(
+            s"Missing required fields in form: ${missingFields.mkString(", ")}"
+          )
+        }
+        val extraFields = b.fields.map(_._1).filterNot(allFields.contains)
+        if (extraFields.nonEmpty) {
+          throw new BaklavaAssertionException(
+            s"Extra fields in form: ${extraFields.mkString(", ")}"
+          )
+        }
+      case _ =>
+    }
+
+    if (responseContext.status != statusCode) {
+      throw new BaklavaAssertionException(
+        s"Expected ${statusCode.status} -> ${responseBodySchema.className}, but got ${responseContext.status.status} -> ${responseContext.responseBodyString.take(maxBodyLengthInAssertion)}"
+      )
+    }
+
+    if (responseContext.responseBodyString.nonEmpty && responseBodySchema == Schema.emptyBodySchema) {
+      throw new BaklavaAssertionException(
+        "Expected empty response body, but got: " + responseContext.responseBodyString.take(maxBodyLengthInAssertion)
+      )
+    }
+
+    val headersParsed = expectedResponseHeaders.map { h =>
+      responseContext.headers.headers.get(h.name) match { // TODO: should be case insensitive
+        case None        => throw new BaklavaAssertionException(s"Header ${h.name} not found but expected")
+        case Some(value) =>
+          h.name ->
+          h.tsm
+            .unapply(value)
+            .getOrElse(
+              throw new BaklavaAssertionException(
+                s"Header ${h.name} with value $value could not be parsed as ${h.schema.className}"
+              )
+            )
+      }
+    }
+    if (strictHeaderCheck && headersParsed.distinctBy(_._1).length != responseContext.headers.headers.size) {
+      throw new BaklavaAssertionException(
+        s"Strict headers check is on, expected following headers: [${expectedResponseHeaders
+            .map(h => h.name)
+            .sorted
+            .mkString(", ")}], but got: [${responseContext.headers.headers.keys.toList.sorted.mkString(", ")}]"
+      )
+    }
+
+    if (
+      requestContext.security.security != NoopSecurity && !requestContext.securitySchemes
+        .exists(_.security == requestContext.security.security)
+    ) {
+      throw new BaklavaAssertionException(
+        s"Used security ${requestContext.security.security.`type`} is not defined in security schemes: [${requestContext.securitySchemes.map(ss => s"${ss.name} -> ${ss.security.`type`}").mkString(", ")}]"
+      )
+    }
+
+    store(requestContext, responseContext.copy(bodySchema = Some(responseBodySchema)))
+  }
+
   case class OnRequest[RequestBody: ToRequestBodyType: Schema, PathParametersProvided, QueryParametersProvided, HeadersProvided](
       body: RequestBody,
       security: AppliedSecurity,
@@ -339,74 +436,25 @@ trait BaklavaTestFrameworkDsl[RouteType, ToRequestBodyType[_], FromResponseBodyT
                       )
                     timesCalled += 1
 
-                    body match {
-                      case b: FormOf[_] =>
-                        val allFields      = implicitly[Schema[RequestBody]].properties.keys.toList
-                        val requiredFields = implicitly[Schema[RequestBody]].properties
-                          .filter(_._2.required)
-                          .keys
-                          .toList
-
-                        val missingFields = requiredFields.filterNot(f => b.fields.exists(_._1 == f))
-                        if (missingFields.nonEmpty) {
-                          throw new BaklavaAssertionException(
-                            s"Missing required fields in form: ${missingFields.mkString(", ")}"
-                          )
-                        }
-                        val extraFields = b.fields.map(_._1).filterNot(allFields.contains)
-                        if (extraFields.nonEmpty) {
-                          throw new BaklavaAssertionException(
-                            s"Extra fields in form: ${extraFields.mkString(", ")}"
-                          )
-                        }
-                      case _ =>
-                    }
-
-                    if (responseContext.status != statusCode) {
-                      throw new BaklavaAssertionException(
-                        s"Expected ${statusCode.status} -> ${implicitly[Schema[ResponseBody]].className}, but got ${responseContext.status.status} -> ${responseContext.responseBodyString.take(maxBodyLengthInAssertion)}"
-                      )
-                    }
-
-                    if (responseContext.responseBodyString.nonEmpty && implicitly[Schema[ResponseBody]] == Schema.emptyBodySchema) {
-                      throw new BaklavaAssertionException(
-                        "Expected empty response body, but got: " + responseContext.responseBodyString.take(maxBodyLengthInAssertion)
-                      )
-                    }
-
-                    val headersParsed = headers.map { h =>
-                      responseContext.headers.headers.get(h.name) match { // TODO: should be case insensitive
-                        case None        => throw new BaklavaAssertionException(s"Header ${h.name} not found but expected")
-                        case Some(value) =>
-                          h.name ->
-                          h.tsm
-                            .unapply(value)
-                            .getOrElse(
-                              throw new BaklavaAssertionException(
-                                s"Header ${h.name} with value $value could not be parsed as ${h.schema.className}"
-                              )
-                            )
-                      }
-                    }
-                    if (strictHeaderCheck && headersParsed.distinctBy(_._1).length != responseContext.headers.headers.size) {
-                      throw new BaklavaAssertionException(
-                        s"Strict headers check is on, expected following headers: [${headers
-                            .map(h => h.name)
-                            .sorted
-                            .mkString(", ")}], but got: [${responseContext.headers.headers.keys.toList.sorted.mkString(", ")}]"
-                      )
-                    }
-
-                    if (
-                      requestContext.security.security != NoopSecurity && !requestContext.securitySchemes
-                        .exists(_.security == requestContext.security.security)
-                    ) {
-                      throw new BaklavaAssertionException(
-                        s"Used security ${requestContext.security.security.`type`} is not defined in security schemes: [${requestContext.securitySchemes.map(ss => s"${ss.name} -> ${ss.security.`type`}").mkString(", ")}]"
-                      )
-                    }
-
-                    store(requestContext, responseContext.copy(bodySchema = Some(implicitly[Schema[ResponseBody]])))
+                    validateResponseAndStore[
+                      RequestBody,
+                      ResponseBody,
+                      PathParameters,
+                      PathParametersProvided,
+                      QueryParameters,
+                      QueryParametersProvided,
+                      Headers,
+                      HeadersProvided
+                    ](
+                      body = body,
+                      requestContext = requestContext,
+                      responseContext = responseContext,
+                      requestBodySchema = implicitly[Schema[RequestBody]],
+                      responseBodySchema = implicitly[Schema[ResponseBody]],
+                      statusCode = statusCode,
+                      expectedResponseHeaders = headers,
+                      strictHeaderCheck = strictHeaderCheck
+                    )
                     responseContext
                   }
                   val baklavaCaseContext = BaklavaCaseContext(finalRequestCtx, wrappedPerformRequest)
@@ -662,74 +710,25 @@ trait BaklavaTestFrameworkDsl[RouteType, ToRequestBodyType[_], FromResponseBodyT
                 )
               timesCalled += 1
 
-              onReq.body match {
-                case b: FormOf[_] =>
-                  val allFields      = implicitly[Schema[RequestBody]].properties.keys.toList
-                  val requiredFields = implicitly[Schema[RequestBody]].properties
-                    .filter(_._2.required)
-                    .keys
-                    .toList
-
-                  val missingFields = requiredFields.filterNot(f => b.fields.exists(_._1 == f))
-                  if (missingFields.nonEmpty) {
-                    throw new BaklavaAssertionException(
-                      s"Missing required fields in form: ${missingFields.mkString(", ")}"
-                    )
-                  }
-                  val extraFields = b.fields.map(_._1).filterNot(allFields.contains)
-                  if (extraFields.nonEmpty) {
-                    throw new BaklavaAssertionException(
-                      s"Extra fields in form: ${extraFields.mkString(", ")}"
-                    )
-                  }
-                case _ =>
-              }
-
-              if (responseContext.status != statusCode) {
-                throw new BaklavaAssertionException(
-                  s"Expected ${statusCode.status} -> ${implicitly[Schema[ResponseBody]].className}, but got ${responseContext.status.status} -> ${responseContext.responseBodyString.take(maxBodyLengthInAssertion)}"
-                )
-              }
-
-              if (responseContext.responseBodyString.nonEmpty && implicitly[Schema[ResponseBody]] == Schema.emptyBodySchema) {
-                throw new BaklavaAssertionException(
-                  "Expected empty response body, but got: " + responseContext.responseBodyString.take(maxBodyLengthInAssertion)
-                )
-              }
-
-              val headersParsed = expectedResponseHeaders.map { h =>
-                responseContext.headers.headers.get(h.name) match {
-                  case None        => throw new BaklavaAssertionException(s"Header ${h.name} not found but expected")
-                  case Some(value) =>
-                    h.name ->
-                    h.tsm
-                      .unapply(value)
-                      .getOrElse(
-                        throw new BaklavaAssertionException(
-                          s"Header ${h.name} with value $value could not be parsed as ${h.schema.className}"
-                        )
-                      )
-                }
-              }
-              if (strictHeaderCheck && headersParsed.distinctBy(_._1).length != responseContext.headers.headers.size) {
-                throw new BaklavaAssertionException(
-                  s"Strict headers check is on, expected following headers: [${expectedResponseHeaders
-                      .map(h => h.name)
-                      .sorted
-                      .mkString(", ")}], but got: [${responseContext.headers.headers.keys.toList.sorted.mkString(", ")}]"
-                )
-              }
-
-              if (
-                requestContext.security.security != NoopSecurity && !requestContext.securitySchemes
-                  .exists(_.security == requestContext.security.security)
-              ) {
-                throw new BaklavaAssertionException(
-                  s"Used security ${requestContext.security.security.`type`} is not defined in security schemes: [${requestContext.securitySchemes.map(ss => s"${ss.name} -> ${ss.security.`type`}").mkString(", ")}]"
-                )
-              }
-
-              store(requestContext, responseContext.copy(bodySchema = Some(implicitly[Schema[ResponseBody]])))
+              validateResponseAndStore[
+                RequestBody,
+                ResponseBody,
+                PathParameters,
+                PathParametersProvided,
+                QueryParameters,
+                QueryParametersProvided,
+                Headers,
+                HeadersProvided
+              ](
+                body = onReq.body,
+                requestContext = requestContext,
+                responseContext = responseContext,
+                requestBodySchema = implicitly[Schema[RequestBody]],
+                responseBodySchema = implicitly[Schema[ResponseBody]],
+                statusCode = statusCode,
+                expectedResponseHeaders = expectedResponseHeaders,
+                strictHeaderCheck = strictHeaderCheck
+              )
               responseContext
             }
             val baklavaCaseContext = BaklavaCaseContext(finalRequestCtx, wrappedPerformRequest)

--- a/core/src/main/scala/pl/iterators/baklava/BaklavaTestFrameworkDsl.scala
+++ b/core/src/main/scala/pl/iterators/baklava/BaklavaTestFrameworkDsl.scala
@@ -425,6 +425,337 @@ trait BaklavaTestFrameworkDsl[RouteType, ToRequestBodyType[_], FromResponseBodyT
       }
   }
 
+  trait WithSetupTestCase[S, RequestBody, ResponseBody, PathParametersProvided, QueryParametersProvided, HeadersProvided] {
+    def assert[R: TestFrameworkExecutionType, PathParameters, QueryParameters, Headers](
+        r: (
+            BaklavaCaseContext[
+              RequestBody,
+              ResponseBody,
+              PathParameters,
+              PathParametersProvided,
+              QueryParameters,
+              QueryParametersProvided,
+              Headers,
+              HeadersProvided
+            ],
+            S
+        ) => R
+    )(implicit
+        providePathParams: ProvidePathParams[PathParameters, PathParametersProvided],
+        provideQueryParams: ProvideQueryParams[QueryParameters, QueryParametersProvided],
+        provideHeaders: ProvideHeaders[Headers, HeadersProvided]
+    ): BaklavaIntermediateTestCase[PathParameters, QueryParameters, Headers]
+  }
+
+  trait WithSetupRequestBuilder[S, RequestBody, PathParametersProvided, QueryParametersProvided, HeadersProvided] {
+    def respondsWith[ResponseBody: FromResponseBodyType: Schema: ClassTag](
+        statusCode: BaklavaHttpStatus,
+        headers: Seq[Header[?]] = Seq.empty,
+        description: String = "",
+        strictHeaderCheck: Boolean = strictHeaderCheckDefault
+    ): WithSetupTestCase[S, RequestBody, ResponseBody, PathParametersProvided, QueryParametersProvided, HeadersProvided]
+  }
+
+  trait WithSetupBuilder[S] {
+    def request[RequestBody: ToRequestBodyType: Schema, PathParametersProvided, QueryParametersProvided, HeadersProvided](
+        f: S => OnRequest[RequestBody, PathParametersProvided, QueryParametersProvided, HeadersProvided]
+    ): WithSetupRequestBuilder[S, RequestBody, PathParametersProvided, QueryParametersProvided, HeadersProvided]
+
+    def request[RequestBody: ToRequestBodyType: Schema, PathParametersProvided, QueryParametersProvided, HeadersProvided](
+        body: RequestBody = EmptyBodyInstance: EmptyBody,
+        security: AppliedSecurity = AppliedSecurity(NoopSecurity, Map.empty),
+        pathParameters: PathParametersProvided = (),
+        queryParameters: QueryParametersProvided = (),
+        headers: HeadersProvided = ()
+    ): WithSetupRequestBuilder[S, RequestBody, PathParametersProvided, QueryParametersProvided, HeadersProvided]
+  }
+
+  def withSetup[S](setup: => S): WithSetupBuilder[S] = {
+    val setupThunk: () => S = () => setup
+    new WithSetupBuilder[S] {
+      override def request[RequestBody: ToRequestBodyType: Schema, PathParametersProvided, QueryParametersProvided, HeadersProvided](
+          f: S => OnRequest[RequestBody, PathParametersProvided, QueryParametersProvided, HeadersProvided]
+      ): WithSetupRequestBuilder[S, RequestBody, PathParametersProvided, QueryParametersProvided, HeadersProvided] =
+        makeRequestBuilder(setupThunk, f)
+
+      override def request[RequestBody: ToRequestBodyType: Schema, PathParametersProvided, QueryParametersProvided, HeadersProvided](
+          body: RequestBody,
+          security: AppliedSecurity,
+          pathParameters: PathParametersProvided,
+          queryParameters: QueryParametersProvided,
+          headers: HeadersProvided
+      ): WithSetupRequestBuilder[S, RequestBody, PathParametersProvided, QueryParametersProvided, HeadersProvided] =
+        makeRequestBuilder(
+          setupThunk,
+          (_: S) =>
+            OnRequest[RequestBody, PathParametersProvided, QueryParametersProvided, HeadersProvided](
+              body = body,
+              security = security,
+              headersProvided = headers,
+              pathParametersProvided = pathParameters,
+              queryParametersProvided = queryParameters
+            )
+        )
+    }
+  }
+
+  private def makeRequestBuilder[
+      S,
+      RequestBody: ToRequestBodyType: Schema,
+      PathParametersProvided,
+      QueryParametersProvided,
+      HeadersProvided
+  ](
+      setupThunk: () => S,
+      requestFn: S => OnRequest[RequestBody, PathParametersProvided, QueryParametersProvided, HeadersProvided]
+  ): WithSetupRequestBuilder[S, RequestBody, PathParametersProvided, QueryParametersProvided, HeadersProvided] =
+    new WithSetupRequestBuilder[S, RequestBody, PathParametersProvided, QueryParametersProvided, HeadersProvided] {
+      override def respondsWith[ResponseBody: FromResponseBodyType: Schema: ClassTag](
+          statusCode: BaklavaHttpStatus,
+          headers: Seq[Header[?]],
+          description: String,
+          strictHeaderCheck: Boolean
+      ): WithSetupTestCase[S, RequestBody, ResponseBody, PathParametersProvided, QueryParametersProvided, HeadersProvided] =
+        makeWithSetupTestCase(setupThunk, requestFn, statusCode, headers, description, strictHeaderCheck)
+    }
+
+  private def makeWithSetupTestCase[
+      S,
+      RequestBody: ToRequestBodyType: Schema,
+      ResponseBody: FromResponseBodyType: Schema: ClassTag,
+      PathParametersProvided,
+      QueryParametersProvided,
+      HeadersProvided
+  ](
+      setupThunk: () => S,
+      requestFn: S => OnRequest[RequestBody, PathParametersProvided, QueryParametersProvided, HeadersProvided],
+      statusCode: BaklavaHttpStatus,
+      expectedResponseHeaders: Seq[Header[?]],
+      description: String,
+      strictHeaderCheck: Boolean
+  ): WithSetupTestCase[S, RequestBody, ResponseBody, PathParametersProvided, QueryParametersProvided, HeadersProvided] =
+    new WithSetupTestCase[S, RequestBody, ResponseBody, PathParametersProvided, QueryParametersProvided, HeadersProvided] {
+      override def assert[R: TestFrameworkExecutionType, PathParameters, QueryParameters, Headers](
+          r: (
+              BaklavaCaseContext[
+                RequestBody,
+                ResponseBody,
+                PathParameters,
+                PathParametersProvided,
+                QueryParameters,
+                QueryParametersProvided,
+                Headers,
+                HeadersProvided
+              ],
+              S
+          ) => R
+      )(implicit
+          providePathParams: ProvidePathParams[PathParameters, PathParametersProvided],
+          provideQueryParams: ProvideQueryParams[QueryParameters, QueryParametersProvided],
+          provideHeaders: ProvideHeaders[Headers, HeadersProvided]
+      ): BaklavaIntermediateTestCase[PathParameters, QueryParameters, Headers] =
+        withSetupExecute(
+          setupThunk,
+          requestFn,
+          statusCode,
+          expectedResponseHeaders,
+          description,
+          strictHeaderCheck,
+          r
+        )
+    }
+
+  private def withSetupExecute[
+      S,
+      R: TestFrameworkExecutionType,
+      RequestBody: ToRequestBodyType: Schema,
+      ResponseBody: FromResponseBodyType: Schema: ClassTag,
+      PathParameters,
+      PathParametersProvided,
+      QueryParameters,
+      QueryParametersProvided,
+      Headers,
+      HeadersProvided
+  ](
+      setupThunk: () => S,
+      requestFn: S => OnRequest[RequestBody, PathParametersProvided, QueryParametersProvided, HeadersProvided],
+      statusCode: BaklavaHttpStatus,
+      expectedResponseHeaders: Seq[Header[?]],
+      description: String,
+      strictHeaderCheck: Boolean,
+      assertFn: (
+          BaklavaCaseContext[
+            RequestBody,
+            ResponseBody,
+            PathParameters,
+            PathParametersProvided,
+            QueryParameters,
+            QueryParametersProvided,
+            Headers,
+            HeadersProvided
+          ],
+          S
+      ) => R
+  )(implicit
+      providePathParams: ProvidePathParams[PathParameters, PathParametersProvided],
+      provideQueryParams: ProvideQueryParams[QueryParameters, QueryParametersProvided],
+      provideHeaders: ProvideHeaders[Headers, HeadersProvided]
+  ): BaklavaIntermediateTestCase[PathParameters, QueryParameters, Headers] =
+    new BaklavaIntermediateTestCase[PathParameters, QueryParameters, Headers] {
+      override def apply(
+          requestContext: BaklavaRequestContext[Unit, PathParameters, Unit, QueryParameters, Unit, Headers, Unit]
+      ): TestFrameworkFragmentType = {
+        val finalDescription = if (description.trim.isEmpty) "" else ": " + description.trim
+        var timesCalled: Int = 0
+
+        requestLevelTextWithExecution(
+          statusCode.status.toString + finalDescription,
+          requestContext, {
+            val setupValue = setupThunk()
+            val onReq      = requestFn(setupValue)
+
+            val finalRequestCtx = resolveRequestContext[
+              RequestBody,
+              PathParameters,
+              PathParametersProvided,
+              QueryParameters,
+              QueryParametersProvided,
+              Headers,
+              HeadersProvided
+            ](
+              requestContext = requestContext,
+              body = onReq.body,
+              bodySchema = implicitly[Schema[RequestBody]],
+              security = onReq.security,
+              pathParametersProvided = onReq.pathParametersProvided,
+              queryParametersProvided = onReq.queryParametersProvided,
+              headersProvided = onReq.headersProvided,
+              responseDescription = if (description.trim.isEmpty) None else Some(description.trim),
+              responseHeaders = expectedResponseHeaders
+            )
+
+            val wrappedPerformRequest = (
+                requestContext: BaklavaRequestContext[
+                  RequestBody,
+                  PathParameters,
+                  PathParametersProvided,
+                  QueryParameters,
+                  QueryParametersProvided,
+                  Headers,
+                  HeadersProvided
+                ],
+                route: RouteType
+            ) => {
+              val responseContext =
+                baklavaPerformRequest[
+                  RequestBody,
+                  ResponseBody,
+                  PathParameters,
+                  PathParametersProvided,
+                  QueryParameters,
+                  QueryParametersProvided,
+                  Headers,
+                  HeadersProvided
+                ](
+                  requestContext,
+                  route
+                )
+              timesCalled += 1
+
+              onReq.body match {
+                case b: FormOf[_] =>
+                  val allFields      = implicitly[Schema[RequestBody]].properties.keys.toList
+                  val requiredFields = implicitly[Schema[RequestBody]].properties
+                    .filter(_._2.required)
+                    .keys
+                    .toList
+
+                  val missingFields = requiredFields.filterNot(f => b.fields.exists(_._1 == f))
+                  if (missingFields.nonEmpty) {
+                    throw new BaklavaAssertionException(
+                      s"Missing required fields in form: ${missingFields.mkString(", ")}"
+                    )
+                  }
+                  val extraFields = b.fields.map(_._1).filterNot(allFields.contains)
+                  if (extraFields.nonEmpty) {
+                    throw new BaklavaAssertionException(
+                      s"Extra fields in form: ${extraFields.mkString(", ")}"
+                    )
+                  }
+                case _ =>
+              }
+
+              if (responseContext.status != statusCode) {
+                throw new BaklavaAssertionException(
+                  s"Expected ${statusCode.status} -> ${implicitly[Schema[ResponseBody]].className}, but got ${responseContext.status.status} -> ${responseContext.responseBodyString.take(maxBodyLengthInAssertion)}"
+                )
+              }
+
+              if (responseContext.responseBodyString.nonEmpty && implicitly[Schema[ResponseBody]] == Schema.emptyBodySchema) {
+                throw new BaklavaAssertionException(
+                  "Expected empty response body, but got: " + responseContext.responseBodyString.take(maxBodyLengthInAssertion)
+                )
+              }
+
+              val headersParsed = expectedResponseHeaders.map { h =>
+                responseContext.headers.headers.get(h.name) match {
+                  case None        => throw new BaklavaAssertionException(s"Header ${h.name} not found but expected")
+                  case Some(value) =>
+                    h.name ->
+                    h.tsm
+                      .unapply(value)
+                      .getOrElse(
+                        throw new BaklavaAssertionException(
+                          s"Header ${h.name} with value $value could not be parsed as ${h.schema.className}"
+                        )
+                      )
+                }
+              }
+              if (strictHeaderCheck && headersParsed.distinctBy(_._1).length != responseContext.headers.headers.size) {
+                throw new BaklavaAssertionException(
+                  s"Strict headers check is on, expected following headers: [${expectedResponseHeaders
+                      .map(h => h.name)
+                      .sorted
+                      .mkString(", ")}], but got: [${responseContext.headers.headers.keys.toList.sorted.mkString(", ")}]"
+                )
+              }
+
+              if (
+                requestContext.security.security != NoopSecurity && !requestContext.securitySchemes
+                  .exists(_.security == requestContext.security.security)
+              ) {
+                throw new BaklavaAssertionException(
+                  s"Used security ${requestContext.security.security.`type`} is not defined in security schemes: [${requestContext.securitySchemes.map(ss => s"${ss.name} -> ${ss.security.`type`}").mkString(", ")}]"
+                )
+              }
+
+              store(requestContext, responseContext.copy(bodySchema = Some(implicitly[Schema[ResponseBody]])))
+              responseContext
+            }
+            val baklavaCaseContext = BaklavaCaseContext(finalRequestCtx, wrappedPerformRequest)
+            val wrappedAssert: BaklavaCaseContext[
+              RequestBody,
+              ResponseBody,
+              PathParameters,
+              PathParametersProvided,
+              QueryParameters,
+              QueryParametersProvided,
+              Headers,
+              HeadersProvided
+            ] => R = ctx => assertFn(ctx, setupValue)
+            wrappedAssert.andThen { x =>
+              if (timesCalled == 0) {
+                throw new BaklavaAssertionException("performRequest was not called in a test, one request should be made")
+              } else if (timesCalled > 1) {
+                throw new RuntimeException("performRequest was called multiple times in a test, only one request should be made")
+              }
+              x
+            }(baklavaCaseContext)
+          }
+        )
+      }
+    }
+
   def onRequest: OnRequest[EmptyBody, Unit, Unit, Unit] =
     onRequest(EmptyBodyInstance: EmptyBody, AppliedSecurity(NoopSecurity, Map.empty), (), (), ())(
       emptyToRequestBodyType,

--- a/core/src/main/scala/pl/iterators/baklava/BaklavaTestFrameworkDsl.scala
+++ b/core/src/main/scala/pl/iterators/baklava/BaklavaTestFrameworkDsl.scala
@@ -142,6 +142,113 @@ trait BaklavaTestFrameworkDsl[RouteType, ToRequestBodyType[_], FromResponseBodyT
 
   def maxBodyLengthInAssertion: Int = 8192
 
+  private[baklava] def resolveRequestContext[
+      RequestBody,
+      PathParameters,
+      PathParametersProvided,
+      QueryParameters,
+      QueryParametersProvided,
+      Headers,
+      HeadersProvided
+  ](
+      requestContext: BaklavaRequestContext[Unit, PathParameters, Unit, QueryParameters, Unit, Headers, Unit],
+      body: RequestBody,
+      bodySchema: Schema[RequestBody],
+      security: AppliedSecurity,
+      pathParametersProvided: PathParametersProvided,
+      queryParametersProvided: QueryParametersProvided,
+      headersProvided: HeadersProvided,
+      responseDescription: Option[String],
+      responseHeaders: Seq[Header[?]]
+  )(implicit
+      providePathParams: ProvidePathParams[PathParameters, PathParametersProvided],
+      provideQueryParams: ProvideQueryParams[QueryParameters, QueryParametersProvided],
+      provideHeaders: ProvideHeaders[Headers, HeadersProvided]
+  ): BaklavaRequestContext[
+    RequestBody,
+    PathParameters,
+    PathParametersProvided,
+    QueryParameters,
+    QueryParametersProvided,
+    Headers,
+    HeadersProvided
+  ] = {
+    val headersToInclude          = provideHeaders.apply(requestContext.headersDefinition, headersProvided)
+    val additionalSecurityHeaders = security match {
+      case AppliedSecurity(_: HttpBearer, params) => Map("Authorization" -> s"Bearer ${params("token")}")
+      case AppliedSecurity(_: HttpBasic, params)  =>
+        Map("Authorization" -> s"Basic ${Base64.getEncoder.encodeToString(s"${params("id")}:${params("secret")}".getBytes)}")
+      case AppliedSecurity(s: ApiKeyInHeader, params)        => Map(s.name -> params("apiKey"))
+      case AppliedSecurity(_: ApiKeyInQuery, _)              => Map.empty[String, String]
+      case AppliedSecurity(_: ApiKeyInCookie, _)             => Map.empty[String, String]
+      case AppliedSecurity(_: MutualTls, _)                  => Map.empty[String, String]
+      case AppliedSecurity(_: OpenIdConnectInBearer, params) => Map("Authorization" -> s"Bearer ${params("token")}")
+      case AppliedSecurity(_: OpenIdConnectInCookie, _)      => Map.empty[String, String]
+      case AppliedSecurity(_: OAuth2InBearer, params)        => Map("Authorization" -> s"Bearer ${params("token")}")
+      case AppliedSecurity(_: OAuth2InCookie, _)             => Map.empty[String, String]
+      case AppliedSecurity(_: NoopSecurity.type, _)          => Map.empty[String, String]
+    }
+    val headersWithCookieModifiedForSecurity: Map[String, String] = security match {
+      case AppliedSecurity(_: HttpBearer, _)          => headersToInclude
+      case AppliedSecurity(_: HttpBasic, _)           => headersToInclude
+      case AppliedSecurity(_: ApiKeyInHeader, _)      => headersToInclude
+      case AppliedSecurity(_: ApiKeyInQuery, _)       => headersToInclude
+      case AppliedSecurity(s: ApiKeyInCookie, params) =>
+        headersToInclude.find(_._1.toLowerCase == "cookie") match {
+          case Some((_, value)) => headersToInclude + ("Cookie" -> s"$value; ${s.name}=${params("apiKey")}")
+          case None             => headersToInclude + ("Cookie" -> s"${s.name}=${params("apiKey")}")
+        }
+      case AppliedSecurity(_: MutualTls, _)                  => headersToInclude
+      case AppliedSecurity(_: OpenIdConnectInBearer, _)      => headersToInclude
+      case AppliedSecurity(_: OpenIdConnectInCookie, params) =>
+        headersToInclude.find(_._1.toLowerCase == "cookie") match {
+          case Some((_, value)) => headersToInclude + ("Cookie" -> s"$value; ${params("name")}=${params("token")}")
+          case None             => headersToInclude + ("Cookie" -> s"${params("name")}=${params("token")}")
+        }
+      case AppliedSecurity(_: OAuth2InBearer, _)      => headersToInclude
+      case AppliedSecurity(_: OAuth2InCookie, params) =>
+        headersToInclude.find(_._1.toLowerCase == "cookie") match {
+          case Some((_, value)) => headersToInclude + ("Cookie" -> s"$value; ${params("name")}=${params("token")}")
+          case None             => headersToInclude + ("Cookie" -> s"${params("name")}=${params("token")}")
+        }
+      case AppliedSecurity(_: NoopSecurity.type, _) => headersToInclude
+    }
+    val securityQueryParameters = security match {
+      case AppliedSecurity(_: HttpBearer, _)            => Map.empty[String, Seq[String]]
+      case AppliedSecurity(_: HttpBasic, _)             => Map.empty[String, Seq[String]]
+      case AppliedSecurity(_: ApiKeyInHeader, _)        => Map.empty[String, Seq[String]]
+      case AppliedSecurity(s: ApiKeyInQuery, params)    => Map(s.name -> Seq(params("apiKey")))
+      case AppliedSecurity(_: ApiKeyInCookie, _)        => Map.empty[String, Seq[String]]
+      case AppliedSecurity(_: MutualTls, _)             => Map.empty[String, Seq[String]]
+      case AppliedSecurity(_: OpenIdConnectInBearer, _) => Map.empty[String, Seq[String]]
+      case AppliedSecurity(_: OpenIdConnectInCookie, _) => Map.empty[String, Seq[String]]
+      case AppliedSecurity(_: OAuth2InBearer, _)        => Map.empty[String, Seq[String]]
+      case AppliedSecurity(_: OAuth2InCookie, _)        => Map.empty[String, Seq[String]]
+      case AppliedSecurity(_: NoopSecurity.type, _)     => Map.empty[String, Seq[String]]
+    }
+
+    requestContext.copy(
+      path = provideQueryParams.apply(
+        requestContext.queryParameters,
+        queryParametersProvided,
+        providePathParams.apply(
+          requestContext.pathParameters,
+          pathParametersProvided,
+          addQueryParametersToUri(requestContext.path, securityQueryParameters)
+        )
+      ),
+      body = if (body != EmptyBodyInstance) Some(body) else None,
+      bodySchema = Some(bodySchema),
+      headers = BaklavaHttpHeaders(headersWithCookieModifiedForSecurity ++ additionalSecurityHeaders),
+      headersProvided = headersProvided,
+      security = security,
+      pathParametersProvided = pathParametersProvided,
+      queryParametersProvided = queryParametersProvided,
+      responseDescription = responseDescription,
+      responseHeaders = responseHeaders
+    )
+  }
+
   case class OnRequest[RequestBody: ToRequestBodyType: Schema, PathParametersProvided, QueryParametersProvided, HeadersProvided](
       body: RequestBody,
       security: AppliedSecurity,
@@ -179,83 +286,25 @@ trait BaklavaTestFrameworkDsl[RouteType, ToRequestBodyType[_], FromResponseBodyT
               val finalDescription = if (description.trim.isEmpty) "" else ": " + description.trim
               var timesCalled: Int = 0
 
-              val headersToInclude = provideHeaders.apply(requestContext.headersDefinition, headersProvided)
-              // TODO: this security logic is duplicated in multiple places and messy and NEEDS TESTS
-              // TODO: e.g. cookie concatenation by hand?!
-              val additionalSecurityHeaders = security match {
-                case AppliedSecurity(_: HttpBearer, params) => Map("Authorization" -> s"Bearer ${params("token")}")
-                case AppliedSecurity(_: HttpBasic, params)  =>
-                  Map("Authorization" -> s"Basic ${Base64.getEncoder.encodeToString(s"${params("id")}:${params("secret")}".getBytes)}")
-                case AppliedSecurity(s: ApiKeyInHeader, params)        => Map(s.name -> params("apiKey"))
-                case AppliedSecurity(_: ApiKeyInQuery, _)              => Map.empty[String, String]
-                case AppliedSecurity(_: ApiKeyInCookie, _)             => Map.empty[String, String]
-                case AppliedSecurity(_: MutualTls, _)                  => Map.empty[String, String]
-                case AppliedSecurity(_: OpenIdConnectInBearer, params) => Map("Authorization" -> s"Bearer ${params("token")}")
-                case AppliedSecurity(_: OpenIdConnectInCookie, _)      => Map.empty[String, String]
-                case AppliedSecurity(_: OAuth2InBearer, params)        => Map("Authorization" -> s"Bearer ${params("token")}")
-                case AppliedSecurity(_: OAuth2InCookie, _)             => Map.empty[String, String]
-                case AppliedSecurity(_: NoopSecurity.type, _)          => Map.empty[String, String]
-              }
-              val headersWithCookieModifiedForSecurity: Map[String, String] = security match {
-                case AppliedSecurity(_: HttpBearer, _)          => headersToInclude
-                case AppliedSecurity(_: HttpBasic, _)           => headersToInclude
-                case AppliedSecurity(_: ApiKeyInHeader, _)      => headersToInclude
-                case AppliedSecurity(_: ApiKeyInQuery, _)       => headersToInclude
-                case AppliedSecurity(s: ApiKeyInCookie, params) =>
-                  headersToInclude.find(_._1.toLowerCase == "cookie") match {
-                    case Some((_, value)) => headersToInclude + ("Cookie" -> s"$value; ${s.name}=${params("apiKey")}")
-                    case None             => headersToInclude + ("Cookie" -> s"${s.name}=${params("apiKey")}")
-                  }
-                case AppliedSecurity(_: MutualTls, _)                  => headersToInclude
-                case AppliedSecurity(_: OpenIdConnectInBearer, _)      => headersToInclude
-                case AppliedSecurity(_: OpenIdConnectInCookie, params) =>
-                  headersToInclude.find(_._1.toLowerCase == "cookie") match {
-                    case Some((_, value)) => headersToInclude + ("Cookie" -> s"$value; ${params("name")}=${params("token")}")
-                    case None             => headersToInclude + ("Cookie" -> s"${params("name")}=${params("token")}")
-                  }
-                case AppliedSecurity(_: OAuth2InBearer, _)      => headersToInclude
-                case AppliedSecurity(_: OAuth2InCookie, params) =>
-                  headersToInclude.find(_._1.toLowerCase == "cookie") match {
-                    case Some((_, value)) => headersToInclude + ("Cookie" -> s"$value; ${params("name")}=${params("token")}")
-                    case None             => headersToInclude + ("Cookie" -> s"${params("name")}=${params("token")}")
-                  }
-                case AppliedSecurity(_: NoopSecurity.type, _) => headersToInclude
-              }
-              val securityQueryParameters = security match {
-                case AppliedSecurity(_: HttpBearer, _)            => Map.empty[String, Seq[String]]
-                case AppliedSecurity(_: HttpBasic, _)             => Map.empty[String, Seq[String]]
-                case AppliedSecurity(_: ApiKeyInHeader, _)        => Map.empty[String, Seq[String]]
-                case AppliedSecurity(s: ApiKeyInQuery, params)    => Map(s.name -> Seq(params("apiKey")))
-                case AppliedSecurity(_: ApiKeyInCookie, _)        => Map.empty[String, Seq[String]]
-                case AppliedSecurity(_: MutualTls, _)             => Map.empty[String, Seq[String]]
-                case AppliedSecurity(_: OpenIdConnectInBearer, _) => Map.empty[String, Seq[String]]
-                case AppliedSecurity(_: OpenIdConnectInCookie, _) => Map.empty[String, Seq[String]]
-                case AppliedSecurity(_: OAuth2InBearer, _)        => Map.empty[String, Seq[String]]
-                case AppliedSecurity(_: OAuth2InCookie, _)        => Map.empty[String, Seq[String]]
-                case AppliedSecurity(_: NoopSecurity.type, _)     => Map.empty[String, Seq[String]]
-              }
-
-              val finalRequestCtx =
-                requestContext.copy(
-                  path = provideQueryParams.apply(
-                    requestContext.queryParameters,
-                    queryParametersProvided,
-                    providePathParams.apply(
-                      requestContext.pathParameters,
-                      pathParametersProvided,
-                      addQueryParametersToUri(requestContext.path, securityQueryParameters)
-                    )
-                  ),
-                  body = if (body != EmptyBodyInstance) Some(body) else None,
-                  bodySchema = Some(implicitly[Schema[RequestBody]]),
-                  headers = BaklavaHttpHeaders(headersWithCookieModifiedForSecurity ++ additionalSecurityHeaders),
-                  headersProvided = headersProvided,
-                  security = security,
-                  pathParametersProvided = pathParametersProvided,
-                  queryParametersProvided = queryParametersProvided,
-                  responseDescription = if (description.trim.isEmpty) None else Some(description.trim),
-                  responseHeaders = headers
-                )
+              val finalRequestCtx = resolveRequestContext[
+                RequestBody,
+                PathParameters,
+                PathParametersProvided,
+                QueryParameters,
+                QueryParametersProvided,
+                Headers,
+                HeadersProvided
+              ](
+                requestContext = requestContext,
+                body = body,
+                bodySchema = implicitly[Schema[RequestBody]],
+                security = security,
+                pathParametersProvided = pathParametersProvided,
+                queryParametersProvided = queryParametersProvided,
+                headersProvided = headersProvided,
+                responseDescription = if (description.trim.isEmpty) None else Some(description.trim),
+                responseHeaders = headers
+              )
 
               requestLevelTextWithExecution(
                 statusCode.status.toString + finalDescription,

--- a/docs/dsl-reference.md
+++ b/docs/dsl-reference.md
@@ -322,6 +322,82 @@ The assertion block receives a [`BaklavaCaseContext`](https://github.com/theiter
 }
 ```
 
+## Deferred Inputs: `withSetup`
+
+When a scenario needs to produce request values from setup logic — for example a database-seeded ID or a freshly-generated token — use `withSetup` to defer the request construction until test execution time.
+
+### Signature
+
+```scala
+def withSetup[S](setup: => S): WithSetupBuilder[S]
+```
+
+`WithSetupBuilder[S]` has two overloaded `.request` methods:
+
+```scala
+// Lazy form — function of the setup value
+def request[...](f: S => OnRequest[...]): WithSetupRequestBuilder[...]
+
+// Eager form — static fields, same named arguments as the top-level onRequest(...)
+def request[...](
+    body: RequestBody            = EmptyBodyInstance: EmptyBody,
+    security: AppliedSecurity    = AppliedSecurity(NoopSecurity, Map.empty),
+    pathParameters: ...          = (),
+    queryParameters: ...         = (),
+    headers: ...                 = ()
+): WithSetupRequestBuilder[...]
+```
+
+The chain concludes with `.respondsWith[R](...)` and a two-argument `.assert { (ctx, s) => ... }` that receives both the request context and the setup value.
+
+### Lazy form — request depends on setup
+
+```scala
+path("/v1/auctions/{auctionId}")(
+  supports(
+    GET,
+    pathParameters = p[AuctionId]("auctionId"),
+    tags = Seq("Auctions")
+  )(
+    withSetup {
+      application.transactor
+        .inSession(seedUser(seller) *> seedAuction(AuctionId(UUID.randomUUID()), seller.id))
+        .unsafeRunSync()
+    }.request { (auction: Auction) =>
+      onRequest(pathParameters = auction.id)
+    }.respondsWith[AuctionDto](OK, description = "Auction found")
+      .assert { case (ctx, auction) =>
+        val response = ctx.performRequest(allRoutes)
+        response.body.id shouldBe auction.id
+      }
+  )
+)
+```
+
+### Eager form — setup value only flows to assert
+
+When the request values are static but the assertion needs data from setup:
+
+```scala
+withSetup {
+  application.transactor.inSession(seedUser(seller)).unsafeRunSync()
+  seller
+}.request(body = sampleCreateRequest(), security = bearer.apply(validJwt(sellerAuth)))
+  .respondsWith[AuctionDto](Created)
+  .assert { case (ctx, seller) =>
+    val response = ctx.performRequest(allRoutes)
+    response.body.sellerId shouldBe seller.id
+  }
+```
+
+### Notes
+
+- `setup` is synchronous. If it runs IO, call `.unsafeRunSync()` (or equivalent) inside the block.
+- The setup block runs once per scenario, at test-execution time — not at class-construction time. Each scenario's setup is independent.
+- **Scala 2.13** requires an explicit type annotation on the lambda parameter of the lazy `.request { ... }` form (e.g., `.request { (id: Long) => ... }`). Scala 3 does not require this.
+- OpenAPI output is unaffected by `withSetup`: parameter schemas still come from `supports(...)`, and request/response body examples still come from the live HTTP transaction.
+- The existing `onRequest(...).respondsWith(...).assert { ctx => ... }` chain remains fully supported and unchanged — `withSetup` is additive.
+
 ## Parameters
 
 ### Path Parameters

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -343,3 +343,34 @@ class GetUsersRouteSpec extends BaseRouteSpec {
 
 }
 ```
+
+## Example: deferred path parameter from seeded data
+
+When a test needs to derive request inputs from setup work (database seeding, token generation, etc.), use `withSetup`:
+
+```scala
+path("/v1/auctions/{auctionId}")(
+  supports(
+    GET,
+    pathParameters = p[AuctionId]("auctionId"),
+    tags = Seq("Auctions")
+  )(
+    withSetup {
+      application.transactor
+        .inSession(seedUser(seller) *> seedAuction(AuctionId(UUID.randomUUID()), seller.id))
+        .unsafeRunSync()
+    }.request { (auction: Auction) =>
+      onRequest(pathParameters = auction.id)
+    }.respondsWith[AuctionDto](OK, description = "Auction found")
+      .assert { case (ctx, auction) =>
+        val response = ctx.performRequest(allRoutes)
+        response.body.id shouldBe auction.id
+      }
+  )
+)
+```
+
+The setup block runs once per scenario at test execution time. Its return value is threaded into both `.request` (to construct the `OnRequest`) and `.assert` (as the second argument of the two-argument lambda).
+
+On Scala 2.13, the lambda parameter must be explicitly typed (`(auction: Auction) => ...`). On Scala 3, type inference resolves it automatically.
+

--- a/openapi/src/test/scala/pl/iterators/baklava/openapi/BackwardCompatibilitySpec.scala
+++ b/openapi/src/test/scala/pl/iterators/baklava/openapi/BackwardCompatibilitySpec.scala
@@ -1,0 +1,99 @@
+package pl.iterators.baklava.openapi
+
+import com.github.pjfanning.pekkohttpcirce.FailFastCirceSupport
+import io.circe.syntax.*
+import org.apache.pekko.actor.ActorSystem
+import org.apache.pekko.http.scaladsl.marshalling.ToEntityMarshaller
+import org.apache.pekko.http.scaladsl.model.HttpMethods.*
+import org.apache.pekko.http.scaladsl.model.StatusCodes.*
+import org.apache.pekko.http.scaladsl.model.{ContentTypes, HttpEntity, HttpResponse}
+import org.apache.pekko.http.scaladsl.server.Directives.complete
+import org.apache.pekko.http.scaladsl.server.Route
+import org.apache.pekko.http.scaladsl.unmarshalling.FromEntityUnmarshaller
+import org.apache.pekko.stream.Materializer
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
+import pl.iterators.baklava.pekkohttp.BaklavaPekkoHttp
+import pl.iterators.baklava.scalatest.{BaklavaScalatest, ScalatestAsExecution}
+import pl.iterators.baklava.{HttpBearer, SecurityScheme}
+import pl.iterators.kebs.circe.KebsCirce
+import pl.iterators.kebs.circe.enums.KebsCirceEnumsLowercase
+import pl.iterators.kebs.enumeratum.KebsEnumeratum
+
+import java.util.concurrent.atomic.AtomicReference
+import scala.concurrent.ExecutionContext
+
+class BackwardCompatibilitySpec
+    extends AnyFunSpec
+    with Matchers
+    with BaklavaPekkoHttp[Unit, Unit, ScalatestAsExecution]
+    with BaklavaScalatest[Route, ToEntityMarshaller, FromEntityUnmarshaller]
+    with FailFastCirceSupport
+    with KebsCirce
+    with KebsCirceEnumsLowercase
+    with KebsEnumeratum {
+
+  private implicit val system: ActorSystem        = ActorSystem()
+  implicit val executionContext: ExecutionContext = system.dispatcher
+  implicit val materializer: Materializer         = Materializer(system)
+
+  val routes: Route = complete(org.apache.pekko.http.scaladsl.model.StatusCodes.OK)
+
+  def strictHeaderCheckDefault: Boolean = false
+
+  case class Widget(id: Long, label: String)
+  case class CreateWidget(label: String)
+
+  val bearer: HttpBearer           = HttpBearer(bearerFormat = "JWT")
+  val bearerScheme: SecurityScheme = SecurityScheme("bearerAuth", bearer)
+
+  private val lastRequestPath: AtomicReference[String]         = new AtomicReference("")
+  private val lastAuthorizationHeader: AtomicReference[String] = new AtomicReference("")
+  private var nextResponse: HttpResponse                       = HttpResponse(OK)
+
+  def performRequest(routes: Route, request: HttpRequest): HttpResponse = {
+    lastRequestPath.set(request.uri.path.toString + request.uri.rawQueryString.map("?" + _).getOrElse(""))
+    request.headers.find(_.name.toLowerCase == "authorization").foreach(h => lastAuthorizationHeader.set(h.value))
+    nextResponse
+  }
+
+  private def jsonResponse(statusCode: org.apache.pekko.http.scaladsl.model.StatusCode, json: String): HttpResponse =
+    HttpResponse(statusCode, entity = HttpEntity(ContentTypes.`application/json`, json))
+
+  path("/widgets/{widgetId}")(
+    supports(
+      GET,
+      pathParameters = p[Long]("widgetId"),
+      queryParameters = q[Option[String]]("filter", "Optional filter"),
+      securitySchemes = Seq(bearerScheme),
+      tags = Seq("Widgets")
+    )(
+      onRequest(pathParameters = 5L, queryParameters = Some("shiny"), security = bearer("tok123"))
+        .respondsWith[Widget](OK, description = "Eager path + query + security still work")
+        .assert { ctx =>
+          nextResponse = jsonResponse(OK, Widget(5L, "Alice").asJson.noSpaces)
+          val response = ctx.performRequest(routes)
+          response.body.id shouldBe 5L
+          lastRequestPath.get() shouldBe "/widgets/5?filter=shiny"
+          lastAuthorizationHeader.get() shouldBe "Bearer tok123"
+        }
+    )
+  )
+
+  path("/widgets")(
+    supports(
+      POST,
+      securitySchemes = Seq(bearerScheme),
+      tags = Seq("Widgets")
+    )(
+      onRequest(body = CreateWidget("gizmo"), security = bearer("tok456"))
+        .respondsWith[Widget](Created, description = "Eager body + security still work")
+        .assert { ctx =>
+          nextResponse = jsonResponse(Created, Widget(11L, "gizmo").asJson.noSpaces)
+          val response = ctx.performRequest(routes)
+          response.body.label shouldBe "gizmo"
+          lastAuthorizationHeader.get() shouldBe "Bearer tok456"
+        }
+    )
+  )
+}

--- a/openapi/src/test/scala/pl/iterators/baklava/openapi/WithSetupFlowSpec.scala
+++ b/openapi/src/test/scala/pl/iterators/baklava/openapi/WithSetupFlowSpec.scala
@@ -1,0 +1,127 @@
+package pl.iterators.baklava.openapi
+
+import com.github.pjfanning.pekkohttpcirce.FailFastCirceSupport
+import io.circe.syntax.*
+import org.apache.pekko.actor.ActorSystem
+import org.apache.pekko.http.scaladsl.marshalling.ToEntityMarshaller
+import org.apache.pekko.http.scaladsl.model.HttpMethods.*
+import org.apache.pekko.http.scaladsl.model.StatusCodes.*
+import org.apache.pekko.http.scaladsl.model.{ContentTypes, HttpEntity, HttpResponse}
+import org.apache.pekko.http.scaladsl.server.Directives.complete
+import org.apache.pekko.http.scaladsl.server.Route
+import org.apache.pekko.http.scaladsl.unmarshalling.FromEntityUnmarshaller
+import org.apache.pekko.stream.Materializer
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
+import pl.iterators.baklava.pekkohttp.BaklavaPekkoHttp
+import pl.iterators.baklava.scalatest.{BaklavaScalatest, ScalatestAsExecution}
+import pl.iterators.baklava.{HttpBearer, SecurityScheme}
+import pl.iterators.kebs.circe.KebsCirce
+import pl.iterators.kebs.circe.enums.KebsCirceEnumsLowercase
+import pl.iterators.kebs.enumeratum.KebsEnumeratum
+
+import java.util.concurrent.atomic.AtomicReference
+import scala.concurrent.ExecutionContext
+
+class WithSetupFlowSpec
+    extends AnyFunSpec
+    with Matchers
+    with BaklavaPekkoHttp[Unit, Unit, ScalatestAsExecution]
+    with BaklavaScalatest[Route, ToEntityMarshaller, FromEntityUnmarshaller]
+    with FailFastCirceSupport
+    with KebsCirce
+    with KebsCirceEnumsLowercase
+    with KebsEnumeratum {
+
+  private implicit val system: ActorSystem        = ActorSystem()
+  implicit val executionContext: ExecutionContext = system.dispatcher
+  implicit val materializer: Materializer         = Materializer(system)
+
+  val routes: Route = complete(org.apache.pekko.http.scaladsl.model.StatusCodes.OK)
+
+  def strictHeaderCheckDefault: Boolean = false
+
+  case class Thing(id: Long, name: String)
+  case class CreateThing(name: String)
+
+  val bearer: HttpBearer           = HttpBearer(bearerFormat = "JWT")
+  val bearerScheme: SecurityScheme = SecurityScheme("bearerAuth", bearer)
+
+  // Captured request path at the mock server — we assert on it.
+  private val lastRequestPath: AtomicReference[String] = new AtomicReference("")
+  private var nextResponse: HttpResponse               = HttpResponse(OK)
+
+  def performRequest(routes: Route, request: HttpRequest): HttpResponse = {
+    lastRequestPath.set(request.uri.path.toString + request.uri.rawQueryString.map("?" + _).getOrElse(""))
+    nextResponse
+  }
+
+  private def jsonResponse(statusCode: org.apache.pekko.http.scaladsl.model.StatusCode, json: String): HttpResponse =
+    HttpResponse(statusCode, entity = HttpEntity(ContentTypes.`application/json`, json))
+
+  path("/things/{thingId}")(
+    supports(
+      GET,
+      pathParameters = p[Long]("thingId", "The thing ID"),
+      securitySchemes = Seq(bearerScheme),
+      tags = Seq("Things")
+    )(
+      // Scenario 1: lazy path parameter produced by setup
+      withSetup {
+        42L // pretend this is `seedThing().unsafeRunSync().id`
+      }.request { (id: Long) =>
+        onRequest(pathParameters = id, security = bearer("tok"))
+      }.respondsWith[Thing](OK, description = "Thing found via setup id")
+        .assert { case (ctx, id) =>
+          nextResponse = jsonResponse(OK, Thing(id, "Alice").asJson.noSpaces)
+          val response = ctx.performRequest(routes)
+          response.body.id shouldBe id
+          lastRequestPath.get() shouldBe "/things/42"
+        }
+    )
+  )
+
+  path("/things")(
+    supports(
+      POST,
+      securitySchemes = Seq(bearerScheme),
+      tags = Seq("Things")
+    )(
+      // Scenario 2: lazy body produced by setup (tuple)
+      withSetup {
+        ("Bob", 7L) // (name, expectedId)
+      }.request { (setup: (String, Long)) =>
+        val (name, _) = setup
+        onRequest(body = CreateThing(name), security = bearer("tok"))
+      }.respondsWith[Thing](Created, description = "Created via setup-derived body")
+        .assert { case (ctx, (name, expectedId)) =>
+          nextResponse = jsonResponse(Created, Thing(expectedId, name).asJson.noSpaces)
+          val response = ctx.performRequest(routes)
+          response.body.name shouldBe name
+          response.body.id shouldBe expectedId
+        }
+    )
+  )
+
+  path("/things/{thingId}/metadata")(
+    supports(
+      GET,
+      pathParameters = p[Long]("thingId"),
+      securitySchemes = Seq(bearerScheme),
+      tags = Seq("Things")
+    )(
+      // Scenario 3: setup yields Unit (side-effect only); eager .request is used.
+      withSetup {
+        val _ = 1 + 1 // side-effect stand-in
+        ()
+      }.request(pathParameters = 99L, security = bearer("tok"))
+        .respondsWith[Thing](OK, description = "Eager request override with Unit setup")
+        .assert { case (ctx, _) =>
+          nextResponse = jsonResponse(OK, Thing(99L, "Zed").asJson.noSpaces)
+          val response = ctx.performRequest(routes)
+          response.body.id shouldBe 99L
+          lastRequestPath.get() shouldBe "/things/99/metadata"
+        }
+    )
+  )
+}


### PR DESCRIPTION
## Summary

Adds a new `withSetup` DSL chain that lets test authors produce request inputs from setup blocks at test-execution time, addressing the path-param / body / imperative-setup pain points from #57.

```scala
withSetup {
  application.transactor.inSession(seedUser(seller) *> seedAuction(id, seller.id)).unsafeRunSync()
}.request { (auction: Auction) =>
  onRequest(pathParameters = auction.id, security = bearer(validJwt(seller)))
}.respondsWith[AuctionDto](OK, description = "Auction found")
 .assert { case (ctx, auction) =>
   val response = ctx.performRequest(allRoutes)
   response.body.id shouldBe auction.id
 }
```

- **Backward compatible** — existing `onRequest(...).respondsWith(...).assert { ctx => ... }` chains behave identically. `BackwardCompatibilitySpec` pins this.
- **Setup is synchronous** — users call `.unsafeRunSync()` (or equivalent) themselves inside the block, keeping Baklava effect-agnostic.
- **OpenAPI output unchanged** — parameter schemas still come from `supports(...)`; body examples still come from the live HTTP transaction.
- **Cross-built** — verified on Scala 2.13.18 and 3.3.7.

## Commit structure

1. `refactor: extract resolveRequestContext helper from assert` — prepare shared binding logic
2. `refactor: restore dropped TODO comments in resolveRequestContext` — fixup
3. `feat: add withSetup DSL for deferred test inputs` — new traits + execution closure
4. `refactor: extract validateResponseAndStore shared helper` — dedup eager/deferred validation
5. `test: add WithSetupFlowSpec covering deferred test inputs` — 3 scenarios (lazy path param, lazy body, eager + Unit setup)
6. `test: add BackwardCompatibilitySpec guarding eager onRequest path` — eager chain safety net
7. `docs: document withSetup for deferred test inputs` — DSL reference + example

## Test plan

- [x] `sbt 'project core' test` — 7/7 pass on Scala 2.13
- [x] `sbt 'project openapi' test` — 35/35 pass on Scala 2.13 (33 existing + `WithSetupFlowSpec` 3 + `BackwardCompatibilitySpec` 2)
- [x] `sbt '++3.3.7' test` — clean on Scala 3.3.7
- [x] `sbt '+test'` — cross-build green

## Known limitation

On Scala 2.13 the lambda parameter of the lazy `.request { ... }` form must be explicitly typed (`.request { (id: Long) => ... }`) because the 4 `OnRequest` type parameters can't all be inferred from the function shape. Scala 3 doesn't require the annotation. Documented in `docs/dsl-reference.md`.

Closes #57.