### PR TITLE
Stabilize example order and merge response descriptions (#50, #51)

### DIFF
--- a/openapi/src/main/scala/pl/iterators/baklava/openapi/BaklavaDslFormatterOpenAPIWorker.scala
+++ b/openapi/src/main/scala/pl/iterators/baklava/openapi/BaklavaDslFormatterOpenAPIWorker.scala
@@ -152,39 +152,46 @@ object BaklavaDslFormatterOpenAPIWorker {
         val operation          = new io.swagger.v3.oas.models.Operation()
         val operationResponses = new ApiResponses()
         calls.groupBy(_.response.status).toList.sortBy(_._1.status).foreach { case (status, commonStatusCalls) =>
-          commonStatusCalls.groupBy(_.response.responseContentType).foreach { case (contentType, commonContentTypeCalls) =>
-            val r           = new io.swagger.v3.oas.models.responses.ApiResponse()
-            val content     = new Content()
-            val mediaType   = new io.swagger.v3.oas.models.media.MediaType()
-            val firstSchema = commonContentTypeCalls.flatMap(_.response.bodySchema).headOption
-            firstSchema.foreach { schema =>
-              mediaType.schema(baklavaSchemaToOpenAPISchema(schema))
-            }
-            commonContentTypeCalls.zipWithIndex.foreach { case (BaklavaSerializableCall(ctx, response), idx) =>
-              val responseStr =
-                if (contentType.contains("application/json"))
-                  parse(response.responseBodyString).map(_.printWith(Printer.spaces2)).getOrElse(response.responseBodyString)
-                else response.responseBodyString
+          commonStatusCalls
+            .groupBy(_.response.responseContentType)
+            .toList
+            .sortBy(_._1.getOrElse(""))
+            .foreach { case (contentType, unsortedContentTypeCalls) =>
+              val commonContentTypeCalls = unsortedContentTypeCalls.sortBy(_.request.responseDescription.getOrElse(""))
+              val r                      = new io.swagger.v3.oas.models.responses.ApiResponse()
+              val content                = new Content()
+              val mediaType              = new io.swagger.v3.oas.models.media.MediaType()
+              val firstSchema            = commonContentTypeCalls.flatMap(_.response.bodySchema).headOption
+              firstSchema.foreach { schema =>
+                mediaType.schema(baklavaSchemaToOpenAPISchema(schema))
+              }
+              commonContentTypeCalls.zipWithIndex.foreach { case (BaklavaSerializableCall(ctx, response), idx) =>
+                val responseStr =
+                  if (contentType.contains("application/json"))
+                    parse(response.responseBodyString).map(_.printWith(Printer.spaces2)).getOrElse(response.responseBodyString)
+                  else response.responseBodyString
 
-              mediaType.addExamples(
-                ctx.responseDescription.getOrElse(s"Example $idx"),
-                new io.swagger.v3.oas.models.examples.Example().value(responseStr)
-              )
+                mediaType.addExamples(
+                  ctx.responseDescription.getOrElse(s"Example $idx"),
+                  new io.swagger.v3.oas.models.examples.Example().value(responseStr)
+                )
+              }
+              val mergedResponseDescription =
+                commonStatusCalls.flatMap(_.request.responseDescription).distinct.mkString(" / ")
+              if (mergedResponseDescription.nonEmpty) r.setDescription(mergedResponseDescription)
+              commonContentTypeCalls.head.request.responseHeaders.filterNot { _.name == "content-type" }.foreach { header =>
+                val h = new io.swagger.v3.oas.models.headers.Header()
+                h.schema(baklavaSchemaToOpenAPISchema(header.schema))
+                h.setRequired(header.schema.required)
+                header.description.foreach(h.setDescription)
+                h.example(commonContentTypeCalls.head.response.headers.headers(header.name)) // TODO: make case-insensitive
+                r.addHeaderObject(header.name, h)
+              }
+              content.addMediaType(contentType.getOrElse("application/octet-stream"), mediaType)
+              if (firstSchema.isDefined)
+                r.setContent(content)
+              operationResponses.addApiResponse(status.status.toString, r)
             }
-            commonStatusCalls.head.request.responseDescription.foreach(r.setDescription)
-            commonContentTypeCalls.head.request.responseHeaders.filterNot { _.name == "content-type" }.foreach { header =>
-              val h = new io.swagger.v3.oas.models.headers.Header()
-              h.schema(baklavaSchemaToOpenAPISchema(header.schema))
-              h.setRequired(header.schema.required)
-              header.description.foreach(h.setDescription)
-              h.example(commonContentTypeCalls.head.response.headers.headers(header.name)) // TODO: make case-insensitive
-              r.addHeaderObject(header.name, h)
-            }
-            content.addMediaType(contentType.getOrElse("application/octet-stream"), mediaType)
-            if (firstSchema.isDefined)
-              r.setContent(content)
-            operationResponses.addApiResponse(status.status.toString, r)
-          }
         }
         operation.responses(operationResponses)
 
@@ -196,26 +203,31 @@ object BaklavaDslFormatterOpenAPIWorker {
         val successfulCalls    = calls.filter(_.response.status.status / 100 == 2).sortBy(_.response.status.status)
         val responsesToProcess =
           if (successfulCalls.isEmpty) calls else successfulCalls // sometimes there are no successful responses
-        responsesToProcess.groupBy(_.response.requestContentType).foreach { case (contentType, calls) =>
-          val mediaType   = new io.swagger.v3.oas.models.media.MediaType()
-          val firstSchema = calls.flatMap(_.request.bodySchema).headOption
-          firstSchema.foreach { schema =>
-            mediaType.schema(baklavaSchemaToOpenAPISchema(schema))
-            calls.zipWithIndex.foreach { case (call, idx) =>
-              // todo this is wierd that requestBodyString is in response
-              val requestStr =
-                if (contentType.contains("application/json"))
-                  parse(call.response.requestBodyString).map(_.printWith(Printer.spaces2)).getOrElse(call.response.requestBodyString)
-                else call.response.requestBodyString
+        responsesToProcess
+          .groupBy(_.response.requestContentType)
+          .toList
+          .sortBy(_._1.getOrElse(""))
+          .foreach { case (contentType, unsortedCalls) =>
+            val calls       = unsortedCalls.sortBy(_.request.responseDescription.getOrElse(""))
+            val mediaType   = new io.swagger.v3.oas.models.media.MediaType()
+            val firstSchema = calls.flatMap(_.request.bodySchema).headOption
+            firstSchema.foreach { schema =>
+              mediaType.schema(baklavaSchemaToOpenAPISchema(schema))
+              calls.zipWithIndex.foreach { case (call, idx) =>
+                // todo this is wierd that requestBodyString is in response
+                val requestStr =
+                  if (contentType.contains("application/json"))
+                    parse(call.response.requestBodyString).map(_.printWith(Printer.spaces2)).getOrElse(call.response.requestBodyString)
+                  else call.response.requestBodyString
 
-              mediaType.addExamples(
-                call.request.responseDescription.getOrElse(s"Example $idx"),
-                new io.swagger.v3.oas.models.examples.Example().value(requestStr)
-              )
+                mediaType.addExamples(
+                  call.request.responseDescription.getOrElse(s"Example $idx"),
+                  new io.swagger.v3.oas.models.examples.Example().value(requestStr)
+                )
+              }
+              content.addMediaType(contentType.getOrElse("application/octet-stream"), mediaType)
             }
-            content.addMediaType(contentType.getOrElse("application/octet-stream"), mediaType)
           }
-        }
         requestBody.setContent(content)
         if (!content.isEmpty) operation.setRequestBody(requestBody)
 

--- a/openapi/src/main/scala/pl/iterators/baklava/openapi/BaklavaDslFormatterOpenAPIWorker.scala
+++ b/openapi/src/main/scala/pl/iterators/baklava/openapi/BaklavaDslFormatterOpenAPIWorker.scala
@@ -177,7 +177,7 @@ object BaklavaDslFormatterOpenAPIWorker {
                 )
               }
               val mergedResponseDescription =
-                commonStatusCalls.flatMap(_.request.responseDescription).distinct.mkString(" / ")
+                commonStatusCalls.flatMap(_.request.responseDescription).distinct.sorted.mkString(" / ")
               if (mergedResponseDescription.nonEmpty) r.setDescription(mergedResponseDescription)
               commonContentTypeCalls.head.request.responseHeaders.filterNot { _.name == "content-type" }.foreach { header =>
                 val h = new io.swagger.v3.oas.models.headers.Header()

--- a/openapi/src/test/scala/pl/iterators/baklava/openapi/ResponseOrderAndDescriptionSpec.scala
+++ b/openapi/src/test/scala/pl/iterators/baklava/openapi/ResponseOrderAndDescriptionSpec.scala
@@ -1,0 +1,111 @@
+package pl.iterators.baklava.openapi
+
+import io.swagger.v3.oas.models.OpenAPI
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
+import pl.iterators.baklava.*
+
+import scala.jdk.CollectionConverters.*
+
+class ResponseOrderAndDescriptionSpec extends AnyFunSpec with Matchers {
+
+  describe("BaklavaDslFormatterOpenAPIWorker response rendering") {
+
+    it("orders examples alphabetically by description regardless of input order (regression for #51)") {
+      val openAPI = new OpenAPI()
+      BaklavaDslFormatterOpenAPIWorker.generateForCalls(
+        openAPI,
+        Seq(
+          jsonCall("Return users matching 'jane'", """[{"id":1}]"""),
+          jsonCall("Return all users", """[{"id":1},{"id":2}]"""),
+          jsonCall("Return first page with 2 users", """[{"id":1},{"id":2}]""")
+        )
+      )
+
+      val examples = openAPI.getPaths.get("/users").getGet.getResponses.get("200").getContent.get("application/json").getExamples
+      examples.asScala.keys.toList shouldBe List(
+        "Return all users",
+        "Return first page with 2 users",
+        "Return users matching 'jane'"
+      )
+    }
+
+    it("produces the same example order regardless of input permutation (regression for #51)") {
+      val a = jsonCall("Return users matching 'jane'", "[]")
+      val b = jsonCall("Return all users", "[]")
+      val c = jsonCall("Return first page with 2 users", "[]")
+
+      val permutations = Seq(Seq(a, b, c), Seq(c, a, b), Seq(b, c, a), Seq(a, c, b))
+      val keyLists     = permutations.map { perm =>
+        val openAPI = new OpenAPI()
+        BaklavaDslFormatterOpenAPIWorker.generateForCalls(openAPI, perm)
+        openAPI.getPaths.get("/users").getGet.getResponses.get("200").getContent.get("application/json").getExamples.asScala.keys.toList
+      }
+
+      keyLists.distinct should have size 1
+    }
+
+    it("merges distinct response descriptions rather than picking the first example's description (regression for #50)") {
+      val openAPI = new OpenAPI()
+      BaklavaDslFormatterOpenAPIWorker.generateForCalls(
+        openAPI,
+        Seq(
+          jsonCall("Return users matching 'jane'", "[]"),
+          jsonCall("Return all users", "[]"),
+          jsonCall("Return first page with 2 users", "[]")
+        )
+      )
+
+      val description = openAPI.getPaths.get("/users").getGet.getResponses.get("200").getDescription
+      description should include("Return all users")
+      description should include("Return first page with 2 users")
+      description should include("Return users matching 'jane'")
+      description should include(" / ")
+    }
+
+    it("keeps a single description unchanged when all examples share it") {
+      val openAPI = new OpenAPI()
+      BaklavaDslFormatterOpenAPIWorker.generateForCalls(
+        openAPI,
+        Seq(
+          jsonCall("OK", "[]"),
+          jsonCall("OK", "[]")
+        )
+      )
+
+      openAPI.getPaths.get("/users").getGet.getResponses.get("200").getDescription shouldBe "OK"
+    }
+  }
+
+  private def jsonCall(responseDescription: String, body: String): BaklavaSerializableCall =
+    BaklavaSerializableCall(
+      request = BaklavaRequestContextSerializable(
+        symbolicPath = "/users",
+        path = "/users",
+        pathDescription = None,
+        pathSummary = None,
+        method = Some(BaklavaHttpMethod("GET")),
+        operationDescription = None,
+        operationSummary = None,
+        operationId = None,
+        operationTags = Seq.empty,
+        securitySchemes = Seq.empty,
+        bodySchema = None,
+        headersSeq = Seq.empty,
+        pathParametersSeq = Seq.empty,
+        queryParametersSeq = Seq.empty,
+        responseDescription = Some(responseDescription),
+        responseHeaders = Seq.empty
+      ),
+      response = BaklavaResponseContextSerializable(
+        protocol = BaklavaHttpProtocol("HTTP/1.1"),
+        status = BaklavaHttpStatus(200),
+        headers = BaklavaHttpHeaders(Map.empty),
+        requestBodyString = "",
+        responseBodyString = body,
+        requestContentType = None,
+        responseContentType = Some("application/json"),
+        bodySchema = Some(BaklavaSchemaSerializable(Schema.stringSchema))
+      )
+    )
+}

--- a/openapi/src/test/scala/pl/iterators/baklava/openapi/ResponseOrderAndDescriptionSpec.scala
+++ b/openapi/src/test/scala/pl/iterators/baklava/openapi/ResponseOrderAndDescriptionSpec.scala
@@ -45,22 +45,22 @@ class ResponseOrderAndDescriptionSpec extends AnyFunSpec with Matchers {
       keyLists.distinct should have size 1
     }
 
-    it("merges distinct response descriptions rather than picking the first example's description (regression for #50)") {
-      val openAPI = new OpenAPI()
-      BaklavaDslFormatterOpenAPIWorker.generateForCalls(
-        openAPI,
-        Seq(
-          jsonCall("Return users matching 'jane'", "[]"),
-          jsonCall("Return all users", "[]"),
-          jsonCall("Return first page with 2 users", "[]")
-        )
+    it("merges distinct response descriptions, sorted, rather than picking the first example's description (regression for #50)") {
+      val calls = Seq(
+        jsonCall("Return users matching 'jane'", "[]"),
+        jsonCall("Return all users", "[]"),
+        jsonCall("Return first page with 2 users", "[]")
       )
 
-      val description = openAPI.getPaths.get("/users").getGet.getResponses.get("200").getDescription
-      description should include("Return all users")
-      description should include("Return first page with 2 users")
-      description should include("Return users matching 'jane'")
-      description should include(" / ")
+      // Merged description must be identical regardless of input permutation.
+      val descriptions = Seq(calls, calls.reverse, Seq(calls(1), calls(2), calls.head)).map { perm =>
+        val openAPI = new OpenAPI()
+        BaklavaDslFormatterOpenAPIWorker.generateForCalls(openAPI, perm)
+        openAPI.getPaths.get("/users").getGet.getResponses.get("200").getDescription
+      }
+
+      descriptions.distinct should have size 1
+      descriptions.head shouldBe "Return all users / Return first page with 2 users / Return users matching 'jane'"
     }
 
     it("keeps a single description unchanged when all examples share it") {


### PR DESCRIPTION
## Summary

Two bugs in OpenAPI response rendering in `BaklavaDslFormatterOpenAPIWorker`:

**#51 — non-deterministic example order.** Examples within a response appeared in different orders across runs because `groupBy` iteration depends on hash ordering, and the underlying calls list comes from filesystem iteration of hashed JSON filenames in `target/baklava/calls/`. Now the contentType `groupBy` is sorted, and calls within a `(status, contentType)` group are sorted by `responseDescription` before iteration. Same fix applied to the request-body section.

**#50 — response description taken from first example.** The response-level `description` field was previously set from the first example's description, which misleadingly represented the whole response by one example's scenario. Now distinct descriptions are joined with `" / "` — consistent with how `operationSummary`/`operationDescription` are merged across multiple `supports` variants (PR #60).

## Test plan

- [x] `ResponseOrderAndDescriptionSpec` — 4 new tests:
  - orders examples alphabetically regardless of input order
  - produces identical order across 4 input permutations
  - merges distinct descriptions with `" / "`
  - keeps a single shared description unchanged
- [x] All existing openapi tests pass (35/35 across both Scala 2.13 and 3.3.7)

Closes #50
Closes #51