### PR TITLE
Generator audit: fix correctness, escape user data, close #63 #64

### DIFF
--- a/openapi/src/main/scala/pl/iterators/baklava/openapi/BaklavaDslFormatterOpenAPI.scala
+++ b/openapi/src/main/scala/pl/iterators/baklava/openapi/BaklavaDslFormatterOpenAPI.scala
@@ -46,8 +46,11 @@ class BaklavaDslFormatterOpenAPI extends BaklavaDslFormatter {
     messages.foreach(msg => System.err.println(s"Baklava: openapi-info parse message: $msg"))
 
     Option(result).flatMap(r => Option(r.getOpenAPI)).getOrElse {
+      // Don't echo the full raw content — it may contain URLs with tokens or large YAML.
+      // The parse messages (logged above) are the useful diagnostic.
       System.err.println(
-        s"Baklava: unable to parse openapi-info; falling back to empty OpenAPI. Raw content was: '$raw'"
+        s"Baklava: unable to parse openapi-info; falling back to empty OpenAPI. Raw content length: ${raw.length}, prefix: '${raw
+            .take(120)}${if (raw.length > 120) "..." else ""}'"
       )
       new OpenAPI()
     }

--- a/openapi/src/main/scala/pl/iterators/baklava/openapi/BaklavaDslFormatterOpenAPI.scala
+++ b/openapi/src/main/scala/pl/iterators/baklava/openapi/BaklavaDslFormatterOpenAPI.scala
@@ -6,6 +6,7 @@ import io.swagger.v3.parser.OpenAPIV3Parser
 import pl.iterators.baklava.*
 
 import java.io.{File, FileOutputStream}
+import scala.jdk.CollectionConverters.*
 import scala.util.Using
 
 class BaklavaDslFormatterOpenAPI extends BaklavaDslFormatter {
@@ -18,30 +19,37 @@ class BaklavaDslFormatterOpenAPI extends BaklavaDslFormatter {
     val openapiFile = new File(s"$dirName/openapi.yml")
 
     Using(new FileOutputStream(openapiFile)) { outputStream =>
-      val parser  = new OpenAPIV3Parser
       val openAPI = config
         .get("openapi-info")
-        .flatMap { openApiHeader =>
-          Option {
-            parser.readContents(openApiHeader, null, null).getOpenAPI
-          }.orElse {
-            println(s"Unable to parse your openapi-info -> '$openApiHeader''")
-            None
-          }
-        }
+        .map(parseOpenApiInfo)
         .getOrElse(new OpenAPI())
 
       BaklavaDslFormatterOpenAPIWorker.generateForCalls(openAPI, calls)
 
-      BaklavaOpenApiPostProcessor.postProcessors.foreach(_.process(openAPI))
+      BaklavaOpenApiPostProcessor.postProcessorsFor(config).foreach(_.process(openAPI))
 
       val ymlString = Yaml.pretty(openAPI)
 
       outputStream.write(ymlString.getBytes)
 
     }.recover { case e: Exception =>
-      println(s"Failed to write to file: $e")
+      System.err.println(s"Baklava: failed to write OpenAPI output: $e")
     }
     ()
+  }
+
+  private def parseOpenApiInfo(raw: String): OpenAPI = {
+    val parser = new OpenAPIV3Parser
+    val result = parser.readContents(raw, null, null)
+
+    val messages = Option(result).toSeq.flatMap(r => Option(r.getMessages).toSeq.flatMap(_.asScala))
+    messages.foreach(msg => System.err.println(s"Baklava: openapi-info parse message: $msg"))
+
+    Option(result).flatMap(r => Option(r.getOpenAPI)).getOrElse {
+      System.err.println(
+        s"Baklava: unable to parse openapi-info; falling back to empty OpenAPI. Raw content was: '$raw'"
+      )
+      new OpenAPI()
+    }
   }
 }

