### PR TITLE
Fix default value "None" rendered for optional query parameters

### DIFF
--- a/core/src/main/scala/pl/iterators/baklava/Schema.scala
+++ b/core/src/main/scala/pl/iterators/baklava/Schema.scala
@@ -130,7 +130,7 @@ trait SchemaDefaults {
     val `enum`: Option[Set[String]]        = schema.`enum`
     val required: Boolean                  = false
     val additionalProperties: Boolean      = schema.additionalProperties
-    val default: Option[Option[T]]         = Some(None)
+    val default: Option[Option[T]]         = None
     val description: Option[String]        = schema.description
   }
   implicit def seqSchema[T](implicit schema: Schema[T]): Schema[Seq[T]] = new Schema[Seq[T]] {

--- a/openapi/src/test/scala/pl/iterators/baklava/openapi/OptionQueryParameterDefaultSpec.scala
+++ b/openapi/src/test/scala/pl/iterators/baklava/openapi/OptionQueryParameterDefaultSpec.scala
@@ -1,0 +1,58 @@
+package pl.iterators.baklava.openapi
+
+import io.swagger.v3.oas.models.OpenAPI
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
+import pl.iterators.baklava.*
+
+import scala.jdk.CollectionConverters.*
+
+class OptionQueryParameterDefaultSpec extends AnyFunSpec with Matchers {
+
+  describe("OpenAPI generation for Option[T] query parameters (regression for #49)") {
+
+    it("does not emit a default field when none is explicitly set") {
+      val optionSchema = BaklavaSchemaSerializable(Schema.optionSchema(Schema.stringSchema))
+      val call         = syntheticCall(BaklavaQueryParamSerializable("filter", None, optionSchema))
+
+      val openAPI = new OpenAPI()
+      BaklavaDslFormatterOpenAPIWorker.generateForCalls(openAPI, Seq(call))
+
+      val parameters  = openAPI.getPaths.get("/items").getGet.getParameters.asScala
+      val filterParam = parameters.find(_.getName == "filter").getOrElse(fail("filter parameter not found"))
+      filterParam.getSchema.getDefault shouldBe null
+    }
+  }
+
+  private def syntheticCall(queryParam: BaklavaQueryParamSerializable): BaklavaSerializableCall =
+    BaklavaSerializableCall(
+      request = BaklavaRequestContextSerializable(
+        symbolicPath = "/items",
+        path = "/items",
+        pathDescription = None,
+        pathSummary = None,
+        method = Some(BaklavaHttpMethod("GET")),
+        operationDescription = None,
+        operationSummary = None,
+        operationId = None,
+        operationTags = Seq.empty,
+        securitySchemes = Seq.empty,
+        bodySchema = None,
+        headersSeq = Seq.empty,
+        pathParametersSeq = Seq.empty,
+        queryParametersSeq = Seq(queryParam),
+        responseDescription = None,
+        responseHeaders = Seq.empty
+      ),
+      response = BaklavaResponseContextSerializable(
+        protocol = BaklavaHttpProtocol("HTTP/1.1"),
+        status = BaklavaHttpStatus(200),
+        headers = BaklavaHttpHeaders(Map.empty),
+        requestBodyString = "",
+        responseBodyString = "",
+        requestContentType = None,
+        responseContentType = None,
+        bodySchema = None
+      )
+    )
+}


### PR DESCRIPTION
The optionSchema implicit hardcoded `default = Some(None)` for every
Option[T], which serialized to the string "None" via toString and ended
up in the OpenAPI output as `default: None`. An optional parameter with
no explicitly set default should not emit a default at all.

Closes #49

https://claude.ai/code/session_011upvhh4Py4sJf7Sv5x3Kmo