### PR TITLE
Merge metadata when multiple supports share the same path+method

### DIFF
--- a/openapi/src/main/scala/pl/iterators/baklava/openapi/BaklavaDslFormatterOpenAPIWorker.scala
+++ b/openapi/src/main/scala/pl/iterators/baklava/openapi/BaklavaDslFormatterOpenAPIWorker.scala
@@ -219,26 +219,35 @@ object BaklavaDslFormatterOpenAPIWorker {
         requestBody.setContent(content)
         if (!content.isEmpty) operation.setRequestBody(requestBody)
 
-        calls.head.request.operationId.foreach(operation.setOperationId)
-        calls.head.request.operationSummary.foreach(operation.setSummary)
-        calls.head.request.operationDescription.foreach(operation.setDescription)
-        operation.setTags(calls.head.request.operationTags.asJava)
+        calls.flatMap(_.request.operationId).distinct.headOption.foreach(operation.setOperationId)
+        val mergedSummary = calls.flatMap(_.request.operationSummary).distinct.mkString(" / ")
+        if (mergedSummary.nonEmpty) operation.setSummary(mergedSummary)
+        val mergedDescription = calls.flatMap(_.request.operationDescription).distinct.mkString("\n\n")
+        if (mergedDescription.nonEmpty) operation.setDescription(mergedDescription)
+        operation.setTags(calls.flatMap(_.request.operationTags).distinct.asJava)
 
-        operation.setSecurity(calls.head.request.securitySchemes.map { ss =>
-          def extractOAuthScopes(flows: OAuthFlows): Seq[String] = {
-            (flows.implicitFlow.toList.flatMap(_.scopes.keys) ++
-              flows.passwordFlow.toList.flatMap(_.scopes.keys) ++
-              flows.authorizationCodeFlow.toList.flatMap(_.scopes.keys) ++
-              flows.clientCredentialsFlow.toList.flatMap(_.scopes.keys)).distinct
-          }
+        def extractOAuthScopes(flows: OAuthFlows): Seq[String] = {
+          (flows.implicitFlow.toList.flatMap(_.scopes.keys) ++
+            flows.passwordFlow.toList.flatMap(_.scopes.keys) ++
+            flows.authorizationCodeFlow.toList.flatMap(_.scopes.keys) ++
+            flows.clientCredentialsFlow.toList.flatMap(_.scopes.keys)).distinct
+        }
 
+        val distinctSchemes         = calls.flatMap(_.request.securitySchemes).distinctBy(_.name)
+        val hasUnauthenticatedVariant = calls.exists(_.request.securitySchemes.isEmpty)
+        val securityRequirements    = distinctSchemes.map { ss =>
           val scopes = ss.security.oAuth2InBearer
             .map(oAuth2 => extractOAuthScopes(oAuth2.flows))
             .orElse(ss.security.oAuth2InCookie.map(oAuth2 => extractOAuthScopes(oAuth2.flows)))
             .getOrElse(Seq.empty)
 
           new io.swagger.v3.oas.models.security.SecurityRequirement().addList(ss.name, scopes.asJava)
-        }.asJava)
+        }
+        val finalSecurityRequirements =
+          if (hasUnauthenticatedVariant && distinctSchemes.nonEmpty)
+            new io.swagger.v3.oas.models.security.SecurityRequirement() +: securityRequirements
+          else securityRequirements
+        operation.setSecurity(finalSecurityRequirements.asJava)
 
         calls.head.request.queryParametersSeq
           .map { queryParam =>

--- a/openapi/src/main/scala/pl/iterators/baklava/openapi/BaklavaDslFormatterOpenAPIWorker.scala
+++ b/openapi/src/main/scala/pl/iterators/baklava/openapi/BaklavaDslFormatterOpenAPIWorker.scala
@@ -219,7 +219,8 @@ object BaklavaDslFormatterOpenAPIWorker {
         requestBody.setContent(content)
         if (!content.isEmpty) operation.setRequestBody(requestBody)
 
-        calls.flatMap(_.request.operationId).distinct.headOption.foreach(operation.setOperationId)
+        val distinctOperationIds = calls.flatMap(_.request.operationId).distinct
+        if (distinctOperationIds.size == 1) operation.setOperationId(distinctOperationIds.head)
         val mergedSummary = calls.flatMap(_.request.operationSummary).distinct.mkString(" / ")
         if (mergedSummary.nonEmpty) operation.setSummary(mergedSummary)
         val mergedDescription = calls.flatMap(_.request.operationDescription).distinct.mkString("\n\n")
@@ -233,9 +234,9 @@ object BaklavaDslFormatterOpenAPIWorker {
             flows.clientCredentialsFlow.toList.flatMap(_.scopes.keys)).distinct
         }
 
-        val distinctSchemes         = calls.flatMap(_.request.securitySchemes).distinctBy(_.name)
+        val distinctSchemes           = calls.flatMap(_.request.securitySchemes).distinctBy(_.name)
         val hasUnauthenticatedVariant = calls.exists(_.request.securitySchemes.isEmpty)
-        val securityRequirements    = distinctSchemes.map { ss =>
+        val securityRequirements      = distinctSchemes.map { ss =>
           val scopes = ss.security.oAuth2InBearer
             .map(oAuth2 => extractOAuthScopes(oAuth2.flows))
             .orElse(ss.security.oAuth2InCookie.map(oAuth2 => extractOAuthScopes(oAuth2.flows)))

--- a/openapi/src/test/scala/pl/iterators/baklava/openapi/BaklavaDslFormatterOpenAPIWorkerSpec.scala
+++ b/openapi/src/test/scala/pl/iterators/baklava/openapi/BaklavaDslFormatterOpenAPIWorkerSpec.scala
@@ -1,0 +1,128 @@
+package pl.iterators.baklava.openapi
+
+import io.swagger.v3.oas.models.OpenAPI
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
+import pl.iterators.baklava.*
+
+import scala.jdk.CollectionConverters.*
+
+class BaklavaDslFormatterOpenAPIWorkerSpec extends AnyFunSpec with Matchers {
+
+  private val bearerScheme = BaklavaSecuritySchemaSerializable(
+    name = "bearerAuth",
+    security = BaklavaSecuritySerializable(httpBearer = Some(HttpBearer(bearerFormat = "JWT")))
+  )
+
+  private def call(
+      method: String,
+      path: String,
+      summary: Option[String],
+      description: Option[String],
+      tags: Seq[String],
+      operationId: Option[String],
+      schemes: Seq[BaklavaSecuritySchemaSerializable],
+      status: Int = 200
+  ): BaklavaSerializableCall =
+    BaklavaSerializableCall(
+      request = BaklavaRequestContextSerializable(
+        symbolicPath = path,
+        path = path,
+        pathDescription = None,
+        pathSummary = None,
+        method = Some(BaklavaHttpMethod(method)),
+        operationDescription = description,
+        operationSummary = summary,
+        operationId = operationId,
+        operationTags = tags,
+        securitySchemes = schemes,
+        bodySchema = None,
+        headersSeq = Seq.empty,
+        pathParametersSeq = Seq.empty,
+        queryParametersSeq = Seq.empty,
+        responseDescription = Some("ok"),
+        responseHeaders = Seq.empty
+      ),
+      response = BaklavaResponseContextSerializable(
+        protocol = BaklavaHttpProtocol("HTTP/1.1"),
+        status = BaklavaHttpStatus(status),
+        headers = BaklavaHttpHeaders(Map.empty),
+        requestBodyString = "",
+        responseBodyString = "",
+        requestContentType = None,
+        responseContentType = None,
+        bodySchema = None
+      )
+    )
+
+  describe("BaklavaDslFormatterOpenAPIWorker") {
+    describe("when merging multiple supports for the same path+method") {
+      it("combines security schemes and adds an empty requirement for the unauthenticated variant") {
+        val calls = Seq(
+          call(
+            method = "GET",
+            path = "/v1/health-check",
+            summary = Some("Returns basic app info"),
+            description = Some("Health check (unauthenticated)"),
+            tags = Seq("System"),
+            operationId = Some("healthCheckPublic"),
+            schemes = Seq.empty
+          ),
+          call(
+            method = "GET",
+            path = "/v1/health-check",
+            summary = Some("Returns app info with DB status"),
+            description = Some("Health check (authenticated)"),
+            tags = Seq("System", "Auth"),
+            operationId = Some("healthCheckAuthenticated"),
+            schemes = Seq(bearerScheme)
+          )
+        )
+
+        val openAPI = new OpenAPI()
+        BaklavaDslFormatterOpenAPIWorker.generateForCalls(openAPI, calls)
+
+        val operation = openAPI.getPaths.get("/v1/health-check").getGet
+        val security  = operation.getSecurity.asScala.toList
+
+        security should have size 2
+        security.head.asScala shouldBe empty
+        security(1).asScala.keySet should contain("bearerAuth")
+
+        operation.getDescription should include("Health check (unauthenticated)")
+        operation.getDescription should include("Health check (authenticated)")
+        operation.getSummary should include("Returns basic app info")
+        operation.getSummary should include("Returns app info with DB status")
+        operation.getTags.asScala should contain theSameElementsAs Seq("System", "Auth")
+      }
+
+      it("does not add an empty security requirement when every variant uses the same scheme") {
+        val calls = Seq(
+          call("GET", "/v1/me", Some("Me v1"), Some("desc 1"), Seq("User"), Some("meV1"), Seq(bearerScheme)),
+          call("GET", "/v1/me", Some("Me v2"), Some("desc 2"), Seq("User"), Some("meV2"), Seq(bearerScheme))
+        )
+
+        val openAPI = new OpenAPI()
+        BaklavaDslFormatterOpenAPIWorker.generateForCalls(openAPI, calls)
+
+        val operation = openAPI.getPaths.get("/v1/me").getGet
+        val security  = operation.getSecurity.asScala.toList
+
+        security should have size 1
+        security.head.asScala.keySet should contain("bearerAuth")
+      }
+
+      it("emits an empty security list for a purely unauthenticated endpoint") {
+        val calls = Seq(
+          call("GET", "/v1/public", Some("Public"), Some("Public endpoint"), Seq.empty, Some("public"), Seq.empty)
+        )
+
+        val openAPI = new OpenAPI()
+        BaklavaDslFormatterOpenAPIWorker.generateForCalls(openAPI, calls)
+
+        val operation = openAPI.getPaths.get("/v1/public").getGet
+        operation.getSecurity.asScala shouldBe empty
+      }
+    }
+  }
+}

--- a/openapi/src/test/scala/pl/iterators/baklava/openapi/BaklavaDslFormatterOpenAPIWorkerSpec.scala
+++ b/openapi/src/test/scala/pl/iterators/baklava/openapi/BaklavaDslFormatterOpenAPIWorkerSpec.scala
@@ -94,6 +94,21 @@ class BaklavaDslFormatterOpenAPIWorkerSpec extends AnyFunSpec with Matchers {
         operation.getSummary should include("Returns basic app info")
         operation.getSummary should include("Returns app info with DB status")
         operation.getTags.asScala should contain theSameElementsAs Seq("System", "Auth")
+
+        // When variants disagree on operationId, omit it rather than pick one arbitrarily.
+        operation.getOperationId shouldBe null
+      }
+
+      it("keeps the operationId when every variant agrees") {
+        val calls = Seq(
+          call("GET", "/v1/agree", Some("a"), Some("d1"), Seq("X"), Some("agreed"), Seq.empty),
+          call("GET", "/v1/agree", Some("b"), Some("d2"), Seq("X"), Some("agreed"), Seq(bearerScheme))
+        )
+
+        val openAPI = new OpenAPI()
+        BaklavaDslFormatterOpenAPIWorker.generateForCalls(openAPI, calls)
+
+        openAPI.getPaths.get("/v1/agree").getGet.getOperationId shouldBe "agreed"
       }
 
       it("does not add an empty security requirement when every variant uses the same scheme") {

--- a/tsrest/src/main/scala/pl/iterators/baklava/tsrest/BaklavaDslFormatterTsRest.scala
+++ b/tsrest/src/main/scala/pl/iterators/baklava/tsrest/BaklavaDslFormatterTsRest.scala
@@ -116,8 +116,8 @@ class BaklavaDslFormatterTsRest extends BaklavaDslFormatter {
 
     val firstCall   = calls.head
     val req         = firstCall.request
-    val summary     = req.operationSummary.getOrElse("")
-    val description = req.operationDescription.getOrElse("")
+    val summary     = calls.flatMap(_.request.operationSummary).distinct.mkString(" / ")
+    val description = calls.flatMap(_.request.operationDescription).distinct.mkString("\\n\\n")
     val path        = req.symbolicPath.replaceAll("\\{", ":").replaceAll("}", "")
 
     // --- Path Params ---

--- a/tsrest/src/main/scala/pl/iterators/baklava/tsrest/BaklavaDslFormatterTsRest.scala
+++ b/tsrest/src/main/scala/pl/iterators/baklava/tsrest/BaklavaDslFormatterTsRest.scala
@@ -116,8 +116,8 @@ class BaklavaDslFormatterTsRest extends BaklavaDslFormatter {
 
     val firstCall   = calls.head
     val req         = firstCall.request
-    val summary     = calls.flatMap(_.request.operationSummary).distinct.mkString(" / ")
-    val description = calls.flatMap(_.request.operationDescription).distinct.mkString("\\n\\n")
+    val summary     = escapeTsSingleQuoted(calls.flatMap(_.request.operationSummary).distinct.mkString(" / "))
+    val description = escapeTsSingleQuoted(calls.flatMap(_.request.operationDescription).distinct.mkString("\n\n"))
     val path        = req.symbolicPath.replaceAll("\\{", ":").replaceAll("}", "")
 
     // --- Path Params ---
@@ -249,6 +249,9 @@ class BaklavaDslFormatterTsRest extends BaklavaDslFormatter {
       }
       .mkString
   }
+
+  private def escapeTsSingleQuoted(s: String): String =
+    s.replace("\\", "\\\\").replace("'", "\\'").replace("\n", "\\n").replace("\r", "\\r")
 
   private def zod(schema: BaklavaSchemaSerializable): String = {
     val desc = schema.description.map(d => s""".describe("${d.replace("\"", "'").replace("\n", "\\n")}")""").getOrElse("")


### PR DESCRIPTION
Previously, when two `supports` blocks were defined for the same path
and method (e.g. an unauthenticated and an authenticated variant of the
same endpoint), only the first variant's security schemes, summary,
description, tags, and operationId were emitted. Critically, if the
first variant was unauthenticated, the operation was rendered with
`security: []` and the auth scheme reference was lost entirely.

Now the OpenAPI formatter collects distinct schemes across every
variant, joins distinct summaries/descriptions/tags, and prepends an
empty `SecurityRequirement` when any variant is unauthenticated — the
OpenAPI convention for "auth optional". The ts-rest formatter performs
the same merge for summary and description.

Fixes #55