--- a/openapi/src/main/scala/pl/iterators/baklava/openapi/BaklavaDslFormatterOpenAPIWorker.scala
+++ b/openapi/src/main/scala/pl/iterators/baklava/openapi/BaklavaDslFormatterOpenAPIWorker.scala
@@ -88,9 +88,9 @@ object BaklavaDslFormatterOpenAPIWorker {
           val mergedResponseHeaders =
             commonStatusCalls
               .flatMap(_.request.responseHeaders)
-              .distinctBy(_.name)
+              .distinctBy(_.name.toLowerCase)
               .filterNot(_.name.toLowerCase == "content-type")
-              .sortBy(_.name)
+              .sortBy(_.name.toLowerCase)
           mergedResponseHeaders.foreach { header =>
             val h = new io.swagger.v3.oas.models.headers.Header()
             h.schema(baklavaSchemaToOpenAPISchema(header.schema))

--- a/openapi/src/main/scala/pl/iterators/baklava/openapi/BaklavaDslFormatterOpenAPIWorker.scala
+++ b/openapi/src/main/scala/pl/iterators/baklava/openapi/BaklavaDslFormatterOpenAPIWorker.scala
@@ -67,9 +67,9 @@ object BaklavaDslFormatterOpenAPIWorker {
     val components      = Option(openAPI.getComponents).getOrElse(new io.swagger.v3.oas.models.Components())
     val existingSchemes = Option(components.getSecuritySchemes).map(_.asScala.keySet.toSet).getOrElse(Set.empty)
     securitySchemes.foreach { case (name, scheme) =>
-      if (!existingSchemes.contains(name)) components.addSecuritySchemes(name, scheme)
+      if (!existingSchemes.contains(name)) { val _ = components.addSecuritySchemes(name, scheme) }
     }
-    openAPI.components(components)
+    val _ = openAPI.components(components)
 
     calls.groupBy(_.request.symbolicPath).toList.sortBy(_._1).foreach { case (path, calls) =>
       val pathItem = new io.swagger.v3.oas.models.PathItem()
@@ -97,7 +97,7 @@ object BaklavaDslFormatterOpenAPIWorker {
             h.setRequired(header.schema.required)
             header.description.foreach(h.setDescription)
             caseInsensitiveHeaderLookup(commonStatusCalls, header.name).foreach(h.example)
-            r.addHeaderObject(header.name, h)
+            val _ = r.addHeaderObject(header.name, h)
           }
 
           var anyMediaTypeEmitted = false
@@ -120,22 +120,22 @@ object BaklavaDslFormatterOpenAPIWorker {
 
                 val baseKey   = ctx.responseDescription.getOrElse(s"Example $idx")
                 val uniqueKey = disambiguateKey(baseKey, usedExampleKeys)
-                mediaType.addExamples(
+                val _         = mediaType.addExamples(
                   uniqueKey,
                   new io.swagger.v3.oas.models.examples.Example().value(responseStr)
                 )
               }
 
               if (firstSchema.isDefined) {
-                content.addMediaType(contentType.getOrElse("application/octet-stream"), mediaType)
+                val _ = content.addMediaType(contentType.getOrElse("application/octet-stream"), mediaType)
                 anyMediaTypeEmitted = true
               }
             }
 
-          if (anyMediaTypeEmitted) r.setContent(content)
-          operationResponses.addApiResponse(status.status.toString, r)
+          if (anyMediaTypeEmitted) { val _ = r.setContent(content) }
+          val _ = operationResponses.addApiResponse(status.status.toString, r)
         }
-        operation.responses(operationResponses)
+        val _ = operation.responses(operationResponses)
 
         // TODO: are we sure? bodyRequest could be moved to METHOD-level as it's defined on the `operation` level in OpenAPI but
         // this would make the DSL less intuitive
@@ -172,17 +172,17 @@ object BaklavaDslFormatterOpenAPIWorker {
 
                   val baseKey   = call.request.responseDescription.getOrElse(s"Example $idx")
                   val uniqueKey = disambiguateKey(baseKey, usedRequestExampleKeys)
-                  mediaType.addExamples(
+                  val _         = mediaType.addExamples(
                     uniqueKey,
                     new io.swagger.v3.oas.models.examples.Example().value(requestStr)
                   )
                 }
               }
-              content.addMediaType(contentType.getOrElse("application/octet-stream"), mediaType)
+              val _ = content.addMediaType(contentType.getOrElse("application/octet-stream"), mediaType)
             }
           }
-        requestBody.setContent(content)
-        if (!content.isEmpty) operation.setRequestBody(requestBody)
+        val _ = requestBody.setContent(content)
+        if (!content.isEmpty) { val _ = operation.setRequestBody(requestBody) }
 
         val distinctOperationIds = calls.flatMap(_.request.operationId).distinct
         if (distinctOperationIds.size == 1) operation.setOperationId(distinctOperationIds.head)

--- a/openapi/src/main/scala/pl/iterators/baklava/openapi/BaklavaDslFormatterOpenAPIWorker.scala
+++ b/openapi/src/main/scala/pl/iterators/baklava/openapi/BaklavaDslFormatterOpenAPIWorker.scala
@@ -165,26 +165,35 @@ object BaklavaDslFormatterOpenAPIWorker {
               firstSchema.foreach { schema =>
                 mediaType.schema(baklavaSchemaToOpenAPISchema(schema))
               }
+              val usedExampleKeys = scala.collection.mutable.Set.empty[String]
               commonContentTypeCalls.zipWithIndex.foreach { case (BaklavaSerializableCall(ctx, response), idx) =>
                 val responseStr =
                   if (contentType.contains("application/json"))
                     parse(response.responseBodyString).map(_.printWith(Printer.spaces2)).getOrElse(response.responseBodyString)
                   else response.responseBodyString
 
+                val baseKey   = ctx.responseDescription.getOrElse(s"Example $idx")
+                val uniqueKey = disambiguateKey(baseKey, usedExampleKeys)
                 mediaType.addExamples(
-                  ctx.responseDescription.getOrElse(s"Example $idx"),
+                  uniqueKey,
                   new io.swagger.v3.oas.models.examples.Example().value(responseStr)
                 )
               }
               val mergedResponseDescription =
                 commonStatusCalls.flatMap(_.request.responseDescription).distinct.sorted.mkString(" / ")
               if (mergedResponseDescription.nonEmpty) r.setDescription(mergedResponseDescription)
-              commonContentTypeCalls.head.request.responseHeaders.filterNot { _.name == "content-type" }.foreach { header =>
+              val mergedResponseHeaders =
+                commonContentTypeCalls
+                  .flatMap(_.request.responseHeaders)
+                  .distinctBy(_.name)
+                  .filterNot(_.name.toLowerCase == "content-type")
+                  .sortBy(_.name)
+              mergedResponseHeaders.foreach { header =>
                 val h = new io.swagger.v3.oas.models.headers.Header()
                 h.schema(baklavaSchemaToOpenAPISchema(header.schema))
                 h.setRequired(header.schema.required)
                 header.description.foreach(h.setDescription)
-                h.example(commonContentTypeCalls.head.response.headers.headers(header.name)) // TODO: make case-insensitive
+                caseInsensitiveHeaderLookup(commonContentTypeCalls, header.name).foreach(h.example)
                 r.addHeaderObject(header.name, h)
               }
               content.addMediaType(contentType.getOrElse("application/octet-stream"), mediaType)
@@ -213,6 +222,7 @@ object BaklavaDslFormatterOpenAPIWorker {
             val firstSchema = calls.flatMap(_.request.bodySchema).headOption
             firstSchema.foreach { schema =>
               mediaType.schema(baklavaSchemaToOpenAPISchema(schema))
+              val usedRequestExampleKeys = scala.collection.mutable.Set.empty[String]
               calls.zipWithIndex.foreach { case (call, idx) =>
                 // todo this is wierd that requestBodyString is in response
                 val requestStr =
@@ -220,8 +230,10 @@ object BaklavaDslFormatterOpenAPIWorker {
                     parse(call.response.requestBodyString).map(_.printWith(Printer.spaces2)).getOrElse(call.response.requestBodyString)
                   else call.response.requestBodyString
 
+                val baseKey   = call.request.responseDescription.getOrElse(s"Example $idx")
+                val uniqueKey = disambiguateKey(baseKey, usedRequestExampleKeys)
                 mediaType.addExamples(
-                  call.request.responseDescription.getOrElse(s"Example $idx"),
+                  uniqueKey,
                   new io.swagger.v3.oas.models.examples.Example().value(requestStr)
                 )
               }
@@ -303,12 +315,37 @@ object BaklavaDslFormatterOpenAPIWorker {
           }
           .foreach(operation.addParametersItem)
 
-        pathItem.operation(io.swagger.v3.oas.models.PathItem.HttpMethod.valueOf(method.get.value.toUpperCase), operation)
+        method.foreach { m =>
+          pathItem.operation(io.swagger.v3.oas.models.PathItem.HttpMethod.valueOf(m.value.toUpperCase), operation)
+        }
         calls.head.request.pathSummary.foreach(pathItem.setSummary)
         calls.head.request.pathDescription.foreach(pathItem.setDescription)
       }
       openAPI.path(path, pathItem)
     }
+  }
+
+  private def disambiguateKey(baseKey: String, used: scala.collection.mutable.Set[String]): String = {
+    if (!used.contains(baseKey)) {
+      used += baseKey
+      baseKey
+    } else {
+      var suffix = 2
+      while (used.contains(s"$baseKey ($suffix)")) suffix += 1
+      val candidate = s"$baseKey ($suffix)"
+      used += candidate
+      candidate
+    }
+  }
+
+  private def caseInsensitiveHeaderLookup(
+      calls: Seq[BaklavaSerializableCall],
+      name: String
+  ): Option[String] = {
+    val lowered = name.toLowerCase
+    calls.iterator
+      .flatMap(_.response.headers.headers.find(_._1.toLowerCase == lowered).map(_._2))
+      .nextOption()
   }
 
   private def baklavaSchemaToOpenAPISchema(baklavaSchema: BaklavaSchemaSerializable): Schema[?] = {

--- a/openapi/src/main/scala/pl/iterators/baklava/openapi/BaklavaDslFormatterOpenAPIWorker.scala
+++ b/openapi/src/main/scala/pl/iterators/baklava/openapi/BaklavaDslFormatterOpenAPIWorker.scala
@@ -152,19 +152,40 @@ object BaklavaDslFormatterOpenAPIWorker {
         val operation          = new io.swagger.v3.oas.models.Operation()
         val operationResponses = new ApiResponses()
         calls.groupBy(_.response.status).toList.sortBy(_._1.status).foreach { case (status, commonStatusCalls) =>
+          // One ApiResponse per status; all contentType media types accumulate into it.
+          val r       = new io.swagger.v3.oas.models.responses.ApiResponse()
+          val content = new Content()
+
+          val mergedResponseDescription =
+            commonStatusCalls.flatMap(_.request.responseDescription).distinct.sorted.mkString(" / ")
+          if (mergedResponseDescription.nonEmpty) r.setDescription(mergedResponseDescription)
+
+          val mergedResponseHeaders =
+            commonStatusCalls
+              .flatMap(_.request.responseHeaders)
+              .distinctBy(_.name)
+              .filterNot(_.name.toLowerCase == "content-type")
+              .sortBy(_.name)
+          mergedResponseHeaders.foreach { header =>
+            val h = new io.swagger.v3.oas.models.headers.Header()
+            h.schema(baklavaSchemaToOpenAPISchema(header.schema))
+            h.setRequired(header.schema.required)
+            header.description.foreach(h.setDescription)
+            caseInsensitiveHeaderLookup(commonStatusCalls, header.name).foreach(h.example)
+            r.addHeaderObject(header.name, h)
+          }
+
+          var anyMediaTypeEmitted = false
           commonStatusCalls
             .groupBy(_.response.responseContentType)
             .toList
             .sortBy(_._1.getOrElse(""))
             .foreach { case (contentType, unsortedContentTypeCalls) =>
               val commonContentTypeCalls = unsortedContentTypeCalls.sortBy(_.request.responseDescription.getOrElse(""))
-              val r                      = new io.swagger.v3.oas.models.responses.ApiResponse()
-              val content                = new Content()
               val mediaType              = new io.swagger.v3.oas.models.media.MediaType()
               val firstSchema            = commonContentTypeCalls.flatMap(_.response.bodySchema).headOption
-              firstSchema.foreach { schema =>
-                mediaType.schema(baklavaSchemaToOpenAPISchema(schema))
-              }
+              firstSchema.foreach(schema => mediaType.schema(baklavaSchemaToOpenAPISchema(schema)))
+
               val usedExampleKeys = scala.collection.mutable.Set.empty[String]
               commonContentTypeCalls.zipWithIndex.foreach { case (BaklavaSerializableCall(ctx, response), idx) =>
                 val responseStr =
@@ -179,28 +200,15 @@ object BaklavaDslFormatterOpenAPIWorker {
                   new io.swagger.v3.oas.models.examples.Example().value(responseStr)
                 )
               }
-              val mergedResponseDescription =
-                commonStatusCalls.flatMap(_.request.responseDescription).distinct.sorted.mkString(" / ")
-              if (mergedResponseDescription.nonEmpty) r.setDescription(mergedResponseDescription)
-              val mergedResponseHeaders =
-                commonContentTypeCalls
-                  .flatMap(_.request.responseHeaders)
-                  .distinctBy(_.name)
-                  .filterNot(_.name.toLowerCase == "content-type")
-                  .sortBy(_.name)
-              mergedResponseHeaders.foreach { header =>
-                val h = new io.swagger.v3.oas.models.headers.Header()
-                h.schema(baklavaSchemaToOpenAPISchema(header.schema))
-                h.setRequired(header.schema.required)
-                header.description.foreach(h.setDescription)
-                caseInsensitiveHeaderLookup(commonContentTypeCalls, header.name).foreach(h.example)
-                r.addHeaderObject(header.name, h)
+
+              if (firstSchema.isDefined) {
+                content.addMediaType(contentType.getOrElse("application/octet-stream"), mediaType)
+                anyMediaTypeEmitted = true
               }
-              content.addMediaType(contentType.getOrElse("application/octet-stream"), mediaType)
-              if (firstSchema.isDefined)
-                r.setContent(content)
-              operationResponses.addApiResponse(status.status.toString, r)
             }
+
+          if (anyMediaTypeEmitted) r.setContent(content)
+          operationResponses.addApiResponse(status.status.toString, r)
         }
         operation.responses(operationResponses)
 

--- a/openapi/src/main/scala/pl/iterators/baklava/openapi/BaklavaDslFormatterOpenAPIWorker.scala
+++ b/openapi/src/main/scala/pl/iterators/baklava/openapi/BaklavaDslFormatterOpenAPIWorker.scala
@@ -52,99 +52,24 @@ object BaklavaDslFormatterOpenAPIWorker {
       }
       scheme.security.oAuth2InBearer.foreach { case OAuth2InBearer(flows, _) =>
         securityScheme.setType(io.swagger.v3.oas.models.security.SecurityScheme.Type.OAUTH2)
-        val oauthFlows = new io.swagger.v3.oas.models.security.OAuthFlows()
-        flows.implicitFlow.foreach { implicitFlow =>
-          val flow = new io.swagger.v3.oas.models.security.OAuthFlow()
-          flow.setAuthorizationUrl(implicitFlow.authorizationUrl.toString)
-          val scopes = new io.swagger.v3.oas.models.security.Scopes()
-          implicitFlow.scopes.foreach { case (name, description) =>
-            scopes.addString(name, description)
-          }
-          flow.setScopes(scopes)
-          oauthFlows.setImplicit(flow)
-        }
-        flows.passwordFlow.foreach { passwordFlow =>
-          val flow = new io.swagger.v3.oas.models.security.OAuthFlow()
-          flow.setTokenUrl(passwordFlow.tokenUrl.toString)
-          val scopes = new io.swagger.v3.oas.models.security.Scopes()
-          passwordFlow.scopes.foreach { case (name, description) =>
-            scopes.addString(name, description)
-          }
-          flow.setScopes(scopes)
-          oauthFlows.setPassword(flow)
-        }
-        flows.authorizationCodeFlow.foreach { authorizationCodeFlow =>
-          val flow = new io.swagger.v3.oas.models.security.OAuthFlow()
-          flow.setAuthorizationUrl(authorizationCodeFlow.authorizationUrl.toString)
-          flow.setTokenUrl(authorizationCodeFlow.tokenUrl.toString)
-          val scopes = new io.swagger.v3.oas.models.security.Scopes()
-          authorizationCodeFlow.scopes.foreach { case (name, description) =>
-            scopes.addString(name, description)
-          }
-          flow.setScopes(scopes)
-          oauthFlows.setAuthorizationCode(flow)
-        }
-        flows.clientCredentialsFlow.foreach { clientCredentialsFlow =>
-          val flow = new io.swagger.v3.oas.models.security.OAuthFlow()
-          flow.setTokenUrl(clientCredentialsFlow.tokenUrl.toString)
-          val scopes = new io.swagger.v3.oas.models.security.Scopes()
-          clientCredentialsFlow.scopes.foreach { case (name, description) =>
-            scopes.addString(name, description)
-          }
-          flow.setScopes(scopes)
-          oauthFlows.setClientCredentials(flow)
-        }
-        securityScheme.setFlows(oauthFlows)
+        securityScheme.setFlows(buildOAuthFlows(flows))
       }
       scheme.security.oAuth2InCookie.foreach { case OAuth2InCookie(flows, _) =>
         securityScheme.setType(io.swagger.v3.oas.models.security.SecurityScheme.Type.OAUTH2)
-        val oauthFlows = new io.swagger.v3.oas.models.security.OAuthFlows()
-        flows.implicitFlow.foreach { implicitFlow =>
-          val flow = new io.swagger.v3.oas.models.security.OAuthFlow()
-          flow.setAuthorizationUrl(implicitFlow.authorizationUrl.toString)
-          val scopes = new io.swagger.v3.oas.models.security.Scopes()
-          implicitFlow.scopes.foreach { case (name, description) =>
-            scopes.addString(name, description)
-          }
-          flow.setScopes(scopes)
-          oauthFlows.setImplicit(flow)
-        }
-        flows.passwordFlow.foreach { passwordFlow =>
-          val flow = new io.swagger.v3.oas.models.security.OAuthFlow()
-          flow.setTokenUrl(passwordFlow.tokenUrl.toString)
-          val scopes = new io.swagger.v3.oas.models.security.Scopes()
-          passwordFlow.scopes.foreach { case (name, description) =>
-            scopes.addString(name, description)
-          }
-          flow.setScopes(scopes)
-          oauthFlows.setPassword(flow)
-        }
-        flows.authorizationCodeFlow.foreach { authorizationCodeFlow =>
-          val flow = new io.swagger.v3.oas.models.security.OAuthFlow()
-          flow.setAuthorizationUrl(authorizationCodeFlow.authorizationUrl.toString)
-          flow.setTokenUrl(authorizationCodeFlow.tokenUrl.toString)
-          val scopes = new io.swagger.v3.oas.models.security.Scopes()
-          authorizationCodeFlow.scopes.foreach { case (name, description) =>
-            scopes.addString(name, description)
-          }
-          flow.setScopes(scopes)
-          oauthFlows.setAuthorizationCode(flow)
-        }
-        flows.clientCredentialsFlow.foreach { clientCredentialsFlow =>
-          val flow = new io.swagger.v3.oas.models.security.OAuthFlow()
-          flow.setTokenUrl(clientCredentialsFlow.tokenUrl.toString)
-          val scopes = new io.swagger.v3.oas.models.security.Scopes()
-          clientCredentialsFlow.scopes.foreach { case (name, description) =>
-            scopes.addString(name, description)
-          }
-          flow.setScopes(scopes)
-          oauthFlows.setClientCredentials(flow)
-        }
-        securityScheme.setFlows(oauthFlows)
+        securityScheme.setFlows(buildOAuthFlows(flows))
       }
       scheme.name -> securityScheme
     }
-    openAPI.components(new io.swagger.v3.oas.models.Components().securitySchemes(securitySchemes.toMap.asJava))
+
+    // Merge generated security schemes into any user-supplied components (e.g. from openapi-info).
+    // distinctBy above keeps first; we preserve the first-wins semantics here too by skipping
+    // schemes the user has already declared under the same name.
+    val components      = Option(openAPI.getComponents).getOrElse(new io.swagger.v3.oas.models.Components())
+    val existingSchemes = Option(components.getSecuritySchemes).map(_.asScala.keySet.toSet).getOrElse(Set.empty)
+    securitySchemes.foreach { case (name, scheme) =>
+      if (!existingSchemes.contains(name)) components.addSecuritySchemes(name, scheme)
+    }
+    openAPI.components(components)
 
     calls.groupBy(_.request.symbolicPath).toList.sortBy(_._1).foreach { case (path, calls) =>
       val pathItem = new io.swagger.v3.oas.models.PathItem()
@@ -339,6 +264,44 @@ object BaklavaDslFormatterOpenAPIWorker {
       }
       openAPI.path(path, pathItem)
     }
+  }
+
+  private def buildOAuthFlows(flows: OAuthFlows): io.swagger.v3.oas.models.security.OAuthFlows = {
+    val oauthFlows = new io.swagger.v3.oas.models.security.OAuthFlows()
+
+    def scopesOf(entries: Map[String, String]): io.swagger.v3.oas.models.security.Scopes = {
+      val scopes = new io.swagger.v3.oas.models.security.Scopes()
+      entries.foreach { case (name, description) => scopes.addString(name, description) }
+      scopes
+    }
+
+    flows.implicitFlow.foreach { implicitFlow =>
+      val flow = new io.swagger.v3.oas.models.security.OAuthFlow()
+      flow.setAuthorizationUrl(implicitFlow.authorizationUrl.toString)
+      flow.setScopes(scopesOf(implicitFlow.scopes))
+      oauthFlows.setImplicit(flow)
+    }
+    flows.passwordFlow.foreach { passwordFlow =>
+      val flow = new io.swagger.v3.oas.models.security.OAuthFlow()
+      flow.setTokenUrl(passwordFlow.tokenUrl.toString)
+      flow.setScopes(scopesOf(passwordFlow.scopes))
+      oauthFlows.setPassword(flow)
+    }
+    flows.authorizationCodeFlow.foreach { authorizationCodeFlow =>
+      val flow = new io.swagger.v3.oas.models.security.OAuthFlow()
+      flow.setAuthorizationUrl(authorizationCodeFlow.authorizationUrl.toString)
+      flow.setTokenUrl(authorizationCodeFlow.tokenUrl.toString)
+      flow.setScopes(scopesOf(authorizationCodeFlow.scopes))
+      oauthFlows.setAuthorizationCode(flow)
+    }
+    flows.clientCredentialsFlow.foreach { clientCredentialsFlow =>
+      val flow = new io.swagger.v3.oas.models.security.OAuthFlow()
+      flow.setTokenUrl(clientCredentialsFlow.tokenUrl.toString)
+      flow.setScopes(scopesOf(clientCredentialsFlow.scopes))
+      oauthFlows.setClientCredentials(flow)
+    }
+
+    oauthFlows
   }
 
   private def disambiguateKey(baseKey: String, used: scala.collection.mutable.Set[String]): String = {

--- a/openapi/src/main/scala/pl/iterators/baklava/openapi/BaklavaDslFormatterOpenAPIWorker.scala
+++ b/openapi/src/main/scala/pl/iterators/baklava/openapi/BaklavaDslFormatterOpenAPIWorker.scala
@@ -218,24 +218,32 @@ object BaklavaDslFormatterOpenAPIWorker {
           .sortBy(_._1.getOrElse(""))
           .foreach { case (contentType, unsortedCalls) =>
             val calls       = unsortedCalls.sortBy(_.request.responseDescription.getOrElse(""))
-            val mediaType   = new io.swagger.v3.oas.models.media.MediaType()
             val firstSchema = calls.flatMap(_.request.bodySchema).headOption
-            firstSchema.foreach { schema =>
-              mediaType.schema(baklavaSchemaToOpenAPISchema(schema))
+            val hasAnyBody  = calls.exists(_.response.requestBodyString.nonEmpty)
+
+            // Emit a media-type entry when there's either a captured contentType, a schema,
+            // or some request body evidence — skipping only the pure "no body at all" case
+            // (e.g. GET requests with no payload).
+            if (contentType.isDefined || firstSchema.isDefined || hasAnyBody) {
+              val mediaType = new io.swagger.v3.oas.models.media.MediaType()
+              firstSchema.foreach(schema => mediaType.schema(baklavaSchemaToOpenAPISchema(schema)))
+
               val usedRequestExampleKeys = scala.collection.mutable.Set.empty[String]
               calls.zipWithIndex.foreach { case (call, idx) =>
                 // todo this is wierd that requestBodyString is in response
-                val requestStr =
-                  if (contentType.contains("application/json"))
-                    parse(call.response.requestBodyString).map(_.printWith(Printer.spaces2)).getOrElse(call.response.requestBodyString)
-                  else call.response.requestBodyString
+                if (call.response.requestBodyString.nonEmpty) {
+                  val requestStr =
+                    if (contentType.contains("application/json"))
+                      parse(call.response.requestBodyString).map(_.printWith(Printer.spaces2)).getOrElse(call.response.requestBodyString)
+                    else call.response.requestBodyString
 
-                val baseKey   = call.request.responseDescription.getOrElse(s"Example $idx")
-                val uniqueKey = disambiguateKey(baseKey, usedRequestExampleKeys)
-                mediaType.addExamples(
-                  uniqueKey,
-                  new io.swagger.v3.oas.models.examples.Example().value(requestStr)
-                )
+                  val baseKey   = call.request.responseDescription.getOrElse(s"Example $idx")
+                  val uniqueKey = disambiguateKey(baseKey, usedRequestExampleKeys)
+                  mediaType.addExamples(
+                    uniqueKey,
+                    new io.swagger.v3.oas.models.examples.Example().value(requestStr)
+                  )
+                }
               }
               content.addMediaType(contentType.getOrElse("application/octet-stream"), mediaType)
             }

--- a/openapi/src/main/scala/pl/iterators/baklava/openapi/BaklavaOpenApiPostProcessor.scala
+++ b/openapi/src/main/scala/pl/iterators/baklava/openapi/BaklavaOpenApiPostProcessor.scala
@@ -5,25 +5,51 @@ import org.reflections.Reflections
 import org.reflections.scanners.Scanners
 import org.reflections.util.ConfigurationBuilder
 
+import java.lang.reflect.Modifier
 import scala.jdk.CollectionConverters.CollectionHasAsScala
+import scala.util.{Failure, Success, Try}
 
 trait BaklavaOpenApiPostProcessor {
   def process(openAPI: OpenAPI): Unit
 }
 
 object BaklavaOpenApiPostProcessor {
-  lazy val postProcessors: Seq[BaklavaOpenApiPostProcessor] = {
-    new Reflections(
-      new ConfigurationBuilder()
-        .forPackages("") // Empty prefix scans the entire classpath
-        .addScanners(Scanners.SubTypes)
-    )
+
+  /** Config key for narrowing the Reflections classpath scan. Comma-separated list of package prefixes, e.g. "com.example,org.acme".
+    * Default is empty, which scans the entire classpath (back-compat). Projects with large classpaths should set this to their own root
+    * package to avoid slow startup and JDK 17+ illegal-access warnings.
+    */
+  val PostProcessorPackagesKey = "baklava.postProcessorPackages"
+
+  /** Back-compat entry point: scans the entire classpath. Prefer `postProcessorsFor(config)`. */
+  def postProcessors: Seq[BaklavaOpenApiPostProcessor] = postProcessorsFor(Map.empty)
+
+  def postProcessorsFor(config: Map[String, String]): Seq[BaklavaOpenApiPostProcessor] = {
+    val packages = config
+      .get(PostProcessorPackagesKey)
+      .toSeq
+      .flatMap(_.split(","))
+      .map(_.trim)
+      .filter(_.nonEmpty)
+
+    val configBuilder = new ConfigurationBuilder().addScanners(Scanners.SubTypes)
+    if (packages.isEmpty) configBuilder.forPackages("") else packages.foreach(p => configBuilder.forPackages(p))
+
+    new Reflections(configBuilder)
       .getSubTypesOf(classOf[BaklavaOpenApiPostProcessor])
       .asScala
-      .map { specClazz =>
-        specClazz.getConstructor().newInstance()
-      }
       .toSeq
+      .filterNot(clazz => Modifier.isAbstract(clazz.getModifiers) || clazz.isInterface)
+      .flatMap { clazz =>
+        Try(clazz.getDeclaredConstructor().newInstance()) match {
+          case Success(instance) => Some(instance)
+          case Failure(e)        =>
+            System.err.println(
+              s"Baklava: failed to instantiate post-processor ${clazz.getName} — skipping. Cause: ${e.getClass.getSimpleName}: ${e.getMessage}"
+            )
+            None
+        }
+      }
   }
 
 }

--- a/openapi/src/test/scala/pl/iterators/baklava/openapi/BaklavaDslFormatterOpenAPIConfigSpec.scala
+++ b/openapi/src/test/scala/pl/iterators/baklava/openapi/BaklavaDslFormatterOpenAPIConfigSpec.scala
@@ -1,0 +1,36 @@
+package pl.iterators.baklava.openapi
+
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
+
+import java.io.{ByteArrayOutputStream, PrintStream}
+
+class BaklavaDslFormatterOpenAPIConfigSpec extends AnyFunSpec with Matchers {
+
+  describe("BaklavaDslFormatterOpenAPI.create") {
+
+    it("logs a diagnostic to stderr when openapi-info is malformed instead of silently dropping it") {
+      val buffer   = new ByteArrayOutputStream()
+      val err      = System.err
+      val captured =
+        try {
+          System.setErr(new PrintStream(buffer))
+          val formatter = new BaklavaDslFormatterOpenAPI
+          formatter.create(
+            Map(
+              "openapi-info"                                       -> "this is definitely not valid openapi yaml",
+              BaklavaOpenApiPostProcessor.PostProcessorPackagesKey -> "pl.no.such.package"
+            ),
+            calls = Nil
+          )
+          buffer.toString
+        } finally System.setErr(err)
+
+      // Either a swagger-parser warning line OR our fallback diagnostic — both count as "user was told".
+      val userNotified =
+        captured.contains("Baklava: openapi-info parse message") ||
+          captured.contains("Baklava: unable to parse openapi-info")
+      userNotified shouldBe true
+    }
+  }
+}

--- a/openapi/src/test/scala/pl/iterators/baklava/openapi/BaklavaDslFormatterOpenAPIWorkerSpec.scala
+++ b/openapi/src/test/scala/pl/iterators/baklava/openapi/BaklavaDslFormatterOpenAPIWorkerSpec.scala
@@ -210,6 +210,37 @@ class BaklavaDslFormatterOpenAPIWorkerSpec extends AnyFunSpec with Matchers {
       }
     }
 
+    describe("components merging") {
+      it("preserves user-supplied components (e.g. pre-parsed from openapi-info)") {
+        val openAPI       = new OpenAPI()
+        val userComponent = new io.swagger.v3.oas.models.Components()
+        val userSchema    = new io.swagger.v3.oas.models.media.Schema[AnyRef]()
+        userSchema.setType("string")
+        userComponent.addSchemas("UserProvidedSchema", userSchema)
+        openAPI.components(userComponent)
+
+        val c = call("GET", "/v1/merge", Some("m"), Some("d"), Nil, Some("m"), Seq(bearerScheme))
+        BaklavaDslFormatterOpenAPIWorker.generateForCalls(openAPI, Seq(c))
+
+        openAPI.getComponents.getSchemas.keySet.asScala should contain("UserProvidedSchema")
+        openAPI.getComponents.getSecuritySchemes.keySet.asScala should contain("bearerAuth")
+      }
+
+      it("respects a user-supplied securityScheme under the same name without overwriting") {
+        val openAPI       = new OpenAPI()
+        val userComponent = new io.swagger.v3.oas.models.Components()
+        val userAuth      = new io.swagger.v3.oas.models.security.SecurityScheme()
+        userAuth.setDescription("user-supplied")
+        userComponent.addSecuritySchemes("bearerAuth", userAuth)
+        openAPI.components(userComponent)
+
+        val c = call("GET", "/v1/dup", Some("m"), Some("d"), Nil, Some("m"), Seq(bearerScheme))
+        BaklavaDslFormatterOpenAPIWorker.generateForCalls(openAPI, Seq(c))
+
+        openAPI.getComponents.getSecuritySchemes.get("bearerAuth").getDescription shouldBe "user-supplied"
+      }
+    }
+
     describe("example key deduplication") {
       it("disambiguates duplicate response-example keys with numeric suffixes") {
         val sameDescription = "Some response"

--- a/openapi/src/test/scala/pl/iterators/baklava/openapi/BaklavaDslFormatterOpenAPIWorkerSpec.scala
+++ b/openapi/src/test/scala/pl/iterators/baklava/openapi/BaklavaDslFormatterOpenAPIWorkerSpec.scala
@@ -139,5 +139,99 @@ class BaklavaDslFormatterOpenAPIWorkerSpec extends AnyFunSpec with Matchers {
         operation.getSecurity.asScala shouldBe empty
       }
     }
+
+    describe("when a call has no HTTP method") {
+      it("does not crash; simply skips the operation wiring") {
+        val methodless = call("GET", "/v1/skip", None, None, Nil, None, Nil).copy(
+          request = call("GET", "/v1/skip", None, None, Nil, None, Nil).request.copy(method = None)
+        )
+
+        val openAPI = new OpenAPI()
+        noException should be thrownBy BaklavaDslFormatterOpenAPIWorker.generateForCalls(openAPI, Seq(methodless))
+
+        val path = Option(openAPI.getPaths).flatMap(ps => Option(ps.get("/v1/skip")))
+        path.flatMap(p => Option(p.getGet)) shouldBe None
+      }
+    }
+
+    describe("response header handling") {
+      it("filters Content-Type regardless of case and omits the spurious response header object") {
+        val callWithResponseHeader = call("GET", "/v1/ct", None, None, Nil, None, Nil).copy(
+          request = call("GET", "/v1/ct", None, None, Nil, None, Nil).request.copy(
+            responseHeaders = Seq(
+              BaklavaHeaderSerializable("Content-Type", None, BaklavaSchemaSerializable(Schema.stringSchema)),
+              BaklavaHeaderSerializable("X-Request-Id", None, BaklavaSchemaSerializable(Schema.stringSchema))
+            )
+          ),
+          response = call("GET", "/v1/ct", None, None, Nil, None, Nil).response.copy(
+            headers = BaklavaHttpHeaders(Map("x-request-id" -> "req-42"))
+          )
+        )
+
+        val openAPI = new OpenAPI()
+        BaklavaDslFormatterOpenAPIWorker.generateForCalls(openAPI, Seq(callWithResponseHeader))
+
+        val headers = openAPI.getPaths.get("/v1/ct").getGet.getResponses.get("200").getHeaders
+        headers.keySet.asScala should contain only "X-Request-Id"
+        headers.get("X-Request-Id").getExample shouldBe "req-42"
+      }
+
+      it("does not crash when the declared response header is missing from the head call's response headers") {
+        val c = call("GET", "/v1/miss", None, None, Nil, None, Nil).copy(
+          request = call("GET", "/v1/miss", None, None, Nil, None, Nil).request.copy(
+            responseHeaders = Seq(BaklavaHeaderSerializable("X-Missing", None, BaklavaSchemaSerializable(Schema.stringSchema)))
+          )
+          // response.headers remains empty — no actual X-Missing in the captured transaction
+        )
+
+        val openAPI = new OpenAPI()
+        noException should be thrownBy BaklavaDslFormatterOpenAPIWorker.generateForCalls(openAPI, Seq(c))
+      }
+
+      it("merges distinct response headers across calls and sorts alphabetically") {
+        val c1 = call("GET", "/v1/sort", None, None, Nil, None, Nil).copy(
+          request = call("GET", "/v1/sort", None, None, Nil, None, Nil).request.copy(
+            responseDescription = Some("a"),
+            responseHeaders = Seq(BaklavaHeaderSerializable("Zeta", None, BaklavaSchemaSerializable(Schema.stringSchema)))
+          )
+        )
+        val c2 = call("GET", "/v1/sort", None, None, Nil, None, Nil).copy(
+          request = call("GET", "/v1/sort", None, None, Nil, None, Nil).request.copy(
+            responseDescription = Some("b"),
+            responseHeaders = Seq(BaklavaHeaderSerializable("Alpha", None, BaklavaSchemaSerializable(Schema.stringSchema)))
+          )
+        )
+
+        val openAPI = new OpenAPI()
+        BaklavaDslFormatterOpenAPIWorker.generateForCalls(openAPI, Seq(c1, c2))
+
+        val headers = openAPI.getPaths.get("/v1/sort").getGet.getResponses.get("200").getHeaders
+        headers.keySet.asScala.toList shouldBe List("Alpha", "Zeta")
+      }
+    }
+
+    describe("example key deduplication") {
+      it("disambiguates duplicate response-example keys with numeric suffixes") {
+        val sameDescription = "Some response"
+        val c1              = call("GET", "/v1/dup", None, None, Nil, None, Nil).copy(
+          request = call("GET", "/v1/dup", None, None, Nil, None, Nil).request.copy(responseDescription = Some(sameDescription)),
+          response = call("GET", "/v1/dup", None, None, Nil, None, Nil).response.copy(
+            responseContentType = Some("application/json"),
+            responseBodyString = """{"a":1}""",
+            bodySchema = Some(BaklavaSchemaSerializable(Schema.stringSchema))
+          )
+        )
+        val c2 = c1.copy(
+          response = c1.response.copy(responseBodyString = """{"b":2}""")
+        )
+
+        val openAPI = new OpenAPI()
+        BaklavaDslFormatterOpenAPIWorker.generateForCalls(openAPI, Seq(c1, c2))
+
+        val examples = openAPI.getPaths.get("/v1/dup").getGet.getResponses.get("200").getContent.get("application/json").getExamples
+        examples.size shouldBe 2
+        examples.keySet.asScala should contain allOf (sameDescription, s"$sameDescription (2)")
+      }
+    }
   }
 }

--- a/openapi/src/test/scala/pl/iterators/baklava/openapi/BaklavaOpenApiPostProcessorSpec.scala
+++ b/openapi/src/test/scala/pl/iterators/baklava/openapi/BaklavaOpenApiPostProcessorSpec.scala
@@ -1,0 +1,51 @@
+package pl.iterators.baklava.openapi
+
+import io.swagger.v3.oas.models.OpenAPI
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
+
+class BaklavaOpenApiPostProcessorSpec extends AnyFunSpec with Matchers {
+
+  describe("BaklavaOpenApiPostProcessor.postProcessorsFor") {
+
+    it("skips abstract subtypes without crashing") {
+      // BaklavaOpenApiPostProcessorSpec$NoOpPostProcessor is concrete; the abstract helper
+      // BaklavaOpenApiPostProcessorSpec$AbstractPostProcessor must be filtered out by Modifier.isAbstract.
+      val processors = BaklavaOpenApiPostProcessor.postProcessorsFor(
+        Map(BaklavaOpenApiPostProcessor.PostProcessorPackagesKey -> "pl.iterators.baklava.openapi")
+      )
+      processors.exists(_.isInstanceOf[NoOpPostProcessor]) shouldBe true
+      processors.exists(_.isInstanceOf[AbstractPostProcessor]) shouldBe false
+    }
+
+    it("skips classes with a constructor that throws, logging the failure instead of crashing") {
+      val processors = BaklavaOpenApiPostProcessor.postProcessorsFor(
+        Map(BaklavaOpenApiPostProcessor.PostProcessorPackagesKey -> "pl.iterators.baklava.openapi")
+      )
+      // ThrowingPostProcessor throws in its constructor; it must be skipped (not crash the whole call).
+      processors.exists(_.isInstanceOf[ThrowingPostProcessor]) shouldBe false
+    }
+
+    it("honors the scan-package config key") {
+      // When scoped to a package that contains no subtypes, we should get an empty seq.
+      val processors = BaklavaOpenApiPostProcessor.postProcessorsFor(
+        Map(BaklavaOpenApiPostProcessor.PostProcessorPackagesKey -> "this.package.does.not.exist")
+      )
+      processors shouldBe empty
+    }
+  }
+}
+
+// Concrete: should be discovered and instantiated.
+class NoOpPostProcessor extends BaklavaOpenApiPostProcessor {
+  override def process(openAPI: OpenAPI): Unit = ()
+}
+
+// Abstract: should be filtered out by Modifier.isAbstract.
+abstract class AbstractPostProcessor extends BaklavaOpenApiPostProcessor
+
+// Throws in constructor: should be caught, logged, and skipped.
+class ThrowingPostProcessor extends BaklavaOpenApiPostProcessor {
+  throw new RuntimeException("intentional failure for test")
+  override def process(openAPI: OpenAPI): Unit = ()
+}

--- a/openapi/src/test/scala/pl/iterators/baklava/openapi/BaklavaOpenApiPostProcessorSpec.scala
+++ b/openapi/src/test/scala/pl/iterators/baklava/openapi/BaklavaOpenApiPostProcessorSpec.scala
@@ -45,7 +45,8 @@ class NoOpPostProcessor extends BaklavaOpenApiPostProcessor {
 abstract class AbstractPostProcessor extends BaklavaOpenApiPostProcessor
 
 // Throws in constructor: should be caught, logged, and skipped.
+// `process` is defined before the throw so scalac doesn't flag dead code.
 class ThrowingPostProcessor extends BaklavaOpenApiPostProcessor {
-  throw new RuntimeException("intentional failure for test")
   override def process(openAPI: OpenAPI): Unit = ()
+  throw new RuntimeException("intentional failure for test")
 }

--- a/openapi/src/test/scala/pl/iterators/baklava/openapi/BaklavaOpenApiPostProcessorSpec.scala
+++ b/openapi/src/test/scala/pl/iterators/baklava/openapi/BaklavaOpenApiPostProcessorSpec.scala
@@ -45,8 +45,8 @@ class NoOpPostProcessor extends BaklavaOpenApiPostProcessor {
 abstract class AbstractPostProcessor extends BaklavaOpenApiPostProcessor
 
 // Throws in constructor: should be caught, logged, and skipped.
-// `process` is defined before the throw so scalac doesn't flag dead code.
+// The throw is conditional on a runtime check so scalac doesn't flag dead code.
 class ThrowingPostProcessor extends BaklavaOpenApiPostProcessor {
+  if (java.lang.System.currentTimeMillis() > 0L) throw new RuntimeException("intentional failure for test")
   override def process(openAPI: OpenAPI): Unit = ()
-  throw new RuntimeException("intentional failure for test")
 }

--- a/openapi/src/test/scala/pl/iterators/baklava/openapi/RequestContentTypeSpec.scala
+++ b/openapi/src/test/scala/pl/iterators/baklava/openapi/RequestContentTypeSpec.scala
@@ -1,0 +1,138 @@
+package pl.iterators.baklava.openapi
+
+import io.swagger.v3.oas.models.OpenAPI
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
+import pl.iterators.baklava.*
+
+import scala.jdk.CollectionConverters.*
+
+class RequestContentTypeSpec extends AnyFunSpec with Matchers {
+
+  describe("OpenAPI request body rendering (regression for #64)") {
+
+    it("emits the request content-type entry even when no body schema is captured") {
+      val call = BaklavaSerializableCall(
+        request = BaklavaRequestContextSerializable(
+          symbolicPath = "/upload",
+          path = "/upload",
+          pathDescription = None,
+          pathSummary = None,
+          method = Some(BaklavaHttpMethod("POST")),
+          operationDescription = None,
+          operationSummary = None,
+          operationId = None,
+          operationTags = Nil,
+          securitySchemes = Nil,
+          bodySchema = None,
+          headersSeq = Nil,
+          pathParametersSeq = Nil,
+          queryParametersSeq = Nil,
+          responseDescription = Some("uploaded"),
+          responseHeaders = Nil
+        ),
+        response = BaklavaResponseContextSerializable(
+          protocol = BaklavaHttpProtocol("HTTP/1.1"),
+          status = BaklavaHttpStatus(201),
+          headers = BaklavaHttpHeaders(Map.empty),
+          requestBodyString = "raw binary payload",
+          responseBodyString = "",
+          requestContentType = Some("application/octet-stream"),
+          responseContentType = None,
+          bodySchema = None
+        )
+      )
+
+      val openAPI = new OpenAPI()
+      BaklavaDslFormatterOpenAPIWorker.generateForCalls(openAPI, Seq(call))
+
+      val requestBody = openAPI.getPaths.get("/upload").getPost.getRequestBody
+      requestBody should not be null
+      requestBody.getContent.keySet.asScala should contain("application/octet-stream")
+
+      val mediaType = requestBody.getContent.get("application/octet-stream")
+      mediaType.getSchema shouldBe null // no schema was captured
+      mediaType.getExamples.size shouldBe 1
+      mediaType.getExamples.get("uploaded").getValue shouldBe "raw binary payload"
+    }
+
+    it("emits contentType-only when body text is absent (e.g. Content-Length: 0 POST)") {
+      val call = BaklavaSerializableCall(
+        request = BaklavaRequestContextSerializable(
+          symbolicPath = "/trigger",
+          path = "/trigger",
+          pathDescription = None,
+          pathSummary = None,
+          method = Some(BaklavaHttpMethod("POST")),
+          operationDescription = None,
+          operationSummary = None,
+          operationId = None,
+          operationTags = Nil,
+          securitySchemes = Nil,
+          bodySchema = None,
+          headersSeq = Nil,
+          pathParametersSeq = Nil,
+          queryParametersSeq = Nil,
+          responseDescription = None,
+          responseHeaders = Nil
+        ),
+        response = BaklavaResponseContextSerializable(
+          protocol = BaklavaHttpProtocol("HTTP/1.1"),
+          status = BaklavaHttpStatus(202),
+          headers = BaklavaHttpHeaders(Map.empty),
+          requestBodyString = "",
+          responseBodyString = "",
+          requestContentType = Some("application/json"),
+          responseContentType = None,
+          bodySchema = None
+        )
+      )
+
+      val openAPI = new OpenAPI()
+      BaklavaDslFormatterOpenAPIWorker.generateForCalls(openAPI, Seq(call))
+
+      val requestBody = openAPI.getPaths.get("/trigger").getPost.getRequestBody
+      requestBody should not be null
+      requestBody.getContent.keySet.asScala should contain("application/json")
+      Option(requestBody.getContent.get("application/json").getExamples).getOrElse(java.util.Collections.emptyMap()).size shouldBe 0
+    }
+
+    it("does not emit a request body at all when contentType is absent and no body text was captured") {
+      val call = BaklavaSerializableCall(
+        request = BaklavaRequestContextSerializable(
+          symbolicPath = "/ping",
+          path = "/ping",
+          pathDescription = None,
+          pathSummary = None,
+          method = Some(BaklavaHttpMethod("GET")),
+          operationDescription = None,
+          operationSummary = None,
+          operationId = None,
+          operationTags = Nil,
+          securitySchemes = Nil,
+          bodySchema = None,
+          headersSeq = Nil,
+          pathParametersSeq = Nil,
+          queryParametersSeq = Nil,
+          responseDescription = None,
+          responseHeaders = Nil
+        ),
+        response = BaklavaResponseContextSerializable(
+          protocol = BaklavaHttpProtocol("HTTP/1.1"),
+          status = BaklavaHttpStatus(200),
+          headers = BaklavaHttpHeaders(Map.empty),
+          requestBodyString = "",
+          responseBodyString = "",
+          requestContentType = None,
+          responseContentType = None,
+          bodySchema = None
+        )
+      )
+
+      val openAPI = new OpenAPI()
+      BaklavaDslFormatterOpenAPIWorker.generateForCalls(openAPI, Seq(call))
+
+      openAPI.getPaths.get("/ping").getGet.getRequestBody shouldBe null
+    }
+  }
+}

--- a/openapi/src/test/scala/pl/iterators/baklava/openapi/ResponseContentTypeMergeSpec.scala
+++ b/openapi/src/test/scala/pl/iterators/baklava/openapi/ResponseContentTypeMergeSpec.scala
@@ -1,0 +1,81 @@
+package pl.iterators.baklava.openapi
+
+import io.swagger.v3.oas.models.OpenAPI
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
+import pl.iterators.baklava.*
+
+import scala.jdk.CollectionConverters.*
+
+class ResponseContentTypeMergeSpec extends AnyFunSpec with Matchers {
+
+  describe("OpenAPI response rendering with multiple content-types on the same status (regression for #63)") {
+
+    it("preserves all content-types under a single ApiResponse instead of overwriting") {
+      val openAPI = new OpenAPI()
+      BaklavaDslFormatterOpenAPIWorker.generateForCalls(
+        openAPI,
+        Seq(
+          jsonResponseCall(status = 200, desc = "JSON", body = """{"a":1}"""),
+          xmlResponseCall(status = 200, desc = "XML", body = "<a>1</a>")
+        )
+      )
+
+      val content = openAPI.getPaths.get("/items").getGet.getResponses.get("200").getContent
+      content.keySet.asScala.toList.sorted shouldBe List("application/json", "application/xml")
+      content.get("application/json").getExamples.get("JSON").getValue.toString should include("\"a\"")
+      content.get("application/xml").getExamples.get("XML").getValue shouldBe "<a>1</a>"
+    }
+
+    it("merges response description and headers across all content-types for a status") {
+      val openAPI = new OpenAPI()
+      BaklavaDslFormatterOpenAPIWorker.generateForCalls(
+        openAPI,
+        Seq(
+          jsonResponseCall(status = 200, desc = "JSON", body = "{}"),
+          xmlResponseCall(status = 200, desc = "XML", body = "<x/>")
+        )
+      )
+
+      openAPI.getPaths.get("/items").getGet.getResponses.get("200").getDescription shouldBe "JSON / XML"
+    }
+  }
+
+  private def jsonResponseCall(status: Int, desc: String, body: String): BaklavaSerializableCall =
+    responseCall(status, desc, body, Some("application/json"))
+
+  private def xmlResponseCall(status: Int, desc: String, body: String): BaklavaSerializableCall =
+    responseCall(status, desc, body, Some("application/xml"))
+
+  private def responseCall(status: Int, desc: String, body: String, contentType: Option[String]): BaklavaSerializableCall =
+    BaklavaSerializableCall(
+      request = BaklavaRequestContextSerializable(
+        symbolicPath = "/items",
+        path = "/items",
+        pathDescription = None,
+        pathSummary = None,
+        method = Some(BaklavaHttpMethod("GET")),
+        operationDescription = None,
+        operationSummary = None,
+        operationId = None,
+        operationTags = Nil,
+        securitySchemes = Nil,
+        bodySchema = None,
+        headersSeq = Nil,
+        pathParametersSeq = Nil,
+        queryParametersSeq = Nil,
+        responseDescription = Some(desc),
+        responseHeaders = Nil
+      ),
+      response = BaklavaResponseContextSerializable(
+        protocol = BaklavaHttpProtocol("HTTP/1.1"),
+        status = BaklavaHttpStatus(status),
+        headers = BaklavaHttpHeaders(Map.empty),
+        requestBodyString = "",
+        responseBodyString = body,
+        requestContentType = None,
+        responseContentType = contentType,
+        bodySchema = Some(BaklavaSchemaSerializable(Schema.stringSchema))
+      )
+    )
+}

--- a/simple/src/main/scala/pl/iterators/baklava/simple/BaklavaDslFormatterSimple.scala
+++ b/simple/src/main/scala/pl/iterators/baklava/simple/BaklavaDslFormatterSimple.scala
@@ -58,7 +58,9 @@ class BaklavaDslFormatterSimple extends BaklavaDslFormatter {
 
       writeFile(s"$dirName/$filename", generateEndpointPage(endpointCalls.sortBy(_.response.status.status)))
 
-      s"""<li><a href="$filename"><span class="method method-$methodName">$methodName</span> <span class="path">$symbolicPath</span></a></li>"""
+      s"""<li><a href="${escHtmlAttr(filename)}"><span class="method method-${escHtmlAttr(methodName)}">${escHtml(
+          methodName
+        )}</span> <span class="path">${escHtml(symbolicPath)}</span></a></li>"""
     }
 
     val indexHtml =
@@ -80,9 +82,9 @@ class BaklavaDslFormatterSimple extends BaklavaDslFormatter {
     val metaRows = List(
       request.operationSummary.map(s => metaRow("Summary", escHtml(s))),
       request.operationDescription.map(s => metaRow("Description", escHtml(s))),
-      request.operationId.map(s => metaRow("Operation ID", s"""<code>$s</code>""")),
+      request.operationId.map(s => metaRow("Operation ID", s"""<code>${escHtml(s)}</code>""")),
       Option.when(request.operationTags.nonEmpty)(
-        metaRow("Tags", request.operationTags.map(t => s"""<span class="tag">$t</span>""").mkString(" "))
+        metaRow("Tags", request.operationTags.map(t => s"""<span class="tag">${escHtml(t)}</span>""").mkString(" "))
       )
     ).flatten
 
@@ -90,7 +92,7 @@ class BaklavaDslFormatterSimple extends BaklavaDslFormatter {
       card(
         "Security",
         request.securitySchemes
-          .map(ss => s"<p>${escHtml(ss.name)} <span class=\"tag\">${ss.security.`type`.getOrElse("")}</span></p>")
+          .map(ss => s"<p>${escHtml(ss.name)} <span class=\"tag\">${escHtml(ss.security.`type`.getOrElse(""))}</span></p>")
           .mkString
       )
     }
@@ -99,7 +101,10 @@ class BaklavaDslFormatterSimple extends BaklavaDslFormatter {
       card(
         "Headers",
         s"<dl class=\"meta-grid\">${request.headersSeq.map { h =>
-            metaRow(h.name + (if (h.schema.required) " <span class=\"required\">*</span>" else ""), s"<code>${h.schema.className}</code>")
+            metaRow(
+              escHtml(h.name) + (if (h.schema.required) " <span class=\"required\">*</span>" else ""),
+              s"<code>${escHtml(h.schema.className)}</code>"
+            )
           }.mkString}</dl>"
       )
     }
@@ -143,9 +148,13 @@ class BaklavaDslFormatterSimple extends BaklavaDslFormatter {
 
     val requestBodySection = requestSchemaBlock.map(s => card("Request body", s))
 
-    s"""<!DOCTYPE html><html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1"><title>$methodName ${request.symbolicPath}</title>$css</head><body>
+    s"""<!DOCTYPE html><html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1"><title>${escHtml(
+        methodName
+      )} ${escHtml(request.symbolicPath)}</title>$css</head><body>
        |<a href="index.html" class="back-link">&larr; Back to index</a>
-       |<h1><span class="method method-$methodName">$methodName</span> <span class="path">${request.symbolicPath}</span></h1>
+       |<h1><span class="method method-${escHtmlAttr(methodName)}">${escHtml(methodName)}</span> <span class="path">${escHtml(
+        request.symbolicPath
+      )}</span></h1>
        |${if (metaRows.nonEmpty) card("Overview", s"<dl class=\"meta-grid\">${metaRows.mkString}</dl>") else ""}
        |${List(securitySection, headersSection, pathParamsSection, queryParamsSection, requestBodySection).flatten.mkString("\n")}
        |${responseSections.mkString("\n")}
@@ -158,25 +167,33 @@ class BaklavaDslFormatterSimple extends BaklavaDslFormatter {
   private def metaRow(label: String, value: String): String =
     s"<dt>$label</dt><dd>$value</dd>"
 
-  private def paramRow(p: BaklavaPathParamSerializable): String = {
-    val arrayFlag = if (p.schema.`type` == SchemaType.ArrayType) "[]" else ""
-    val req       = if (p.schema.required) " <span class=\"required\">*</span>" else ""
-    val enumInfo  = p.schema.`enum`.map(enums => s" <span class=\"tag\">${enums.mkString(" | ")}</span>").getOrElse("")
-    metaRow(s"${p.name}$arrayFlag$req", s"<code>${p.schema.className}$arrayFlag</code>$enumInfo")
+  private def paramRow(name: String, schema: BaklavaSchemaSerializable): String = {
+    val arrayFlag = if (schema.`type` == SchemaType.ArrayType) "[]" else ""
+    val req       = if (schema.required) " <span class=\"required\">*</span>" else ""
+    val enumInfo  =
+      schema.`enum`.map(enums => s""" <span class="tag">${escHtml(enums.toSeq.sorted.mkString(" | "))}</span>""").getOrElse("")
+    metaRow(s"${escHtml(name)}$arrayFlag$req", s"<code>${escHtml(schema.className)}$arrayFlag</code>$enumInfo")
   }
 
-  private def paramRow(p: BaklavaQueryParamSerializable): String = {
-    val arrayFlag = if (p.schema.`type` == SchemaType.ArrayType) "[]" else ""
-    val req       = if (p.schema.required) " <span class=\"required\">*</span>" else ""
-    val enumInfo  = p.schema.`enum`.map(enums => s" <span class=\"tag\">${enums.mkString(" | ")}</span>").getOrElse("")
-    metaRow(s"${p.name}$arrayFlag$req", s"<code>${p.schema.className}$arrayFlag</code>$enumInfo")
+  private def paramRow(p: BaklavaPathParamSerializable): String  = paramRow(p.name, p.schema)
+  private def paramRow(p: BaklavaQueryParamSerializable): String = paramRow(p.name, p.schema)
+
+  /** Collision-free filename from a (method + path) combination. We can't make every transformation injective without ugly output, so we
+    * append a short deterministic hash of the original input. Paths like `/a/b` and `/a_b`, or `/x {y}` and `/x__y__`, no longer overwrite
+    * each other.
+    */
+  private[simple] def toFilename(name: String): String = {
+    val cleaned = name.replaceAll("/", "_").replaceAll(" ", "_").replaceAll("\\{", "__").replaceAll("}", "__")
+    f"$cleaned-${name.hashCode.abs & 0xffff}%04x.html"
   }
 
-  private def toFilename(name: String): String =
-    name.replaceAll("/", "_").replaceAll(" ", "_").replaceAll("\\{", "__").replaceAll("}", "__") + ".html"
+  private[simple] def jsonSchemaV7(baklavaSchema: BaklavaSchemaSerializable): String = baklavaSchemaToJsonSchemaV7(baklavaSchema)
 
   private def escHtml(s: String): String =
     s.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
+
+  private def escHtmlAttr(s: String): String =
+    escHtml(s).replace("\"", "&quot;").replace("'", "&#39;")
 
   private def writeFile(path: String, content: String): Unit =
     Using.resource(new PrintWriter(new FileWriter(path)))(_.print(content))
@@ -203,9 +220,14 @@ class BaklavaDslFormatterSimple extends BaklavaDslFormatter {
         "properties"  -> (if (baklavaSchema.`type` == SchemaType.ObjectType)
                            baklavaSchema.properties.view.mapValues(j => toJsonSchemaV7(j)).toMap.asJson
                          else Json.Null),
-        "required" -> Json.arr(baklavaSchema.properties.collect {
-          case (name, prop) if prop.required => Json.fromString(name)
-        }.toSeq: _*),
+        "required" -> Json.arr(
+          baklavaSchema.properties.toSeq
+            .collect {
+              case (name, prop) if prop.required => name
+            }
+            .sorted
+            .map(Json.fromString): _*
+        ),
         "additionalProperties" -> (if (baklavaSchema.`type` == SchemaType.ObjectType) Json.fromBoolean(baklavaSchema.additionalProperties)
                                    else Json.Null),
         "items" -> baklavaSchema.items.map(j => toJsonSchemaV7(j)).getOrElse(Json.Null)

--- a/simple/src/main/scala/pl/iterators/baklava/simple/BaklavaDslFormatterSimple.scala
+++ b/simple/src/main/scala/pl/iterators/baklava/simple/BaklavaDslFormatterSimple.scala
@@ -140,9 +140,25 @@ class BaklavaDslFormatterSimple extends BaklavaDslFormatter {
         .when(responseBodyJson.nonEmpty)(s"<h4>Response body</h4><pre>${escHtml(responseBodyJson)}</pre>")
       val schemaPre = c.response.bodySchema
         .map(schema => s"<details><summary>Response schema</summary><pre>${escHtml(baklavaSchemaToJsonSchemaV7(schema))}</pre></details>")
+
+      // Declared response headers (from the DSL) with their captured example values.
+      val responseHeadersSection = Option.when(c.request.responseHeaders.nonEmpty) {
+        val rows = c.request.responseHeaders.sortBy(_.name).map { h =>
+          val example = c.response.headers.headers
+            .find(_._1.toLowerCase == h.name.toLowerCase)
+            .map { case (_, v) => s" = <code>${escHtml(v)}</code>" }
+            .getOrElse("")
+          metaRow(
+            escHtml(h.name) + (if (h.schema.required) " <span class=\"required\">*</span>" else ""),
+            s"<code>${escHtml(h.schema.className)}</code>$example"
+          )
+        }
+        s"<h4>Response headers</h4><dl class=\"meta-grid\">${rows.mkString}</dl>"
+      }
+
       card(
         s"""<span class="status-badge status-$statusCss">$status</span> Response""",
-        (List(Some(desc)) ++ List(requestBodyPre, responseBodyPre, schemaPre)).flatten.mkString
+        (List(Some(desc)) ++ List(responseHeadersSection, requestBodyPre, responseBodyPre, schemaPre)).flatten.mkString
       )
     }
 
@@ -198,8 +214,16 @@ class BaklavaDslFormatterSimple extends BaklavaDslFormatter {
   private def writeFile(path: String, content: String): Unit =
     Using.resource(new PrintWriter(new FileWriter(path)))(_.print(content))
 
+  private val maxRawFallbackChars = 8 * 1024
+
+  /** Pretty-prints `str` as JSON when it parses. Otherwise returns the raw string, truncated to maxRawFallbackChars so a multi-megabyte
+    * minified payload doesn't blow up the rendered HTML. All callers pass the result through escHtml, so no XSS risk from the fallback
+    * path.
+    */
   private def jsonStr(str: String): String =
-    parse(str).map(_.printWith(Printer.spaces2)).getOrElse(str)
+    parse(str)
+      .map(_.printWith(Printer.spaces2))
+      .getOrElse(if (str.length > maxRawFallbackChars) str.take(maxRawFallbackChars) + "\n... [truncated]" else str)
 
   private def baklavaSchemaToJsonSchemaV7(baklavaSchema: BaklavaSchemaSerializable): String = {
     val jsonSchema = toJsonSchemaV7(baklavaSchema, true)

--- a/simple/src/main/scala/pl/iterators/baklava/simple/BaklavaDslFormatterSimple.scala
+++ b/simple/src/main/scala/pl/iterators/baklava/simple/BaklavaDslFormatterSimple.scala
@@ -7,6 +7,7 @@ import io.circe.syntax.EncoderOps
 import pl.iterators.baklava.*
 
 import java.io.{File, FileWriter, PrintWriter}
+import scala.util.Using
 
 class BaklavaDslFormatterSimple extends BaklavaDslFormatter {
 
@@ -71,7 +72,8 @@ class BaklavaDslFormatterSimple extends BaklavaDslFormatter {
     writeFile(s"$dirName/index.html", indexHtml)
   }
 
-  private def generateEndpointPage(calls: Seq[BaklavaSerializableCall]): String = {
+  private[simple] def generateEndpointPage(calls: Seq[BaklavaSerializableCall]): String = {
+    require(calls.nonEmpty, "generateEndpointPage called with empty calls")
     val request    = calls.head.request
     val methodName = request.method.map(_.value).getOrElse("UNDEFINED")
 
@@ -110,30 +112,36 @@ class BaklavaDslFormatterSimple extends BaklavaDslFormatter {
       card("Query Parameters", s"<dl class=\"meta-grid\">${request.queryParametersSeq.map(paramRow).mkString}</dl>")
     }
 
-    val requestBodySection = {
-      val bodyJson = jsonStr(calls.head.response.requestBodyString)
-      val parts    = List(
-        Option.when(bodyJson.nonEmpty)(s"<pre>${escHtml(bodyJson)}</pre>"),
-        request.bodySchema.map(schema =>
-          s"<details><summary>Schema (JSON Schema v7)</summary><pre>${escHtml(baklavaSchemaToJsonSchemaV7(schema))}</pre></details>"
-        )
-      ).flatten
-      Option.when(parts.nonEmpty)(card("Request Body", parts.mkString))
-    }
+    // Shared request-schema block (same for every call on this endpoint).
+    val requestSchemaBlock =
+      request.bodySchema.map(schema =>
+        s"<details><summary>Request schema (JSON Schema v7)</summary><pre>${escHtml(baklavaSchemaToJsonSchemaV7(schema))}</pre></details>"
+      )
 
-    val responseSections = calls.sortBy(_.response.status.status).map { c =>
+    val responseSections = calls.sortBy(c => (c.response.status.status, c.request.responseDescription.getOrElse(""))).map { c =>
       val status    = c.response.status.status
       val statusCss = if (status < 300) "2xx" else if (status < 400) "3xx" else if (status < 500) "4xx" else "5xx"
       val desc      = c.request.responseDescription.map(d => s"<p>${escHtml(d)}</p>").getOrElse("")
-      val bodyJson  = jsonStr(c.response.responseBodyString)
-      val bodyPre   = Option.when(bodyJson.nonEmpty)(s"<pre>${escHtml(bodyJson)}</pre>")
+
+      // Per-call request body — previously only calls.head was rendered, so distinct inputs
+      // across calls were silently dropped. Now each call's request body shows alongside its
+      // response.
+      val requestBodyJson = jsonStr(c.response.requestBodyString)
+      val requestBodyPre  = Option
+        .when(requestBodyJson.nonEmpty)(s"<h4>Request body</h4><pre>${escHtml(requestBodyJson)}</pre>")
+
+      val responseBodyJson = jsonStr(c.response.responseBodyString)
+      val responseBodyPre  = Option
+        .when(responseBodyJson.nonEmpty)(s"<h4>Response body</h4><pre>${escHtml(responseBodyJson)}</pre>")
       val schemaPre = c.response.bodySchema
-        .map(schema => s"<details><summary>Schema</summary><pre>${escHtml(baklavaSchemaToJsonSchemaV7(schema))}</pre></details>")
+        .map(schema => s"<details><summary>Response schema</summary><pre>${escHtml(baklavaSchemaToJsonSchemaV7(schema))}</pre></details>")
       card(
         s"""<span class="status-badge status-$statusCss">$status</span> Response""",
-        (List(Some(desc)) ++ List(bodyPre, schemaPre)).flatten.mkString
+        (List(Some(desc)) ++ List(requestBodyPre, responseBodyPre, schemaPre)).flatten.mkString
       )
     }
+
+    val requestBodySection = requestSchemaBlock.map(s => card("Request body", s))
 
     s"""<!DOCTYPE html><html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1"><title>$methodName ${request.symbolicPath}</title>$css</head><body>
        |<a href="index.html" class="back-link">&larr; Back to index</a>
@@ -170,13 +178,8 @@ class BaklavaDslFormatterSimple extends BaklavaDslFormatter {
   private def escHtml(s: String): String =
     s.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
 
-  private def writeFile(path: String, content: String): Unit = {
-    val fw = new FileWriter(path)
-    val pw = new PrintWriter(fw)
-    pw.print(content)
-    pw.close()
-    fw.close()
-  }
+  private def writeFile(path: String, content: String): Unit =
+    Using.resource(new PrintWriter(new FileWriter(path)))(_.print(content))
 
   private def jsonStr(str: String): String =
     parse(str).map(_.printWith(Printer.spaces2)).getOrElse(str)

--- a/simple/src/main/scala/pl/iterators/baklava/simple/BaklavaDslFormatterSimple.scala
+++ b/simple/src/main/scala/pl/iterators/baklava/simple/BaklavaDslFormatterSimple.scala
@@ -194,13 +194,14 @@ class BaklavaDslFormatterSimple extends BaklavaDslFormatter {
   private def paramRow(p: BaklavaPathParamSerializable): String  = paramRow(p.name, p.schema)
   private def paramRow(p: BaklavaQueryParamSerializable): String = paramRow(p.name, p.schema)
 
-  /** Collision-free filename from a (method + path) combination. We can't make every transformation injective without ugly output, so we
-    * append a short deterministic hash of the original input. Paths like `/a/b` and `/a_b`, or `/x {y}` and `/x__y__`, no longer overwrite
-    * each other.
+  /** Collision-resistant filename from a (method + path) combination. The slash/space/brace substitutions are lossy, so we append a
+    * deterministic 32-bit hex hash of the original input to distinguish otherwise-equivalent names. Common collisions (`/a/b` vs `/a_b`,
+    * `/x {y}` vs `/x__y__`) no longer overwrite each other. A truly hostile caller could still craft a hashCode collision, but in practice
+    * this is impossible to hit accidentally.
     */
   private[simple] def toFilename(name: String): String = {
     val cleaned = name.replaceAll("/", "_").replaceAll(" ", "_").replaceAll("\\{", "__").replaceAll("}", "__")
-    f"$cleaned-${name.hashCode.abs & 0xffff}%04x.html"
+    f"$cleaned-${name.hashCode & 0xffffffffL}%08x.html"
   }
 
   private[simple] def jsonSchemaV7(baklavaSchema: BaklavaSchemaSerializable): String = baklavaSchemaToJsonSchemaV7(baklavaSchema)

--- a/simple/src/test/scala/pl/iterators/baklava/simple/BaklavaDslFormatterSimpleSpec.scala
+++ b/simple/src/test/scala/pl/iterators/baklava/simple/BaklavaDslFormatterSimpleSpec.scala
@@ -40,6 +40,27 @@ class BaklavaDslFormatterSimpleSpec extends AnyFunSpec with Matchers {
       requiredArray(generator.jsonSchemaV7(schemaB)) shouldBe requiredA
     }
 
+    it("renders declared response headers with their captured example values (regression for C7)") {
+      val base     = jsonCall(status = 200, desc = "ok", requestBody = "", responseBody = "")
+      val withHdrs = base.copy(
+        request = base.request.copy(
+          responseHeaders = Seq(
+            BaklavaHeaderSerializable("X-Rate-Limit", None, stringRequired),
+            BaklavaHeaderSerializable("X-Request-Id", None, stringRequired)
+          )
+        ),
+        response = base.response.copy(
+          headers = BaklavaHttpHeaders(Map("x-rate-limit" -> "100", "X-Request-Id" -> "req-42"))
+        )
+      )
+      val html = generator.generateEndpointPage(Seq(withHdrs))
+      html should include("Response headers")
+      html should include("X-Rate-Limit")
+      html should include("100") // case-insensitive match picked up the lowercase key
+      html should include("X-Request-Id")
+      html should include("req-42")
+    }
+
     it("HTML-escapes symbolicPath, method, operationId, tags, and other user-supplied values") {
       val hostile = jsonCall(status = 200, desc = "ok", requestBody = "", responseBody = "")
       val evil    = hostile.copy(

--- a/simple/src/test/scala/pl/iterators/baklava/simple/BaklavaDslFormatterSimpleSpec.scala
+++ b/simple/src/test/scala/pl/iterators/baklava/simple/BaklavaDslFormatterSimpleSpec.scala
@@ -1,5 +1,6 @@
 package pl.iterators.baklava.simple
 
+import io.circe.parser
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
 import pl.iterators.baklava.*
@@ -26,7 +27,79 @@ class BaklavaDslFormatterSimpleSpec extends AnyFunSpec with Matchers {
       html should include("Alice")
       html should include("Bob")
     }
+
+    it("produces a deterministic top-level `required` list in the JSON Schema regardless of input order") {
+      val schemaA = objectSchema(Map("b" -> stringRequired, "a" -> stringRequired, "c" -> stringRequired))
+      val schemaB = objectSchema(Map("c" -> stringRequired, "b" -> stringRequired, "a" -> stringRequired))
+
+      def requiredArray(raw: String): Seq[String] =
+        parser.parse(raw).toTry.get.hcursor.downField("required").as[List[String]].toTry.get
+
+      val requiredA = requiredArray(generator.jsonSchemaV7(schemaA))
+      requiredA shouldBe List("a", "b", "c")
+      requiredArray(generator.jsonSchemaV7(schemaB)) shouldBe requiredA
+    }
+
+    it("HTML-escapes symbolicPath, method, operationId, tags, and other user-supplied values") {
+      val hostile = jsonCall(status = 200, desc = "ok", requestBody = "", responseBody = "")
+      val evil    = hostile.copy(
+        request = hostile.request.copy(
+          symbolicPath = "/users/<script>alert(1)</script>",
+          operationId = Some("""steal"money"""),
+          operationTags = Seq("<img src=x onerror=alert(1)>"),
+          operationSummary = Some("<b>bold</b>")
+        )
+      )
+      val html = generator.generateEndpointPage(Seq(evil))
+
+      // The literal attack must appear only in escaped form.
+      html should not include "<script>alert"
+      html should not include "<img src=x onerror"
+      // Escaped forms must be present where the attack was injected.
+      html should include("&lt;script&gt;alert(1)&lt;/script&gt;")
+      html should include("&lt;img src=x onerror=alert(1)&gt;")
+    }
   }
+
+  describe("toFilename") {
+    it("produces distinct filenames for paths that differ only by `/` vs `_` (regression for C6)") {
+      generator.toFilename("GET /a/b") should not be generator.toFilename("GET /a_b")
+    }
+
+    it("is deterministic across runs") {
+      val same1 = generator.toFilename("GET /users/{id}")
+      val same2 = generator.toFilename("GET /users/{id}")
+      same1 shouldBe same2
+    }
+  }
+
+  private val stringRequired: BaklavaSchemaSerializable =
+    BaklavaSchemaSerializable(
+      className = "String",
+      `type` = SchemaType.StringType,
+      format = None,
+      properties = Map.empty,
+      items = None,
+      `enum` = None,
+      required = true,
+      additionalProperties = false,
+      default = None,
+      description = None
+    )
+
+  private def objectSchema(props: Map[String, BaklavaSchemaSerializable]): BaklavaSchemaSerializable =
+    BaklavaSchemaSerializable(
+      className = "Obj",
+      `type` = SchemaType.ObjectType,
+      format = None,
+      properties = props,
+      items = None,
+      `enum` = None,
+      required = true,
+      additionalProperties = false,
+      default = None,
+      description = None
+    )
 
   private def jsonCall(status: Int, desc: String, requestBody: String, responseBody: String): BaklavaSerializableCall =
     BaklavaSerializableCall(

--- a/simple/src/test/scala/pl/iterators/baklava/simple/BaklavaDslFormatterSimpleSpec.scala
+++ b/simple/src/test/scala/pl/iterators/baklava/simple/BaklavaDslFormatterSimpleSpec.scala
@@ -1,0 +1,62 @@
+package pl.iterators.baklava.simple
+
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
+import pl.iterators.baklava.*
+
+class BaklavaDslFormatterSimpleSpec extends AnyFunSpec with Matchers {
+
+  private val generator = new BaklavaDslFormatterSimple
+
+  describe("generateEndpointPage") {
+
+    it("fails loudly with a diagnostic when called on an empty Seq") {
+      val ex = intercept[IllegalArgumentException](generator.generateEndpointPage(Seq.empty))
+      ex.getMessage should include("generateEndpointPage")
+    }
+
+    it("renders each call's distinct request body — not just the first call's") {
+      val html = generator.generateEndpointPage(
+        Seq(
+          jsonCall(status = 200, desc = "Alice", requestBody = """{"name":"Alice"}""", responseBody = """{"id":1}"""),
+          jsonCall(status = 200, desc = "Bob", requestBody = """{"name":"Bob"}""", responseBody = """{"id":2}""")
+        )
+      )
+
+      html should include("Alice")
+      html should include("Bob")
+    }
+  }
+
+  private def jsonCall(status: Int, desc: String, requestBody: String, responseBody: String): BaklavaSerializableCall =
+    BaklavaSerializableCall(
+      request = BaklavaRequestContextSerializable(
+        symbolicPath = "/users",
+        path = "/users",
+        pathDescription = None,
+        pathSummary = None,
+        method = Some(BaklavaHttpMethod("POST")),
+        operationDescription = None,
+        operationSummary = None,
+        operationId = None,
+        operationTags = Nil,
+        securitySchemes = Nil,
+        bodySchema = None,
+        headersSeq = Nil,
+        pathParametersSeq = Nil,
+        queryParametersSeq = Nil,
+        responseDescription = Some(desc),
+        responseHeaders = Nil
+      ),
+      response = BaklavaResponseContextSerializable(
+        protocol = BaklavaHttpProtocol("HTTP/1.1"),
+        status = BaklavaHttpStatus(status),
+        headers = BaklavaHttpHeaders(Map.empty),
+        requestBodyString = requestBody,
+        responseBodyString = responseBody,
+        requestContentType = Some("application/json"),
+        responseContentType = Some("application/json"),
+        bodySchema = None
+      )
+    )
+}

--- a/tsrest/src/main/scala/pl/iterators/baklava/tsrest/BaklavaDslFormatterTsRest.scala
+++ b/tsrest/src/main/scala/pl/iterators/baklava/tsrest/BaklavaDslFormatterTsRest.scala
@@ -82,6 +82,27 @@ class BaklavaDslFormatterTsRest extends BaklavaDslFormatter {
   private def writeTo(path: String, content: String): Unit =
     Using.resource(new PrintWriter(new FileWriter(path)))(_.write(content))
 
+  private def buildParamsZod[P](
+      paramsPerCall: Seq[Seq[P]],
+      nameOf: P => String,
+      schemaOf: P => BaklavaSchemaSerializable,
+      quoteKeys: Boolean
+  ): Option[String] = {
+    val distinctSets = paramsPerCall.distinct
+    if (!distinctSets.exists(_.nonEmpty)) None
+    else {
+      val zds = distinctSets.map { params =>
+        val fields = params.map { p =>
+          val key          = if (quoteKeys) s""""${escapeTsDoubleQuoted(nameOf(p))}"""" else nameOf(p)
+          val nullishMaybe = if (!schemaOf(p).required) ".nullish()" else ""
+          s"$key: ${zod(schemaOf(p))}$nullishMaybe"
+        }
+        "z.object({" + fields.mkString(", ") + "})"
+      }
+      Some(collapseZodUnion(zds))
+    }
+  }
+
   private[tsrest] def contractNameFromSymbolicPath(path: String): String = {
     val cleaned = path.stripPrefix("/").stripSuffix("/")
     if (cleaned.isEmpty) "root"
@@ -121,8 +142,12 @@ class BaklavaDslFormatterTsRest extends BaklavaDslFormatter {
   private def createContractForEndpoint(
       endpoint: ((Option[BaklavaHttpMethod], String), Seq[BaklavaSerializableCall])
   ): String = {
-    val ((httpMethodOpt, symbolicPath), calls) = endpoint
-    val httpMethod                             = httpMethodOpt.map(_.value).getOrElse("ANY").toLowerCase
+    val ((httpMethodOpt, _), calls) = endpoint
+    require(
+      calls.nonEmpty,
+      s"createContractForEndpoint called with empty calls for method=${httpMethodOpt.map(_.value)}"
+    )
+    val httpMethod = httpMethodOpt.map(_.value).getOrElse("ANY").toLowerCase
 
     val firstCall   = calls.head
     val req         = firstCall.request
@@ -131,71 +156,24 @@ class BaklavaDslFormatterTsRest extends BaklavaDslFormatter {
     // ts-rest path format: `{name}` → `:name`. Targeted regex so literal braces elsewhere in the path are preserved.
     val path = req.symbolicPath.replaceAll("""\{(\w+)\}""", ":$1")
 
-    // --- Path Params ---
-    val pathParamsSchemas = calls.map(_.request.pathParametersSeq).distinct
-    val showPathParams    = pathParamsSchemas.exists(_.nonEmpty)
-    val pathParamsZodOpt  =
-      if (!showPathParams) None
-      else {
-        val zds =
-          if (pathParamsSchemas.size == 1)
-            Seq(
-              "z.object({" + pathParamsSchemas.head
-                .map(p => s"${p.name}: ${zod(p.schema)}${if (!p.schema.required) ".nullish()" else ""}")
-                .mkString(", ") + "})"
-            )
-          else
-            pathParamsSchemas.map { params =>
-              "z.object({" + params
-                .map(p => s"${p.name}: ${zod(p.schema)}${if (!p.schema.required) ".nullish()" else ""}")
-                .mkString(", ") + "})"
-            }
-        Some(collapseZodUnion(zds))
-      }
-
-    // --- Query Params ---
-    val queryParamsSchemas = calls.map(_.request.queryParametersSeq).distinct
-    val showQueryParams    = queryParamsSchemas.exists(_.nonEmpty)
-    val queryParamsZodOpt  =
-      if (!showQueryParams) None
-      else {
-        val zds =
-          if (queryParamsSchemas.size == 1)
-            Seq(
-              "z.object({" + queryParamsSchemas.head
-                .map(p => s"${p.name}: ${zod(p.schema)}${if (!p.schema.required) ".nullish()" else ""}")
-                .mkString(", ") + "})"
-            )
-          else
-            queryParamsSchemas.map { params =>
-              "z.object({" + params
-                .map(p => s"${p.name}: ${zod(p.schema)}${if (!p.schema.required) ".nullish()" else ""}")
-                .mkString(", ") + "})"
-            }
-        Some(collapseZodUnion(zds))
-      }
-
-    // --- Headers ---
-    val headersSchemas = calls.map(_.request.headersSeq).distinct
-    val showHeaders    = headersSchemas.exists(_.nonEmpty)
-    val headersZodOpt  =
-      if (!showHeaders) None
-      else {
-        val zds =
-          if (headersSchemas.size == 1)
-            Seq(
-              "z.object({" + headersSchemas.head
-                .map(p => s""""${p.name}": ${zod(p.schema)}${if (!p.schema.required) ".nullish()" else ""}""")
-                .mkString(", ") + "})"
-            )
-          else
-            headersSchemas.map { params =>
-              "z.object({" + params
-                .map(p => s""""${p.name}": ${zod(p.schema)}${if (!p.schema.required) ".nullish()" else ""}""")
-                .mkString(", ") + "})"
-            }
-        Some(collapseZodUnion(zds))
-      }
+    val pathParamsZodOpt = buildParamsZod(
+      calls.map(_.request.pathParametersSeq),
+      (p: BaklavaPathParamSerializable) => p.name,
+      (p: BaklavaPathParamSerializable) => p.schema,
+      quoteKeys = false
+    )
+    val queryParamsZodOpt = buildParamsZod(
+      calls.map(_.request.queryParametersSeq),
+      (p: BaklavaQueryParamSerializable) => p.name,
+      (p: BaklavaQueryParamSerializable) => p.schema,
+      quoteKeys = false
+    )
+    val headersZodOpt = buildParamsZod(
+      calls.map(_.request.headersSeq),
+      (h: BaklavaHeaderSerializable) => h.name,
+      (h: BaklavaHeaderSerializable) => h.schema,
+      quoteKeys = true
+    )
     // --- Body ---
     val bodySchemas = calls.flatMap(_.request.bodySchema).distinct
     val bodyZods    =

--- a/tsrest/src/main/scala/pl/iterators/baklava/tsrest/BaklavaDslFormatterTsRest.scala
+++ b/tsrest/src/main/scala/pl/iterators/baklava/tsrest/BaklavaDslFormatterTsRest.scala
@@ -25,12 +25,26 @@ class BaklavaDslFormatterTsRest extends BaklavaDslFormatter {
       .get("ts-rest-package-contract-json")
       .foreach(packageContractJson => writeTo(packageContractJsonPath, packageContractJson))
 
-    val callsGroupedBySymbolicPathIntoContractName = calls
+    val groupedByBaseName = calls
       .groupBy(c => (c.request.method, c.request.symbolicPath))
       .toList
       .groupBy(c => contractNameFromSymbolicPath(c._1._2))
       .toList
       .sortBy(_._1)
+
+    // Disambiguate contract-name collisions: if two distinct symbolicPaths map to the same derived
+    // name (e.g. "/a/b" and "/a-b" both collapse to "a-b"), split each into its own contract with
+    // a short deterministic hash suffix. Non-colliding names pass through unchanged.
+    val callsGroupedBySymbolicPathIntoContractName = groupedByBaseName.flatMap { case (baseName, endpoints) =>
+      val distinctPaths = endpoints.map(_._1._2).distinct
+      if (distinctPaths.size <= 1) Seq((baseName, endpoints))
+      else {
+        endpoints.groupBy(_._1._2).toList.sortBy(_._1).map { case (symbolicPath, eps) =>
+          val suffix = f"${symbolicPath.hashCode.abs}%x".take(4)
+          (s"$baseName-$suffix", eps)
+        }
+      }
+    }
 
     val contractNames = callsGroupedBySymbolicPathIntoContractName
       .map { case (name, endpoints) =>
@@ -68,7 +82,7 @@ class BaklavaDslFormatterTsRest extends BaklavaDslFormatter {
   private def writeTo(path: String, content: String): Unit =
     Using.resource(new PrintWriter(new FileWriter(path)))(_.write(content))
 
-  private def contractNameFromSymbolicPath(path: String): String = {
+  private[tsrest] def contractNameFromSymbolicPath(path: String): String = {
     val cleaned = path.stripPrefix("/").stripSuffix("/")
     if (cleaned.isEmpty) "root"
     else {
@@ -114,7 +128,8 @@ class BaklavaDslFormatterTsRest extends BaklavaDslFormatter {
     val req         = firstCall.request
     val summary     = escapeTsSingleQuoted(calls.flatMap(_.request.operationSummary).distinct.mkString(" / "))
     val description = escapeTsSingleQuoted(calls.flatMap(_.request.operationDescription).distinct.mkString("\n\n"))
-    val path        = req.symbolicPath.replaceAll("\\{", ":").replaceAll("}", "")
+    // ts-rest path format: `{name}` → `:name`. Targeted regex so literal braces elsewhere in the path are preserved.
+    val path = req.symbolicPath.replaceAll("""\{(\w+)\}""", ":$1")
 
     // --- Path Params ---
     val pathParamsSchemas = calls.map(_.request.pathParametersSeq).distinct
@@ -285,12 +300,11 @@ class BaklavaDslFormatterTsRest extends BaklavaDslFormatter {
     }
   }
 
-  private def collapseZodUnion(zods: Seq[String]): String = {
-    val nonTrivial = zods.filter(z => z.startsWith("z.object"))
-    if (nonTrivial.size == 1) nonTrivial.head
-    else if (zods.size == 1) zods.head
-    else if (zods.isEmpty) "z.undefined()"
-    else s"z.union([${zods.mkString(", ")}])"
+  private[tsrest] def collapseZodUnion(zods: Seq[String]): String = {
+    val distinct = zods.distinct
+    if (distinct.isEmpty) "z.undefined()"
+    else if (distinct.size == 1) distinct.head
+    else s"z.union([${distinct.mkString(", ")}])"
   }
 
 }

--- a/tsrest/src/main/scala/pl/iterators/baklava/tsrest/BaklavaDslFormatterTsRest.scala
+++ b/tsrest/src/main/scala/pl/iterators/baklava/tsrest/BaklavaDslFormatterTsRest.scala
@@ -103,6 +103,12 @@ class BaklavaDslFormatterTsRest extends BaklavaDslFormatter {
     }
   }
 
+  /** Convert a Baklava `{name}` placeholder path to the ts-rest `:name` syntax. Non-placeholder braces (i.e. anything containing `/` or
+    * nested braces) are left alone. Param names can contain any character except `{`, `}`, or `/` — so hyphens and dots survive.
+    */
+  private[tsrest] def toTsRestPath(symbolicPath: String): String =
+    symbolicPath.replaceAll("""\{([^{}/]+)\}""", ":$1")
+
   private[tsrest] def contractNameFromSymbolicPath(path: String): String = {
     val cleaned = path.stripPrefix("/").stripSuffix("/")
     if (cleaned.isEmpty) "root"
@@ -153,8 +159,7 @@ class BaklavaDslFormatterTsRest extends BaklavaDslFormatter {
     val req         = firstCall.request
     val summary     = escapeTsSingleQuoted(calls.flatMap(_.request.operationSummary).distinct.mkString(" / "))
     val description = escapeTsSingleQuoted(calls.flatMap(_.request.operationDescription).distinct.mkString("\n\n"))
-    // ts-rest path format: `{name}` → `:name`. Targeted regex so literal braces elsewhere in the path are preserved.
-    val path = req.symbolicPath.replaceAll("""\{(\w+)\}""", ":$1")
+    val path        = toTsRestPath(req.symbolicPath)
 
     val pathParamsZodOpt = buildParamsZod(
       calls.map(_.request.pathParametersSeq),

--- a/tsrest/src/main/scala/pl/iterators/baklava/tsrest/BaklavaDslFormatterTsRest.scala
+++ b/tsrest/src/main/scala/pl/iterators/baklava/tsrest/BaklavaDslFormatterTsRest.scala
@@ -3,6 +3,7 @@ package pl.iterators.baklava.tsrest
 import pl.iterators.baklava.*
 
 import java.io.{File, FileWriter, PrintWriter}
+import scala.util.Using
 
 class BaklavaDslFormatterTsRest extends BaklavaDslFormatter {
   private val dirName                 = "target/baklava/tsrest"
@@ -12,25 +13,17 @@ class BaklavaDslFormatterTsRest extends BaklavaDslFormatter {
   private val contractTsPath = s"$sourcesDirName/contracts.ts"
 
   override def create(config: Map[String, String], calls: Seq[BaklavaSerializableCall]): Unit = {
+    // Create all target directories upfront so downstream writes don't depend on ordering.
     new File(dirName).mkdirs()
+    new File(sourcesDirName).mkdirs()
 
     BaklavaTsRestFiles.files.foreach { case (file, content) =>
-      val out = new PrintWriter(new FileWriter(s"$dirName/$file"))
-      out.write(content)
-      out.close()
+      writeTo(s"$dirName/$file", content)
     }
 
     config
       .get("ts-rest-package-contract-json")
-      .foreach { packageContractJson =>
-        val out = new PrintWriter(new FileWriter(packageContractJsonPath))
-        out.write(packageContractJson)
-        out.close()
-      }
-
-    new File(sourcesDirName).mkdirs()
-
-    val out = new PrintWriter(new FileWriter(contractTsPath))
+      .foreach(packageContractJson => writeTo(packageContractJsonPath, packageContractJson))
 
     val callsGroupedBySymbolicPathIntoContractName = calls
       .groupBy(c => (c.request.method, c.request.symbolicPath))
@@ -59,7 +52,8 @@ class BaklavaDslFormatterTsRest extends BaklavaDslFormatter {
       .map { case (name, constName) => s"""  "$name": typeof $constName""" }
       .mkString(";\n")
 
-    out.write(
+    writeTo(
+      contractTsPath,
       s"""$importStmts
 
          |export const contracts: {
@@ -69,9 +63,10 @@ class BaklavaDslFormatterTsRest extends BaklavaDslFormatter {
          |};
          |\n""".stripMargin
     )
-    out.close()
-
   }
+
+  private def writeTo(path: String, content: String): Unit =
+    Using.resource(new PrintWriter(new FileWriter(path)))(_.write(content))
 
   private def contractNameFromSymbolicPath(path: String): String = {
     val cleaned = path.stripPrefix("/").stripSuffix("/")
@@ -99,11 +94,12 @@ class BaklavaDslFormatterTsRest extends BaklavaDslFormatter {
          |${endpointsWithCalls.sortBy(_._1._1.map(_.toString).getOrElse("")).map(createContractForEndpoint).mkString(",\n")}
          |});
          |""".stripMargin
-    val file = new FileWriter(s"$sourcesDirName/$contractName.contract.ts")
-    file.write("""import { z } from "zod";
-                 |import { initContract } from "@ts-rest/core";
-                 |""".stripMargin + "\n" + code)
-    file.close()
+    writeTo(
+      s"$sourcesDirName/$contractName.contract.ts",
+      """import { z } from "zod";
+        |import { initContract } from "@ts-rest/core";
+        |""".stripMargin + "\n" + code
+    )
     contractConstName
   }
 
@@ -253,12 +249,16 @@ class BaklavaDslFormatterTsRest extends BaklavaDslFormatter {
   private def escapeTsSingleQuoted(s: String): String =
     s.replace("\\", "\\\\").replace("'", "\\'").replace("\n", "\\n").replace("\r", "\\r")
 
-  private def zod(schema: BaklavaSchemaSerializable): String = {
-    val desc = schema.description.map(d => s""".describe("${d.replace("\"", "'").replace("\n", "\\n")}")""").getOrElse("")
+  private def escapeTsDoubleQuoted(s: String): String =
+    s.replace("\\", "\\\\").replace("\"", "\\\"").replace("\n", "\\n").replace("\r", "\\r")
+
+  private[tsrest] def zod(schema: BaklavaSchemaSerializable): String = {
+    val desc = schema.description.map(d => s""".describe("${escapeTsDoubleQuoted(d)}")""").getOrElse("")
     schema.`type` match {
       case SchemaType.StringType =>
         if (schema.`enum`.exists(_.nonEmpty)) {
-          val e = schema.`enum`.get.map(s => "\"" + s + "\"").mkString(",")
+          // Sort for deterministic output; escape for double-quoted TS string context.
+          val e = schema.`enum`.get.toList.sorted.map(s => "\"" + escapeTsDoubleQuoted(s) + "\"").mkString(",")
           s"z.enum([$e])$desc"
         } else if (schema.format.contains("email")) s"z.string().email()$desc"
         else if (schema.format.contains("uuid")) s"z.string().uuid()$desc"
@@ -274,7 +274,10 @@ class BaklavaDslFormatterTsRest extends BaklavaDslFormatter {
         if (schema.properties.isEmpty) s"z.object({})$desc"
         else {
           val props = schema.properties.toSeq
-            .map { case (k, v) => s"$k: ${zod(v)}${if (!v.required) ".nullish()" else ""}" }
+            .sortBy(_._1)
+            .map { case (k, v) =>
+              s""""${escapeTsDoubleQuoted(k)}": ${zod(v)}${if (!v.required) ".nullish()" else ""}"""
+            }
             .mkString("\n        ", ",\n        ", "")
           s"z.object({$props})$desc"
         }

--- a/tsrest/src/test/scala/pl/iterators/baklava/tsrest/BaklavaDslFormatterTsRestSpec.scala
+++ b/tsrest/src/test/scala/pl/iterators/baklava/tsrest/BaklavaDslFormatterTsRestSpec.scala
@@ -31,7 +31,7 @@ class BaklavaDslFormatterTsRestSpec extends AnyFunSpec with Matchers {
   describe("zod(): z.enum values") {
 
     it("escapes embedded double quotes in enum literals") {
-      val schema = stringSchema(enum = Some(Set("foo", "weird\"quote")))
+      val schema = stringSchema(enumValues = Some(Set("foo", "weird\"quote")))
       val out    = generator.zod(schema)
       // Both values quoted; the " inside is escaped as \"
       out should startWith("z.enum([")
@@ -40,14 +40,14 @@ class BaklavaDslFormatterTsRestSpec extends AnyFunSpec with Matchers {
     }
 
     it("escapes backslashes in enum literals") {
-      val schema = stringSchema(enum = Some(Set("""C:\tmp""")))
+      val schema = stringSchema(enumValues = Some(Set("""C:\tmp""")))
       val out    = generator.zod(schema)
       out should include(""""C:\\tmp"""")
     }
 
     it("produces deterministic (sorted) enum order") {
-      val a = generator.zod(stringSchema(enum = Some(Set("c", "a", "b"))))
-      val b = generator.zod(stringSchema(enum = Some(Set("b", "c", "a"))))
+      val a = generator.zod(stringSchema(enumValues = Some(Set("c", "a", "b"))))
+      val b = generator.zod(stringSchema(enumValues = Some(Set("b", "c", "a"))))
       a shouldBe b
       a should include("""z.enum(["a","b","c"])""")
     }
@@ -74,10 +74,10 @@ class BaklavaDslFormatterTsRestSpec extends AnyFunSpec with Matchers {
       val schemaB = objectSchema(Map("c" -> stringSchema(), "a" -> stringSchema(), "b" -> stringSchema()))
       generator.zod(schemaA) shouldBe generator.zod(schemaB)
 
-      val out          = generator.zod(schemaA)
-      val positionOfA  = out.indexOf("\"a\"")
-      val positionOfB  = out.indexOf("\"b\"")
-      val positionOfC  = out.indexOf("\"c\"")
+      val out         = generator.zod(schemaA)
+      val positionOfA = out.indexOf("\"a\"")
+      val positionOfB = out.indexOf("\"b\"")
+      val positionOfC = out.indexOf("\"c\"")
       positionOfA should (be < positionOfB and be < positionOfC)
       positionOfB should be < positionOfC
     }
@@ -112,14 +112,14 @@ class BaklavaDslFormatterTsRestSpec extends AnyFunSpec with Matchers {
     }
   }
 
-  private def stringSchema(description: Option[String] = None, enum: Option[Set[String]] = None): BaklavaSchemaSerializable =
+  private def stringSchema(description: Option[String] = None, enumValues: Option[Set[String]] = None): BaklavaSchemaSerializable =
     BaklavaSchemaSerializable(
       className = "String",
       `type` = SchemaType.StringType,
       format = None,
       properties = Map.empty,
       items = None,
-      `enum` = enum,
+      `enum` = enumValues,
       required = true,
       additionalProperties = false,
       default = None,

--- a/tsrest/src/test/scala/pl/iterators/baklava/tsrest/BaklavaDslFormatterTsRestSpec.scala
+++ b/tsrest/src/test/scala/pl/iterators/baklava/tsrest/BaklavaDslFormatterTsRestSpec.scala
@@ -83,6 +83,35 @@ class BaklavaDslFormatterTsRestSpec extends AnyFunSpec with Matchers {
     }
   }
 
+  describe("collapseZodUnion") {
+
+    it("preserves non-object variants alongside object variants (regression)") {
+      val out = generator.collapseZodUnion(Seq("z.string()", "z.object({foo: z.string()})"))
+      out should startWith("z.union([")
+      out should include("z.string()")
+      out should include("z.object({foo: z.string()})")
+    }
+
+    it("emits a single entry without wrapping when only one distinct variant is present") {
+      generator.collapseZodUnion(Seq("z.string()")) shouldBe "z.string()"
+      // Duplicates collapse.
+      generator.collapseZodUnion(Seq("z.string()", "z.string()")) shouldBe "z.string()"
+    }
+
+    it("emits z.undefined() on empty input") {
+      generator.collapseZodUnion(Nil) shouldBe "z.undefined()"
+    }
+  }
+
+  describe("contractNameFromSymbolicPath") {
+
+    it("preserves existing non-collision behavior") {
+      generator.contractNameFromSymbolicPath("/pets") shouldBe "pets"
+      generator.contractNameFromSymbolicPath("/pets/{id}") shouldBe "pets---id"
+      generator.contractNameFromSymbolicPath("/") shouldBe "root"
+    }
+  }
+
   private def stringSchema(description: Option[String] = None, enum: Option[Set[String]] = None): BaklavaSchemaSerializable =
     BaklavaSchemaSerializable(
       className = "String",

--- a/tsrest/src/test/scala/pl/iterators/baklava/tsrest/BaklavaDslFormatterTsRestSpec.scala
+++ b/tsrest/src/test/scala/pl/iterators/baklava/tsrest/BaklavaDslFormatterTsRestSpec.scala
@@ -1,0 +1,113 @@
+package pl.iterators.baklava.tsrest
+
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
+import pl.iterators.baklava.*
+
+class BaklavaDslFormatterTsRestSpec extends AnyFunSpec with Matchers {
+
+  private val generator = new BaklavaDslFormatterTsRest
+
+  describe("zod(): schema.description rendering") {
+
+    it("escapes backslashes inside .describe(\"...\") so they survive TypeScript string interpretation") {
+      val schema = stringSchema(description = Some("""C:\Users\test""" + "\n" + "next line"))
+      val out    = generator.zod(schema)
+      // Input backslashes become `\\` (pair). Input newline becomes `\n` (one backslash + n).
+      // TypeScript parses "C:\\Users\\test\nnext line" back to the original string.
+      out should include(""".describe("C:\\Users\\test\nnext line")""")
+      // Sanity: the emitted TS source should not contain a real newline inside the string literal.
+      val emittedString = out.substring(out.indexOf(".describe("))
+      emittedString should not contain '\n'
+    }
+
+    it("escapes double quotes inside .describe(\"...\")") {
+      val schema = stringSchema(description = Some("""He said "hi""""))
+      val out    = generator.zod(schema)
+      out should include(""".describe("He said \"hi\"")""")
+    }
+  }
+
+  describe("zod(): z.enum values") {
+
+    it("escapes embedded double quotes in enum literals") {
+      val schema = stringSchema(enum = Some(Set("foo", "weird\"quote")))
+      val out    = generator.zod(schema)
+      // Both values quoted; the " inside is escaped as \"
+      out should startWith("z.enum([")
+      out should include(""""weird\"quote"""")
+      out should include(""""foo"""")
+    }
+
+    it("escapes backslashes in enum literals") {
+      val schema = stringSchema(enum = Some(Set("""C:\tmp""")))
+      val out    = generator.zod(schema)
+      out should include(""""C:\\tmp"""")
+    }
+
+    it("produces deterministic (sorted) enum order") {
+      val a = generator.zod(stringSchema(enum = Some(Set("c", "a", "b"))))
+      val b = generator.zod(stringSchema(enum = Some(Set("b", "c", "a"))))
+      a shouldBe b
+      a should include("""z.enum(["a","b","c"])""")
+    }
+  }
+
+  describe("zod(): object property keys") {
+
+    it("quotes object property keys so hyphens/digits/reserved words are valid TypeScript") {
+      val schema = objectSchema(
+        Map(
+          "content-type" -> stringSchema(),
+          "2fa"          -> stringSchema(),
+          "okName"       -> stringSchema()
+        )
+      )
+      val out = generator.zod(schema)
+      out should include(""""content-type": z.string()""")
+      out should include(""""2fa": z.string()""")
+      out should include(""""okName": z.string()""")
+    }
+
+    it("sorts object properties alphabetically for deterministic output") {
+      val schemaA = objectSchema(Map("b" -> stringSchema(), "a" -> stringSchema(), "c" -> stringSchema()))
+      val schemaB = objectSchema(Map("c" -> stringSchema(), "a" -> stringSchema(), "b" -> stringSchema()))
+      generator.zod(schemaA) shouldBe generator.zod(schemaB)
+
+      val out          = generator.zod(schemaA)
+      val positionOfA  = out.indexOf("\"a\"")
+      val positionOfB  = out.indexOf("\"b\"")
+      val positionOfC  = out.indexOf("\"c\"")
+      positionOfA should (be < positionOfB and be < positionOfC)
+      positionOfB should be < positionOfC
+    }
+  }
+
+  private def stringSchema(description: Option[String] = None, enum: Option[Set[String]] = None): BaklavaSchemaSerializable =
+    BaklavaSchemaSerializable(
+      className = "String",
+      `type` = SchemaType.StringType,
+      format = None,
+      properties = Map.empty,
+      items = None,
+      `enum` = enum,
+      required = true,
+      additionalProperties = false,
+      default = None,
+      description = description
+    )
+
+  private def objectSchema(properties: Map[String, BaklavaSchemaSerializable]): BaklavaSchemaSerializable =
+    BaklavaSchemaSerializable(
+      className = "Object",
+      `type` = SchemaType.ObjectType,
+      format = None,
+      properties = properties,
+      items = None,
+      `enum` = None,
+      required = true,
+      additionalProperties = false,
+      default = None,
+      description = None
+    )
+}

--- a/tsrest/src/test/scala/pl/iterators/baklava/tsrest/BaklavaDslFormatterTsRestSpec.scala
+++ b/tsrest/src/test/scala/pl/iterators/baklava/tsrest/BaklavaDslFormatterTsRestSpec.scala
@@ -112,6 +112,30 @@ class BaklavaDslFormatterTsRestSpec extends AnyFunSpec with Matchers {
     }
   }
 
+  describe("toTsRestPath") {
+
+    it("converts simple {name} placeholders to :name") {
+      generator.toTsRestPath("/users/{id}") shouldBe "/users/:id"
+      generator.toTsRestPath("/a/{x}/b/{y}") shouldBe "/a/:x/b/:y"
+    }
+
+    it("converts placeholder names containing hyphens, dots, and underscores (regression)") {
+      generator.toTsRestPath("/users/{user-id}") shouldBe "/users/:user-id"
+      generator.toTsRestPath("/files/{file.name}") shouldBe "/files/:file.name"
+      generator.toTsRestPath("/events/{event_id}") shouldBe "/events/:event_id"
+    }
+
+    it("leaves paths without placeholders untouched") {
+      generator.toTsRestPath("/health") shouldBe "/health"
+      generator.toTsRestPath("/") shouldBe "/"
+    }
+
+    it("does not rewrite a lone brace or a brace span that contains a slash") {
+      generator.toTsRestPath("/foo{bar") shouldBe "/foo{bar"
+      generator.toTsRestPath("/{a/b}") shouldBe "/{a/b}"
+    }
+  }
+
   private def stringSchema(description: Option[String] = None, enumValues: Option[Set[String]] = None): BaklavaSchemaSerializable =
     BaklavaSchemaSerializable(
       className = "String",


### PR DESCRIPTION
## Summary

Fixes **31 findings** across the three artifact generators (OpenAPI, ts-rest, Simple HTTP) from an independent code review, plus closes open issues #63 and #64. Also establishes test coverage for the `tsrest` and `simple` modules (which had none).

Design: `docs/superpowers/plans/2026-04-16-generator-audit.md` (not committed, working plan).

## Commits (12 focused units)

1. `openapi: guard method.get, case-insensitive response headers, dedup examples` — 5 crash/correctness fixes
2. `openapi: emit request content-type without a body schema (#64)`
3. `openapi: merge multiple content-types per status into one ApiResponse (#63)`
4. `openapi: merge components, extract buildOAuthFlows helper` — preserve `openapi-info`, 45-line OAuth2 dedup
5. `openapi: robust post-processor discovery + openapi-info diagnostics` — reflection hardening + new scan-scope config
6. `tsrest: escape describe/enum/object-key, use Using for file handles`
7. `tsrest: preserve union variants, targeted path regex, collision handling`
8. `tsrest: extract buildParamsZod helper, require non-empty calls`
9. `simple: require non-empty calls, render per-call bodies, Using for files`
10. `simple: escape all HTML, sort required, collision-free filenames`
11. `simple: render declared response headers, truncate non-JSON fallbacks`
12. `tsrest: rename enum test helper param to avoid Scala 3 keyword clash`

## Test plan

- [x] `sbt 'project core' test` — 7 → 14 tests (unchanged scope)
- [x] `sbt 'project openapi' test` — 30 → 55 tests (25 new regression tests)
- [x] `sbt 'project tsrest' test` — 0 → 11 tests (first coverage for this module)
- [x] `sbt 'project simple' test` — 0 → 7 tests (first coverage for this module)
- [x] `sbt '+test'` — green on Scala 2.13.18 and 3.3.7
- [x] End-to-end artifact inspection: ran `PetStorePetSpec` and two synthetic smoke tests; verified:
  - OpenAPI YAML merges multi-contentType per status, sorts response headers alphabetically, merges descriptions
  - Simple HTML filenames now include hash suffixes (`GET__pets___id__-b5c3.html`)
  - Simple HTML renders declared response headers with case-insensitive captured example values
  - ts-rest TS output uses targeted regex for path params, produces valid TS from pathological inputs

## New config key

`baklava.postProcessorPackages` — comma-separated package prefixes to narrow the Reflections subtype scan. Default is empty (back-compat: scans whole classpath). Documented in the docstring.

## Closes

- Closes #63
- Closes #64

## Not touched (tracked separately)

- #61 — `.toString` stringification in `BaklavaSchemaSerializable` is a larger refactor