### PR TITLE
openapi: merge parameter declarations across all calls in operation (#66)

### DIFF
--- a/core/src/main/scala/pl/iterators/baklava/BaklavaSerialize.scala
+++ b/core/src/main/scala/pl/iterators/baklava/BaklavaSerialize.scala
@@ -218,7 +218,7 @@ object BaklavaRequestContextSerializable {
       securitySchemes = c.securitySchemes.map(s => BaklavaSecuritySchemaSerializable(s)),
       bodySchema = c.bodySchema.filter(_ != Schema.emptyBodySchema).map(s => BaklavaSchemaSerializable(s)),
       headersSeq = c.headersSeq.map { h =>
-        BaklavaHeaderSerializable(h, caseInsensitiveHeaderValue(c.headers.headers, h.name))
+        BaklavaHeaderSerializable(h, caseInsensitiveHeaderValue(c.headers, h.name))
       },
       pathParametersSeq = c.pathParametersSeq.map { p =>
         BaklavaPathParamSerializable(p, pathParamValues.get(p.name))
@@ -282,9 +282,9 @@ object BaklavaRequestContextSerializable {
         .toMap
   }
 
-  private def caseInsensitiveHeaderValue(headers: Map[String, String], name: String): Option[String] = {
-    val lowered = name.toLowerCase
-    headers.find(_._1.toLowerCase == lowered).map(_._2)
+  private def caseInsensitiveHeaderValue(headers: Seq[SttpHeader], name: String): Option[String] = {
+    val lowered = name.toLowerCase(java.util.Locale.ROOT)
+    headers.find(_.name.toLowerCase(java.util.Locale.ROOT) == lowered).map(_.value)
   }
 }
 

--- a/core/src/main/scala/pl/iterators/baklava/BaklavaSerialize.scala
+++ b/core/src/main/scala/pl/iterators/baklava/BaklavaSerialize.scala
@@ -135,32 +135,41 @@ object BaklavaSchemaSerializable {
 case class BaklavaHeaderSerializable(
     name: String,
     description: Option[String],
-    schema: BaklavaSchemaSerializable
+    schema: BaklavaSchemaSerializable,
+    example: Option[String] = None
 ) extends Serializable
 object BaklavaHeaderSerializable {
   def apply[T](h: Header[T]): BaklavaHeaderSerializable =
     BaklavaHeaderSerializable(h.name, h.description, BaklavaSchemaSerializable(h.schema))
+  def apply[T](h: Header[T], example: Option[String]): BaklavaHeaderSerializable =
+    BaklavaHeaderSerializable(h.name, h.description, BaklavaSchemaSerializable(h.schema), example)
 }
 
 case class BaklavaPathParamSerializable(
     name: String,
     description: Option[String],
-    schema: BaklavaSchemaSerializable
+    schema: BaklavaSchemaSerializable,
+    example: Option[String] = None
 ) extends Serializable
 
 object BaklavaPathParamSerializable {
   def apply[T](h: PathParam[T]): BaklavaPathParamSerializable =
     BaklavaPathParamSerializable(h.name, h.description, BaklavaSchemaSerializable(h.schema))
+  def apply[T](h: PathParam[T], example: Option[String]): BaklavaPathParamSerializable =
+    BaklavaPathParamSerializable(h.name, h.description, BaklavaSchemaSerializable(h.schema), example)
 }
 
 case class BaklavaQueryParamSerializable(
     name: String,
     description: Option[String],
-    schema: BaklavaSchemaSerializable
+    schema: BaklavaSchemaSerializable,
+    example: Option[String] = None
 ) extends Serializable
 object BaklavaQueryParamSerializable {
   def apply[T](h: QueryParam[T]): BaklavaQueryParamSerializable =
     BaklavaQueryParamSerializable(h.name, h.description, BaklavaSchemaSerializable(h.schema))
+  def apply[T](h: QueryParam[T], example: Option[String]): BaklavaQueryParamSerializable =
+    BaklavaQueryParamSerializable(h.name, h.description, BaklavaSchemaSerializable(h.schema), example)
 }
 
 case class BaklavaRequestContextSerializable(
@@ -192,24 +201,91 @@ case class BaklavaRequestContextSerializable(
 ) extends Serializable
 
 object BaklavaRequestContextSerializable {
-  def apply(c: BaklavaRequestContext[_, _, _, _, _, _, _]): BaklavaRequestContextSerializable = BaklavaRequestContextSerializable(
-    symbolicPath = c.symbolicPath,
-    path = c.path,
-    pathDescription = c.pathDescription,
-    pathSummary = c.pathSummary,
-    method = c.method,
-    operationDescription = c.operationDescription,
-    operationSummary = c.operationSummary,
-    operationId = c.operationId,
-    operationTags = c.operationTags,
-    securitySchemes = c.securitySchemes.map(s => BaklavaSecuritySchemaSerializable(s)),
-    bodySchema = c.bodySchema.filter(_ != Schema.emptyBodySchema).map(s => BaklavaSchemaSerializable(s)),
-    headersSeq = c.headersSeq.map(h => BaklavaHeaderSerializable(h)),
-    pathParametersSeq = c.pathParametersSeq.map(p => BaklavaPathParamSerializable(p)),
-    queryParametersSeq = c.queryParametersSeq.map(p => BaklavaQueryParamSerializable(p)),
-    responseDescription = c.responseDescription,
-    responseHeaders = c.responseHeaders.map(h => BaklavaHeaderSerializable(h))
-  )
+  def apply(c: BaklavaRequestContext[_, _, _, _, _, _, _]): BaklavaRequestContextSerializable = {
+    val pathParamValues  = extractPathParamValues(c.symbolicPath, c.path)
+    val queryParamValues = extractQueryParamValues(c.path)
+
+    BaklavaRequestContextSerializable(
+      symbolicPath = c.symbolicPath,
+      path = c.path,
+      pathDescription = c.pathDescription,
+      pathSummary = c.pathSummary,
+      method = c.method,
+      operationDescription = c.operationDescription,
+      operationSummary = c.operationSummary,
+      operationId = c.operationId,
+      operationTags = c.operationTags,
+      securitySchemes = c.securitySchemes.map(s => BaklavaSecuritySchemaSerializable(s)),
+      bodySchema = c.bodySchema.filter(_ != Schema.emptyBodySchema).map(s => BaklavaSchemaSerializable(s)),
+      headersSeq = c.headersSeq.map { h =>
+        BaklavaHeaderSerializable(h, caseInsensitiveHeaderValue(c.headers.headers, h.name))
+      },
+      pathParametersSeq = c.pathParametersSeq.map { p =>
+        BaklavaPathParamSerializable(p, pathParamValues.get(p.name))
+      },
+      queryParametersSeq = c.queryParametersSeq.map { p =>
+        BaklavaQueryParamSerializable(p, queryParamValues.get(p.name))
+      },
+      responseDescription = c.responseDescription,
+      responseHeaders = c.responseHeaders.map(h => BaklavaHeaderSerializable(h))
+    )
+  }
+
+  /** Strip any `#fragment` and `?query` from a resolved path, in that order. */
+  private def stripFragmentAndQuery(resolvedPath: String): String =
+    resolvedPath.split('#').headOption.getOrElse(resolvedPath).split('?').headOption.getOrElse("")
+
+  /** Strip any `#fragment` from a resolved path. */
+  private def stripFragment(resolvedPath: String): String =
+    resolvedPath.split('#').headOption.getOrElse(resolvedPath)
+
+  /** Extract `{name} -> actualValue` from a resolved URL by matching against its symbolic template. Both inputs are split on `/`; the
+    * resolved path is stripped of its fragment and query string first. A segment `{name}` in the template maps to whatever appears in the
+    * same position in the resolved path. URL-decoding is applied to the extracted values so `%20` etc. round-trip.
+    */
+  private def extractPathParamValues(symbolicPath: String, resolvedPath: String): Map[String, String] = {
+    val pathOnly      = stripFragmentAndQuery(resolvedPath)
+    val templateParts = symbolicPath.split('/')
+    val resolvedParts = pathOnly.split('/')
+    if (templateParts.length != resolvedParts.length) Map.empty
+    else
+      templateParts
+        .zip(resolvedParts)
+        .collect {
+          case (t, r) if t.startsWith("{") && t.endsWith("}") =>
+            val name = t.substring(1, t.length - 1)
+            name -> java.net.URLDecoder.decode(r, "UTF-8")
+        }
+        .toMap
+  }
+
+  /** Parse a URL query string into `name -> value` pairs. The resolved path is stripped of its `#fragment` first so a trailing fragment
+    * doesn't leak into the last query value. If a key appears multiple times (e.g. `?tag=a&tag=b`), the values are joined with commas —
+    * matching OpenAPI's default explode=true representation reasonably well for a single example value.
+    */
+  private def extractQueryParamValues(resolvedPath: String): Map[String, String] = {
+    val queryPart = stripFragment(resolvedPath).split('?').drop(1).headOption.getOrElse("")
+    if (queryPart.isEmpty) Map.empty
+    else
+      queryPart
+        .split('&')
+        .filter(_.nonEmpty)
+        .toSeq
+        .map { kv =>
+          val eq = kv.indexOf('=')
+          if (eq < 0) java.net.URLDecoder.decode(kv, "UTF-8")           -> ""
+          else java.net.URLDecoder.decode(kv.substring(0, eq), "UTF-8") -> java.net.URLDecoder.decode(kv.substring(eq + 1), "UTF-8")
+        }
+        .groupBy(_._1)
+        .view
+        .mapValues(_.map(_._2).mkString(","))
+        .toMap
+  }
+
+  private def caseInsensitiveHeaderValue(headers: Map[String, String], name: String): Option[String] = {
+    val lowered = name.toLowerCase
+    headers.find(_._1.toLowerCase == lowered).map(_._2)
+  }
 }
 
 case class BaklavaResponseContextSerializable(

--- a/openapi/src/main/scala/pl/iterators/baklava/openapi/BaklavaDslFormatterOpenAPIWorker.scala
+++ b/openapi/src/main/scala/pl/iterators/baklava/openapi/BaklavaDslFormatterOpenAPIWorker.scala
@@ -227,7 +227,7 @@ object BaklavaDslFormatterOpenAPIWorker {
             parameter.setExplode(true) // I guess this is default?
             parameter.setSchema(baklavaSchemaToOpenAPISchema(queryParam.schema))
             queryParam.description.foreach(parameter.setDescription)
-            // Example values from captured test inputs are tracked separately in #68.
+            attachParameterExamples(parameter, collectQueryExamples(calls, queryParam.name))
             parameter
           }
           .foreach(operation.addParametersItem)
@@ -242,7 +242,7 @@ object BaklavaDslFormatterOpenAPIWorker {
             parameter.setRequired(true)
             parameter.setSchema(baklavaSchemaToOpenAPISchema(pathParam.schema))
             pathParam.description.foreach(parameter.setDescription)
-            // Example values from captured test inputs are tracked separately in #68.
+            attachParameterExamples(parameter, collectPathExamples(calls, pathParam.name))
             parameter
           }
           .foreach(operation.addParametersItem)
@@ -262,7 +262,7 @@ object BaklavaDslFormatterOpenAPIWorker {
             parameter.setRequired(header.schema.required)
             parameter.setSchema(baklavaSchemaToOpenAPISchema(header.schema))
             header.description.foreach(parameter.setDescription)
-            // Example values from captured test inputs are tracked separately in #68.
+            attachParameterExamples(parameter, collectHeaderExamples(calls, header.name))
             parameter
           }
           .foreach(operation.addParametersItem)
@@ -313,6 +313,54 @@ object BaklavaDslFormatterOpenAPIWorker {
     }
 
     oauthFlows
+  }
+
+  /** Collect `(scenarioName -> exampleValue)` pairs for a named parameter across all calls. The scenario name comes from
+    * `responseDescription` when present; calls without a description are included with an empty scenario name (which
+    * `attachParameterExamples` later fills in with `Example <idx>`). Calls whose example is `None` (no captured value) are skipped.
+    */
+  private def collectQueryExamples(calls: Seq[BaklavaSerializableCall], name: String): Seq[(String, String)] =
+    calls.flatMap { c =>
+      val label    = c.request.responseDescription.getOrElse("")
+      val maybeVal = c.request.queryParametersSeq.find(_.name == name).flatMap(_.example)
+      maybeVal.map(label -> _)
+    }
+
+  private def collectPathExamples(calls: Seq[BaklavaSerializableCall], name: String): Seq[(String, String)] =
+    calls.flatMap { c =>
+      val label    = c.request.responseDescription.getOrElse("")
+      val maybeVal = c.request.pathParametersSeq.find(_.name == name).flatMap(_.example)
+      maybeVal.map(label -> _)
+    }
+
+  private def collectHeaderExamples(calls: Seq[BaklavaSerializableCall], name: String): Seq[(String, String)] =
+    calls.flatMap { c =>
+      val label    = c.request.responseDescription.getOrElse("")
+      val lowered  = name.toLowerCase
+      val maybeVal = c.request.headersSeq.find(_.name.toLowerCase == lowered).flatMap(_.example)
+      maybeVal.map(label -> _)
+    }
+
+  /** Attach example values to an OpenAPI `Parameter`. If all captured values are identical, use the singular `example`. If they differ,
+    * emit a named `examples` map keyed by scenario name (with disambiguation for duplicate / missing labels). Nothing is emitted when no
+    * examples were captured.
+    */
+  private def attachParameterExamples(
+      parameter: io.swagger.v3.oas.models.parameters.Parameter,
+      examples: Seq[(String, String)]
+  ): Unit = {
+    val distinctValues = examples.map(_._2).distinct
+    if (distinctValues.isEmpty) () // nothing to attach
+    else if (distinctValues.size == 1) {
+      val _ = parameter.example(distinctValues.head)
+    } else {
+      val used = scala.collection.mutable.Set.empty[String]
+      examples.zipWithIndex.foreach { case ((label, value), idx) =>
+        val baseKey  = if (label.isEmpty) s"Example $idx" else label
+        val finalKey = disambiguateKey(baseKey, used)
+        val _        = parameter.addExample(finalKey, new io.swagger.v3.oas.models.examples.Example().value(value))
+      }
+    }
   }
 
   private def disambiguateKey(baseKey: String, used: scala.collection.mutable.Set[String]): String = {

--- a/openapi/src/main/scala/pl/iterators/baklava/openapi/BaklavaDslFormatterOpenAPIWorker.scala
+++ b/openapi/src/main/scala/pl/iterators/baklava/openapi/BaklavaDslFormatterOpenAPIWorker.scala
@@ -238,7 +238,8 @@ object BaklavaDslFormatterOpenAPIWorker {
             val parameter = new io.swagger.v3.oas.models.parameters.Parameter()
             parameter.setName(pathParam.name)
             parameter.setIn("path")
-            parameter.setRequired(pathParam.schema.required)
+            // Path params must always be `required: true` per OAS 3.x.
+            parameter.setRequired(true)
             parameter.setSchema(baklavaSchemaToOpenAPISchema(pathParam.schema))
             pathParam.description.foreach(parameter.setDescription)
             // Example values from captured test inputs are tracked separately in #68.
@@ -248,9 +249,11 @@ object BaklavaDslFormatterOpenAPIWorker {
 
         val mergedHeaders = calls
           .flatMap(_.request.headersSeq)
-          .distinctBy(_.name.toLowerCase)
-          .filter(h => h.name.toLowerCase != "content-type" && h.name.toLowerCase != "accept" && h.name.toLowerCase != "authorization")
-          .sortBy(_.name.toLowerCase)
+          .map(h => (h, h.name.toLowerCase(java.util.Locale.ROOT)))
+          .distinctBy(_._2)
+          .filterNot { case (_, lowered) => lowered == "content-type" || lowered == "accept" || lowered == "authorization" }
+          .sortBy(_._2)
+          .map(_._1)
         mergedHeaders
           .map { header =>
             val parameter = new io.swagger.v3.oas.models.parameters.Parameter()

--- a/openapi/src/main/scala/pl/iterators/baklava/openapi/BaklavaDslFormatterOpenAPIWorker.scala
+++ b/openapi/src/main/scala/pl/iterators/baklava/openapi/BaklavaDslFormatterOpenAPIWorker.scala
@@ -215,7 +215,10 @@ object BaklavaDslFormatterOpenAPIWorker {
           else securityRequirements
         operation.setSecurity(finalSecurityRequirements.asJava)
 
-        calls.head.request.queryParametersSeq
+        // Merge parameter declarations across every call in the operation so variants with different
+        // query/path/header sets all contribute. Previously only calls.head's parameters survived.
+        val mergedQueryParams = calls.flatMap(_.request.queryParametersSeq).distinctBy(_.name).sortBy(_.name)
+        mergedQueryParams
           .map { queryParam =>
             val parameter = new io.swagger.v3.oas.models.parameters.Parameter()
             parameter.setName(queryParam.name)
@@ -224,12 +227,13 @@ object BaklavaDslFormatterOpenAPIWorker {
             parameter.setExplode(true) // I guess this is default?
             parameter.setSchema(baklavaSchemaToOpenAPISchema(queryParam.schema))
             queryParam.description.foreach(parameter.setDescription)
-            // TODO: we could add example best on provided in test case :shrug:
+            // Example values from captured test inputs are tracked separately in #68.
             parameter
           }
           .foreach(operation.addParametersItem)
 
-        calls.head.request.pathParametersSeq
+        val mergedPathParams = calls.flatMap(_.request.pathParametersSeq).distinctBy(_.name).sortBy(_.name)
+        mergedPathParams
           .map { pathParam =>
             val parameter = new io.swagger.v3.oas.models.parameters.Parameter()
             parameter.setName(pathParam.name)
@@ -237,13 +241,17 @@ object BaklavaDslFormatterOpenAPIWorker {
             parameter.setRequired(pathParam.schema.required)
             parameter.setSchema(baklavaSchemaToOpenAPISchema(pathParam.schema))
             pathParam.description.foreach(parameter.setDescription)
-            // TODO: we could add example best on provided in test case :shrug:
+            // Example values from captured test inputs are tracked separately in #68.
             parameter
           }
           .foreach(operation.addParametersItem)
 
-        calls.head.request.headersSeq
+        val mergedHeaders = calls
+          .flatMap(_.request.headersSeq)
+          .distinctBy(_.name.toLowerCase)
           .filter(h => h.name.toLowerCase != "content-type" && h.name.toLowerCase != "accept" && h.name.toLowerCase != "authorization")
+          .sortBy(_.name.toLowerCase)
+        mergedHeaders
           .map { header =>
             val parameter = new io.swagger.v3.oas.models.parameters.Parameter()
             parameter.setName(header.name)
@@ -251,7 +259,7 @@ object BaklavaDslFormatterOpenAPIWorker {
             parameter.setRequired(header.schema.required)
             parameter.setSchema(baklavaSchemaToOpenAPISchema(header.schema))
             header.description.foreach(parameter.setDescription)
-            // TODO: we could add example best on provided in test case :shrug:
+            // Example values from captured test inputs are tracked separately in #68.
             parameter
           }
           .foreach(operation.addParametersItem)

--- a/openapi/src/test/resources/gold/openapi/openapi.yml
+++ b/openapi/src/test/resources/gold/openapi/openapi.yml
@@ -214,6 +214,11 @@ paths:
           - active
           - archived
           - draft
+        examples:
+          All active projects:
+            value: active
+          All archived projects:
+            value: archived
       responses:
         "200":
           description: All active projects / All archived projects
@@ -409,6 +414,7 @@ paths:
         schema:
           type: integer
           format: int64
+        example: "42"
       requestBody:
         content:
           application/json:
@@ -501,6 +507,7 @@ paths:
         schema:
           type: integer
           format: int64
+        example: "42"
       responses:
         "200":
           description: All tasks in the project
@@ -570,6 +577,7 @@ paths:
         schema:
           type: integer
           format: int64
+        example: "42"
       requestBody:
         content:
           application/json:
@@ -660,14 +668,6 @@ paths:
       description: List users with pagination and optional role filter
       operationId: listUsers
       parameters:
-      - name: page
-        in: query
-        description: Page number (1-indexed)
-        required: false
-        explode: true
-        schema:
-          type: integer
-          format: int32
       - name: limit
         in: query
         description: Items per page (max 100)
@@ -676,6 +676,16 @@ paths:
         schema:
           type: integer
           format: int32
+        example: "20"
+      - name: page
+        in: query
+        description: Page number (1-indexed)
+        required: false
+        explode: true
+        schema:
+          type: integer
+          format: int32
+        example: "1"
       - name: role
         in: query
         description: Filter by role
@@ -688,6 +698,7 @@ paths:
           - admin
           - member
           - guest
+        example: admin
       responses:
         "200":
           description: First page of users
@@ -785,6 +796,11 @@ paths:
         schema:
           type: string
           format: uuid
+        examples:
+          User found:
+            value: 00000000-0000-0000-0000-000000000001
+          User not found:
+            value: 00000000-0000-0000-0000-0000000000ff
       responses:
         "200":
           description: User found
@@ -865,6 +881,7 @@ paths:
         schema:
           type: string
           format: uuid
+        example: 00000000-0000-0000-0000-000000000001
       requestBody:
         content:
           application/json:
@@ -944,6 +961,7 @@ paths:
         schema:
           type: string
           format: uuid
+        example: 00000000-0000-0000-0000-000000000002
       responses:
         "204":
           description: User deleted

--- a/openapi/src/test/resources/gold/simple/DELETE__users___userId__-cf0347bd.html
+++ b/openapi/src/test/resources/gold/simple/DELETE__users___userId__-cf0347bd.html
@@ -25,11 +25,13 @@
   .status-badge { display: inline-block; padding: 2px 8px; border-radius: 4px; font-weight: 600; font-size: 0.8rem; color: #fff; }
   .status-2xx { background: #198754; } .status-3xx { background: #0dcaf0; color: #000; } .status-4xx { background: #fd7e14; } .status-5xx { background: #dc3545; }
   .back-link { display: inline-block; margin-bottom: 16px; font-size: 0.85rem; }
+  ul.examples { list-style: none; padding: 0; margin: 4px 0 0; font-size: 0.85rem; }
+  ul.examples li { padding: 2px 0; }
 </style></head><body>
 <a href="index.html" class="back-link">&larr; Back to index</a>
 <h1><span class="method method-DELETE">DELETE</span> <span class="path">/users/{userId}</span></h1>
 <div class="card"><div class="card-header">Overview</div><div class="card-body"><dl class="meta-grid"><dt>Summary</dt><dd>Delete user</dd><dt>Description</dt><dd>Delete a user</dd><dt>Operation ID</dt><dd><code>deleteUser</code></dd><dt>Tags</dt><dd><span class="tag">Users</span></dd></dl></div></div>
 <div class="card"><div class="card-header">Security</div><div class="card-body"><p>bearerAuth <span class="tag">http</span></p></div></div>
-<div class="card"><div class="card-header">Path Parameters</div><div class="card-body"><dl class="meta-grid"><dt>userId <span class="required">*</span></dt><dd><code>UUID</code></dd></dl></div></div>
+<div class="card"><div class="card-header">Path Parameters</div><div class="card-body"><dl class="meta-grid"><dt>userId <span class="required">*</span></dt><dd><code>UUID</code> = <code>00000000-0000-0000-0000-000000000002</code></dd></dl></div></div>
 <div class="card"><div class="card-header"><span class="status-badge status-2xx">204</span> Response</div><div class="card-body"><p>User deleted</p></div></div>
 </body></html>

--- a/openapi/src/test/resources/gold/simple/GET__health-334cfc61.html
+++ b/openapi/src/test/resources/gold/simple/GET__health-334cfc61.html
@@ -25,6 +25,8 @@
   .status-badge { display: inline-block; padding: 2px 8px; border-radius: 4px; font-weight: 600; font-size: 0.8rem; color: #fff; }
   .status-2xx { background: #198754; } .status-3xx { background: #0dcaf0; color: #000; } .status-4xx { background: #fd7e14; } .status-5xx { background: #dc3545; }
   .back-link { display: inline-block; margin-bottom: 16px; font-size: 0.85rem; }
+  ul.examples { list-style: none; padding: 0; margin: 4px 0 0; font-size: 0.85rem; }
+  ul.examples li { padding: 2px 0; }
 </style></head><body>
 <a href="index.html" class="back-link">&larr; Back to index</a>
 <h1><span class="method method-GET">GET</span> <span class="path">/health</span></h1>

--- a/openapi/src/test/resources/gold/simple/GET__me-2647d21d.html
+++ b/openapi/src/test/resources/gold/simple/GET__me-2647d21d.html
@@ -25,6 +25,8 @@
   .status-badge { display: inline-block; padding: 2px 8px; border-radius: 4px; font-weight: 600; font-size: 0.8rem; color: #fff; }
   .status-2xx { background: #198754; } .status-3xx { background: #0dcaf0; color: #000; } .status-4xx { background: #fd7e14; } .status-5xx { background: #dc3545; }
   .back-link { display: inline-block; margin-bottom: 16px; font-size: 0.85rem; }
+  ul.examples { list-style: none; padding: 0; margin: 4px 0 0; font-size: 0.85rem; }
+  ul.examples li { padding: 2px 0; }
 </style></head><body>
 <a href="index.html" class="back-link">&larr; Back to index</a>
 <h1><span class="method method-GET">GET</span> <span class="path">/me</span></h1>

--- a/openapi/src/test/resources/gold/simple/GET__projects-9a7aa53f.html
+++ b/openapi/src/test/resources/gold/simple/GET__projects-9a7aa53f.html
@@ -25,12 +25,14 @@
   .status-badge { display: inline-block; padding: 2px 8px; border-radius: 4px; font-weight: 600; font-size: 0.8rem; color: #fff; }
   .status-2xx { background: #198754; } .status-3xx { background: #0dcaf0; color: #000; } .status-4xx { background: #fd7e14; } .status-5xx { background: #dc3545; }
   .back-link { display: inline-block; margin-bottom: 16px; font-size: 0.85rem; }
+  ul.examples { list-style: none; padding: 0; margin: 4px 0 0; font-size: 0.85rem; }
+  ul.examples li { padding: 2px 0; }
 </style></head><body>
 <a href="index.html" class="back-link">&larr; Back to index</a>
 <h1><span class="method method-GET">GET</span> <span class="path">/projects</span></h1>
 <div class="card"><div class="card-header">Overview</div><div class="card-body"><dl class="meta-grid"><dt>Summary</dt><dd>List projects</dd><dt>Description</dt><dd>List projects, optionally filtered by status</dd><dt>Operation ID</dt><dd><code>listProjects</code></dd><dt>Tags</dt><dd><span class="tag">Projects</span></dd></dl></div></div>
 <div class="card"><div class="card-header">Security</div><div class="card-body"><p>oauth2 <span class="tag">oauth2</span></p></div></div>
-<div class="card"><div class="card-header">Query Parameters</div><div class="card-body"><dl class="meta-grid"><dt>status</dt><dd><code>ProjectStatus</code> <span class="tag">active | archived | draft</span></dd></dl></div></div>
+<div class="card"><div class="card-header">Query Parameters</div><div class="card-body"><dl class="meta-grid"><dt>status</dt><dd><code>ProjectStatus</code> <span class="tag">active | archived | draft</span><ul class="examples"><li><em>All active projects:</em> <code>active</code></li><li><em>All archived projects:</em> <code>archived</code></li></ul></dd></dl></div></div>
 <div class="card"><div class="card-header"><span class="status-badge status-2xx">200</span> Response</div><div class="card-body"><p>All active projects</p><h4>Response body</h4><pre>[
   {
     "id" : 42,

--- a/openapi/src/test/resources/gold/simple/GET__projects___projectId___tasks-b0b82093.html
+++ b/openapi/src/test/resources/gold/simple/GET__projects___projectId___tasks-b0b82093.html
@@ -25,12 +25,14 @@
   .status-badge { display: inline-block; padding: 2px 8px; border-radius: 4px; font-weight: 600; font-size: 0.8rem; color: #fff; }
   .status-2xx { background: #198754; } .status-3xx { background: #0dcaf0; color: #000; } .status-4xx { background: #fd7e14; } .status-5xx { background: #dc3545; }
   .back-link { display: inline-block; margin-bottom: 16px; font-size: 0.85rem; }
+  ul.examples { list-style: none; padding: 0; margin: 4px 0 0; font-size: 0.85rem; }
+  ul.examples li { padding: 2px 0; }
 </style></head><body>
 <a href="index.html" class="back-link">&larr; Back to index</a>
 <h1><span class="method method-GET">GET</span> <span class="path">/projects/{projectId}/tasks</span></h1>
 <div class="card"><div class="card-header">Overview</div><div class="card-body"><dl class="meta-grid"><dt>Summary</dt><dd>List tasks</dd><dt>Description</dt><dd>List all tasks in a project</dd><dt>Operation ID</dt><dd><code>listTasks</code></dd><dt>Tags</dt><dd><span class="tag">Tasks</span></dd></dl></div></div>
 <div class="card"><div class="card-header">Security</div><div class="card-body"><p>oauth2 <span class="tag">oauth2</span></p></div></div>
-<div class="card"><div class="card-header">Path Parameters</div><div class="card-body"><dl class="meta-grid"><dt>projectId <span class="required">*</span></dt><dd><code>Long</code></dd></dl></div></div>
+<div class="card"><div class="card-header">Path Parameters</div><div class="card-body"><dl class="meta-grid"><dt>projectId <span class="required">*</span></dt><dd><code>Long</code> = <code>42</code></dd></dl></div></div>
 <div class="card"><div class="card-header"><span class="status-badge status-2xx">200</span> Response</div><div class="card-body"><p>All tasks in the project</p><h4>Response body</h4><pre>[
   {
     "id" : 101,

--- a/openapi/src/test/resources/gold/simple/GET__users-c054bf63.html
+++ b/openapi/src/test/resources/gold/simple/GET__users-c054bf63.html
@@ -25,12 +25,14 @@
   .status-badge { display: inline-block; padding: 2px 8px; border-radius: 4px; font-weight: 600; font-size: 0.8rem; color: #fff; }
   .status-2xx { background: #198754; } .status-3xx { background: #0dcaf0; color: #000; } .status-4xx { background: #fd7e14; } .status-5xx { background: #dc3545; }
   .back-link { display: inline-block; margin-bottom: 16px; font-size: 0.85rem; }
+  ul.examples { list-style: none; padding: 0; margin: 4px 0 0; font-size: 0.85rem; }
+  ul.examples li { padding: 2px 0; }
 </style></head><body>
 <a href="index.html" class="back-link">&larr; Back to index</a>
 <h1><span class="method method-GET">GET</span> <span class="path">/users</span></h1>
 <div class="card"><div class="card-header">Overview</div><div class="card-body"><dl class="meta-grid"><dt>Summary</dt><dd>List users</dd><dt>Description</dt><dd>List users with pagination and optional role filter</dd><dt>Operation ID</dt><dd><code>listUsers</code></dd><dt>Tags</dt><dd><span class="tag">Users</span></dd></dl></div></div>
 <div class="card"><div class="card-header">Security</div><div class="card-body"><p>bearerAuth <span class="tag">http</span></p></div></div>
-<div class="card"><div class="card-header">Query Parameters</div><div class="card-body"><dl class="meta-grid"><dt>page</dt><dd><code>Int</code></dd><dt>limit</dt><dd><code>Int</code></dd><dt>role</dt><dd><code>Role</code> <span class="tag">admin | guest | member</span></dd></dl></div></div>
+<div class="card"><div class="card-header">Query Parameters</div><div class="card-body"><dl class="meta-grid"><dt>page</dt><dd><code>Int</code> = <code>1</code></dd><dt>limit</dt><dd><code>Int</code> = <code>20</code></dd><dt>role</dt><dd><code>Role</code> <span class="tag">admin | guest | member</span> = <code>admin</code></dd></dl></div></div>
 <div class="card"><div class="card-header"><span class="status-badge status-2xx">200</span> Response</div><div class="card-body"><p>First page of users</p><h4>Response headers</h4><dl class="meta-grid"><dt>X-Rate-Limit-Remaining <span class="required">*</span></dt><dd><code>Int</code> = <code>59</code></dd></dl><h4>Response body</h4><pre>{
   "users" : [
     {

--- a/openapi/src/test/resources/gold/simple/GET__users___userId__-baf46b48.html
+++ b/openapi/src/test/resources/gold/simple/GET__users___userId__-baf46b48.html
@@ -25,12 +25,14 @@
   .status-badge { display: inline-block; padding: 2px 8px; border-radius: 4px; font-weight: 600; font-size: 0.8rem; color: #fff; }
   .status-2xx { background: #198754; } .status-3xx { background: #0dcaf0; color: #000; } .status-4xx { background: #fd7e14; } .status-5xx { background: #dc3545; }
   .back-link { display: inline-block; margin-bottom: 16px; font-size: 0.85rem; }
+  ul.examples { list-style: none; padding: 0; margin: 4px 0 0; font-size: 0.85rem; }
+  ul.examples li { padding: 2px 0; }
 </style></head><body>
 <a href="index.html" class="back-link">&larr; Back to index</a>
 <h1><span class="method method-GET">GET</span> <span class="path">/users/{userId}</span></h1>
 <div class="card"><div class="card-header">Overview</div><div class="card-body"><dl class="meta-grid"><dt>Summary</dt><dd>Get user</dd><dt>Description</dt><dd>Fetch a single user by UUID</dd><dt>Operation ID</dt><dd><code>getUser</code></dd><dt>Tags</dt><dd><span class="tag">Users</span></dd></dl></div></div>
 <div class="card"><div class="card-header">Security</div><div class="card-body"><p>bearerAuth <span class="tag">http</span></p></div></div>
-<div class="card"><div class="card-header">Path Parameters</div><div class="card-body"><dl class="meta-grid"><dt>userId <span class="required">*</span></dt><dd><code>UUID</code></dd></dl></div></div>
+<div class="card"><div class="card-header">Path Parameters</div><div class="card-body"><dl class="meta-grid"><dt>userId <span class="required">*</span></dt><dd><code>UUID</code><ul class="examples"><li><em>User found:</em> <code>00000000-0000-0000-0000-000000000001</code></li><li><em>User not found:</em> <code>00000000-0000-0000-0000-0000000000ff</code></li></ul></dd></dl></div></div>
 <div class="card"><div class="card-header"><span class="status-badge status-2xx">200</span> Response</div><div class="card-body"><p>User found</p><h4>Response body</h4><pre>{
   "id" : "00000000-0000-0000-0000-000000000001",
   "email" : "alice@example.com",

--- a/openapi/src/test/resources/gold/simple/PATCH__projects___projectId__-fc9e4246.html
+++ b/openapi/src/test/resources/gold/simple/PATCH__projects___projectId__-fc9e4246.html
@@ -25,12 +25,14 @@
   .status-badge { display: inline-block; padding: 2px 8px; border-radius: 4px; font-weight: 600; font-size: 0.8rem; color: #fff; }
   .status-2xx { background: #198754; } .status-3xx { background: #0dcaf0; color: #000; } .status-4xx { background: #fd7e14; } .status-5xx { background: #dc3545; }
   .back-link { display: inline-block; margin-bottom: 16px; font-size: 0.85rem; }
+  ul.examples { list-style: none; padding: 0; margin: 4px 0 0; font-size: 0.85rem; }
+  ul.examples li { padding: 2px 0; }
 </style></head><body>
 <a href="index.html" class="back-link">&larr; Back to index</a>
 <h1><span class="method method-PATCH">PATCH</span> <span class="path">/projects/{projectId}</span></h1>
 <div class="card"><div class="card-header">Overview</div><div class="card-body"><dl class="meta-grid"><dt>Summary</dt><dd>Patch project</dd><dt>Description</dt><dd>Partially update a project</dd><dt>Operation ID</dt><dd><code>patchProject</code></dd><dt>Tags</dt><dd><span class="tag">Projects</span></dd></dl></div></div>
 <div class="card"><div class="card-header">Security</div><div class="card-body"><p>oauth2 <span class="tag">oauth2</span></p></div></div>
-<div class="card"><div class="card-header">Path Parameters</div><div class="card-body"><dl class="meta-grid"><dt>projectId <span class="required">*</span></dt><dd><code>Long</code></dd></dl></div></div>
+<div class="card"><div class="card-header">Path Parameters</div><div class="card-body"><dl class="meta-grid"><dt>projectId <span class="required">*</span></dt><dd><code>Long</code> = <code>42</code></dd></dl></div></div>
 <div class="card"><div class="card-header">Request body</div><div class="card-body"><details><summary>Request schema (JSON Schema v7)</summary><pre>{
   "$schema" : "http://json-schema.org/draft-07/schema#",
   "title" : "PatchProjectRequest",

--- a/openapi/src/test/resources/gold/simple/POST__auth_login-3b67d231.html
+++ b/openapi/src/test/resources/gold/simple/POST__auth_login-3b67d231.html
@@ -25,6 +25,8 @@
   .status-badge { display: inline-block; padding: 2px 8px; border-radius: 4px; font-weight: 600; font-size: 0.8rem; color: #fff; }
   .status-2xx { background: #198754; } .status-3xx { background: #0dcaf0; color: #000; } .status-4xx { background: #fd7e14; } .status-5xx { background: #dc3545; }
   .back-link { display: inline-block; margin-bottom: 16px; font-size: 0.85rem; }
+  ul.examples { list-style: none; padding: 0; margin: 4px 0 0; font-size: 0.85rem; }
+  ul.examples li { padding: 2px 0; }
 </style></head><body>
 <a href="index.html" class="back-link">&larr; Back to index</a>
 <h1><span class="method method-POST">POST</span> <span class="path">/auth/login</span></h1>

--- a/openapi/src/test/resources/gold/simple/POST__projects-0f98e629.html
+++ b/openapi/src/test/resources/gold/simple/POST__projects-0f98e629.html
@@ -25,6 +25,8 @@
   .status-badge { display: inline-block; padding: 2px 8px; border-radius: 4px; font-weight: 600; font-size: 0.8rem; color: #fff; }
   .status-2xx { background: #198754; } .status-3xx { background: #0dcaf0; color: #000; } .status-4xx { background: #fd7e14; } .status-5xx { background: #dc3545; }
   .back-link { display: inline-block; margin-bottom: 16px; font-size: 0.85rem; }
+  ul.examples { list-style: none; padding: 0; margin: 4px 0 0; font-size: 0.85rem; }
+  ul.examples li { padding: 2px 0; }
 </style></head><body>
 <a href="index.html" class="back-link">&larr; Back to index</a>
 <h1><span class="method method-POST">POST</span> <span class="path">/projects</span></h1>

--- a/openapi/src/test/resources/gold/simple/POST__projects___projectId___tasks-f083bafd.html
+++ b/openapi/src/test/resources/gold/simple/POST__projects___projectId___tasks-f083bafd.html
@@ -25,12 +25,14 @@
   .status-badge { display: inline-block; padding: 2px 8px; border-radius: 4px; font-weight: 600; font-size: 0.8rem; color: #fff; }
   .status-2xx { background: #198754; } .status-3xx { background: #0dcaf0; color: #000; } .status-4xx { background: #fd7e14; } .status-5xx { background: #dc3545; }
   .back-link { display: inline-block; margin-bottom: 16px; font-size: 0.85rem; }
+  ul.examples { list-style: none; padding: 0; margin: 4px 0 0; font-size: 0.85rem; }
+  ul.examples li { padding: 2px 0; }
 </style></head><body>
 <a href="index.html" class="back-link">&larr; Back to index</a>
 <h1><span class="method method-POST">POST</span> <span class="path">/projects/{projectId}/tasks</span></h1>
 <div class="card"><div class="card-header">Overview</div><div class="card-body"><dl class="meta-grid"><dt>Summary</dt><dd>Create task</dd><dt>Description</dt><dd>Create a task in a project</dd><dt>Operation ID</dt><dd><code>createTask</code></dd><dt>Tags</dt><dd><span class="tag">Tasks</span></dd></dl></div></div>
 <div class="card"><div class="card-header">Security</div><div class="card-body"><p>oauth2 <span class="tag">oauth2</span></p></div></div>
-<div class="card"><div class="card-header">Path Parameters</div><div class="card-body"><dl class="meta-grid"><dt>projectId <span class="required">*</span></dt><dd><code>Long</code></dd></dl></div></div>
+<div class="card"><div class="card-header">Path Parameters</div><div class="card-body"><dl class="meta-grid"><dt>projectId <span class="required">*</span></dt><dd><code>Long</code> = <code>42</code></dd></dl></div></div>
 <div class="card"><div class="card-header">Request body</div><div class="card-body"><details><summary>Request schema (JSON Schema v7)</summary><pre>{
   "$schema" : "http://json-schema.org/draft-07/schema#",
   "title" : "CreateTaskRequest",

--- a/openapi/src/test/resources/gold/simple/POST__webhooks-20c9a68b.html
+++ b/openapi/src/test/resources/gold/simple/POST__webhooks-20c9a68b.html
@@ -25,6 +25,8 @@
   .status-badge { display: inline-block; padding: 2px 8px; border-radius: 4px; font-weight: 600; font-size: 0.8rem; color: #fff; }
   .status-2xx { background: #198754; } .status-3xx { background: #0dcaf0; color: #000; } .status-4xx { background: #fd7e14; } .status-5xx { background: #dc3545; }
   .back-link { display: inline-block; margin-bottom: 16px; font-size: 0.85rem; }
+  ul.examples { list-style: none; padding: 0; margin: 4px 0 0; font-size: 0.85rem; }
+  ul.examples li { padding: 2px 0; }
 </style></head><body>
 <a href="index.html" class="back-link">&larr; Back to index</a>
 <h1><span class="method method-POST">POST</span> <span class="path">/webhooks</span></h1>

--- a/openapi/src/test/resources/gold/simple/PUT__users___userId__-3f0ffd01.html
+++ b/openapi/src/test/resources/gold/simple/PUT__users___userId__-3f0ffd01.html
@@ -25,12 +25,14 @@
   .status-badge { display: inline-block; padding: 2px 8px; border-radius: 4px; font-weight: 600; font-size: 0.8rem; color: #fff; }
   .status-2xx { background: #198754; } .status-3xx { background: #0dcaf0; color: #000; } .status-4xx { background: #fd7e14; } .status-5xx { background: #dc3545; }
   .back-link { display: inline-block; margin-bottom: 16px; font-size: 0.85rem; }
+  ul.examples { list-style: none; padding: 0; margin: 4px 0 0; font-size: 0.85rem; }
+  ul.examples li { padding: 2px 0; }
 </style></head><body>
 <a href="index.html" class="back-link">&larr; Back to index</a>
 <h1><span class="method method-PUT">PUT</span> <span class="path">/users/{userId}</span></h1>
 <div class="card"><div class="card-header">Overview</div><div class="card-body"><dl class="meta-grid"><dt>Summary</dt><dd>Update user</dd><dt>Description</dt><dd>Replace a user's profile (admin only)</dd><dt>Operation ID</dt><dd><code>updateUser</code></dd><dt>Tags</dt><dd><span class="tag">Users</span></dd></dl></div></div>
 <div class="card"><div class="card-header">Security</div><div class="card-body"><p>bearerAuth <span class="tag">http</span></p></div></div>
-<div class="card"><div class="card-header">Path Parameters</div><div class="card-body"><dl class="meta-grid"><dt>userId <span class="required">*</span></dt><dd><code>UUID</code></dd></dl></div></div>
+<div class="card"><div class="card-header">Path Parameters</div><div class="card-body"><dl class="meta-grid"><dt>userId <span class="required">*</span></dt><dd><code>UUID</code> = <code>00000000-0000-0000-0000-000000000001</code></dd></dl></div></div>
 <div class="card"><div class="card-header">Request body</div><div class="card-body"><details><summary>Request schema (JSON Schema v7)</summary><pre>{
   "$schema" : "http://json-schema.org/draft-07/schema#",
   "title" : "UpdateUserRequest",

--- a/openapi/src/test/resources/gold/simple/index.html
+++ b/openapi/src/test/resources/gold/simple/index.html
@@ -25,6 +25,8 @@
   .status-badge { display: inline-block; padding: 2px 8px; border-radius: 4px; font-weight: 600; font-size: 0.8rem; color: #fff; }
   .status-2xx { background: #198754; } .status-3xx { background: #0dcaf0; color: #000; } .status-4xx { background: #fd7e14; } .status-5xx { background: #dc3545; }
   .back-link { display: inline-block; margin-bottom: 16px; font-size: 0.85rem; }
+  ul.examples { list-style: none; padding: 0; margin: 4px 0 0; font-size: 0.85rem; }
+  ul.examples li { padding: 2px 0; }
 </style></head><body>
 <h1>API Documentation</h1>
 <ul class="endpoint-list">

--- a/openapi/src/test/scala/pl/iterators/baklava/openapi/ParameterExampleSpec.scala
+++ b/openapi/src/test/scala/pl/iterators/baklava/openapi/ParameterExampleSpec.scala
@@ -1,0 +1,315 @@
+package pl.iterators.baklava.openapi
+
+import io.swagger.v3.oas.models.OpenAPI
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
+import pl.iterators.baklava.*
+
+import scala.jdk.CollectionConverters.*
+
+/** Regression suite for #68: query/path/header parameter example values flow from captured test-case inputs into the generated OpenAPI
+  * `parameter.example` / `parameter.examples` fields.
+  */
+class ParameterExampleSpec extends AnyFunSpec with Matchers {
+
+  describe("OpenAPI parameter example emission (regression for #68)") {
+
+    it("emits a singular example for a path parameter when all calls captured the same value") {
+      val call1 = synthCall(
+        symbolicPath = "/items/{id}",
+        resolvedPath = "/items/42",
+        pathParams = Seq(("id", "42"))
+      )
+      val call2 = synthCall(
+        symbolicPath = "/items/{id}",
+        resolvedPath = "/items/42",
+        pathParams = Seq(("id", "42"))
+      )
+
+      val openAPI = new OpenAPI()
+      BaklavaDslFormatterOpenAPIWorker.generateForCalls(openAPI, Seq(call1, call2))
+
+      val idParam = openAPI.getPaths
+        .get("/items/{id}")
+        .getGet
+        .getParameters
+        .asScala
+        .find(p => p.getName == "id" && p.getIn == "path")
+        .getOrElse(fail("id parameter missing"))
+      idParam.getExample shouldBe "42"
+      Option(idParam.getExamples) shouldBe None
+    }
+
+    it("emits named examples (keyed by responseDescription) when calls captured different values") {
+      val call1 = synthCall(
+        symbolicPath = "/items/{id}",
+        resolvedPath = "/items/42",
+        pathParams = Seq(("id", "42")),
+        scenarioName = Some("found")
+      )
+      val call2 = synthCall(
+        symbolicPath = "/items/{id}",
+        resolvedPath = "/items/zzz",
+        pathParams = Seq(("id", "zzz")),
+        scenarioName = Some("not-found")
+      )
+
+      val openAPI = new OpenAPI()
+      BaklavaDslFormatterOpenAPIWorker.generateForCalls(openAPI, Seq(call1, call2))
+
+      val idParam = openAPI.getPaths
+        .get("/items/{id}")
+        .getGet
+        .getParameters
+        .asScala
+        .find(p => p.getName == "id" && p.getIn == "path")
+        .getOrElse(fail("id parameter missing"))
+      Option(idParam.getExample) shouldBe None
+      val examples = idParam.getExamples.asScala
+      examples.keySet should contain theSameElementsAs Set("found", "not-found")
+      examples("found").getValue shouldBe "42"
+      examples("not-found").getValue shouldBe "zzz"
+    }
+
+    it("emits query parameter examples parsed from the resolved URL") {
+      val call1 = synthCall(
+        symbolicPath = "/search",
+        resolvedPath = "/search?q=hello&limit=10",
+        queryParams = Seq(("q", ""), ("limit", ""))
+      )
+
+      val openAPI = new OpenAPI()
+      BaklavaDslFormatterOpenAPIWorker.generateForCalls(openAPI, Seq(call1))
+
+      val params = openAPI.getPaths.get("/search").getGet.getParameters.asScala.filter(_.getIn == "query")
+      params.find(_.getName == "q").get.getExample shouldBe "hello"
+      params.find(_.getName == "limit").get.getExample shouldBe "10"
+    }
+
+    it("emits header parameter examples from the captured headers map (case-insensitive)") {
+      val call = synthCall(
+        symbolicPath = "/h",
+        resolvedPath = "/h",
+        headers = Seq(("X-Request-Id", "req-42")),
+        sentHeaders = Map("x-request-id" -> "req-42")
+      )
+
+      val openAPI = new OpenAPI()
+      BaklavaDslFormatterOpenAPIWorker.generateForCalls(openAPI, Seq(call))
+
+      val headerParam = openAPI.getPaths
+        .get("/h")
+        .getGet
+        .getParameters
+        .asScala
+        .find(p => p.getName == "X-Request-Id" && p.getIn == "header")
+        .getOrElse(fail("header param missing"))
+      headerParam.getExample shouldBe "req-42"
+    }
+
+    it("URL-decodes path parameter values so %20 round-trips to space") {
+      val call = synthCall(
+        symbolicPath = "/users/{name}",
+        resolvedPath = "/users/John%20Doe",
+        pathParams = Seq(("name", "ignored-at-test-level-actual-value-comes-from-URL"))
+      )
+
+      val openAPI = new OpenAPI()
+      BaklavaDslFormatterOpenAPIWorker.generateForCalls(openAPI, Seq(call))
+
+      val nameParam = openAPI.getPaths
+        .get("/users/{name}")
+        .getGet
+        .getParameters
+        .asScala
+        .find(p => p.getName == "name" && p.getIn == "path")
+        .getOrElse(fail("name parameter missing"))
+      nameParam.getExample shouldBe "John Doe"
+    }
+  }
+
+  describe("end-to-end extraction through BaklavaRequestContextSerializable.apply") {
+    // These tests drive the real serializer — no duplicated extraction logic — to catch regressions
+    // in the URL parsing that the synthCall-based tests above can't see.
+
+    it("extracts path and query examples from a real resolved URL") {
+      val ctx = buildRequestContext(
+        symbolicPath = "/users/{id}",
+        resolvedPath = "/users/42?limit=10&offset=20",
+        pathParamNames = Seq("id"),
+        queryParamNames = Seq("limit", "offset")
+      )
+      val serialized = BaklavaRequestContextSerializable(ctx)
+
+      serialized.pathParametersSeq.find(_.name == "id").flatMap(_.example) shouldBe Some("42")
+      serialized.queryParametersSeq.find(_.name == "limit").flatMap(_.example) shouldBe Some("10")
+      serialized.queryParametersSeq.find(_.name == "offset").flatMap(_.example) shouldBe Some("20")
+    }
+
+    it("strips URL fragments before extracting path params (regression for #72 review)") {
+      val ctx = buildRequestContext(
+        symbolicPath = "/users/{id}",
+        resolvedPath = "/users/42#section-3",
+        pathParamNames = Seq("id")
+      )
+      val serialized = BaklavaRequestContextSerializable(ctx)
+
+      serialized.pathParametersSeq.find(_.name == "id").flatMap(_.example) shouldBe Some("42")
+    }
+
+    it("strips URL fragments before extracting query params (regression for #72 review)") {
+      val ctx = buildRequestContext(
+        symbolicPath = "/search",
+        resolvedPath = "/search?q=1#frag",
+        queryParamNames = Seq("q")
+      )
+      val serialized = BaklavaRequestContextSerializable(ctx)
+
+      serialized.queryParametersSeq.find(_.name == "q").flatMap(_.example) shouldBe Some("1")
+    }
+  }
+
+  // PathParam/QueryParam have `ToPathParam`/`ToQueryParam` implicits that live in traits, not
+  // companion objects, so they aren't found by implicit resolution from a non-mixin test. Supply
+  // them explicitly — the actual `unapply` logic is immaterial here, we only need the name to
+  // flow through and the URL parser on the serializer side to do its job.
+  private implicit val stringPathParam: ToPathParam[String] = new ToPathParam[String] {
+    override def apply(s: String): String = s
+  }
+  private implicit val stringQueryParam: ToQueryParam[String] = new ToQueryParam[String] {
+    override def apply(s: String): Seq[String] = Seq(s)
+  }
+
+  private def buildRequestContext(
+      symbolicPath: String,
+      resolvedPath: String,
+      pathParamNames: Seq[String] = Nil,
+      queryParamNames: Seq[String] = Nil
+  ): BaklavaRequestContext[Unit, Unit, Unit, Unit, Unit, Unit, Unit] =
+    BaklavaRequestContext[Unit, Unit, Unit, Unit, Unit, Unit, Unit](
+      symbolicPath = symbolicPath,
+      path = resolvedPath,
+      pathDescription = None,
+      pathSummary = None,
+      method = Some(BaklavaHttpMethod("GET")),
+      operationDescription = None,
+      operationSummary = None,
+      operationId = None,
+      operationTags = Nil,
+      securitySchemes = Nil,
+      body = None,
+      bodySchema = None,
+      headers = BaklavaHttpHeaders(Map.empty),
+      headersDefinition = (),
+      headersProvided = (),
+      headersSeq = Nil,
+      security = AppliedSecurity(NoopSecurity, Map.empty),
+      pathParameters = (),
+      pathParametersProvided = (),
+      pathParametersSeq = pathParamNames.map(n => PathParam[String](n, None)),
+      queryParameters = (),
+      queryParametersProvided = (),
+      queryParametersSeq = queryParamNames.map(n => QueryParam[String](n, None)),
+      responseDescription = None,
+      responseHeaders = Nil
+    )
+
+  private val stringSchema = BaklavaSchemaSerializable(Schema.stringSchema)
+
+  private def synthCall(
+      symbolicPath: String,
+      resolvedPath: String,
+      queryParams: Seq[(String, String)] = Nil,
+      pathParams: Seq[(String, String)] = Nil,
+      headers: Seq[(String, String)] = Nil,
+      sentHeaders: Map[String, String] = Map.empty,
+      scenarioName: Option[String] = None
+  ): BaklavaSerializableCall = {
+    // The test directly constructs BaklavaSerializableCall bypassing the normal extraction path,
+    // so we can exercise the generator-side emission independently. We still manually plug in
+    // example values matching what the real extractor would produce, where relevant.
+    val path  = BaklavaPathParamValues(symbolicPath, resolvedPath)
+    val query = BaklavaQueryParamValues(resolvedPath)
+    BaklavaSerializableCall(
+      request = BaklavaRequestContextSerializable(
+        symbolicPath = symbolicPath,
+        path = resolvedPath,
+        pathDescription = None,
+        pathSummary = None,
+        method = Some(BaklavaHttpMethod("GET")),
+        operationDescription = None,
+        operationSummary = None,
+        operationId = None,
+        operationTags = Nil,
+        securitySchemes = Nil,
+        bodySchema = None,
+        headersSeq = headers.map { case (name, _) =>
+          BaklavaHeaderSerializable(
+            name,
+            None,
+            stringSchema,
+            sentHeaders.find(_._1.toLowerCase == name.toLowerCase).map(_._2)
+          )
+        },
+        pathParametersSeq = pathParams.map { case (name, _) =>
+          BaklavaPathParamSerializable(name, None, stringSchema, path.get(name))
+        },
+        queryParametersSeq = queryParams.map { case (name, _) =>
+          BaklavaQueryParamSerializable(name, None, stringSchema, query.get(name))
+        },
+        responseDescription = scenarioName.orElse(Some("ok")),
+        responseHeaders = Nil
+      ),
+      response = BaklavaResponseContextSerializable(
+        protocol = BaklavaHttpProtocol("HTTP/1.1"),
+        status = BaklavaHttpStatus(200),
+        headers = BaklavaHttpHeaders(sentHeaders),
+        requestBodyString = "",
+        responseBodyString = "",
+        requestContentType = None,
+        responseContentType = None,
+        bodySchema = None
+      )
+    )
+  }
+
+  // Mirror of the private extractors in BaklavaSerialize so the test can construct examples
+  // exactly as the runtime does, without relying on the full serialize round-trip.
+  private object BaklavaPathParamValues {
+    def apply(symbolicPath: String, resolvedPath: String): Map[String, String] = {
+      val pathOnly      = resolvedPath.split('?').headOption.getOrElse(resolvedPath)
+      val templateParts = symbolicPath.split('/')
+      val resolvedParts = pathOnly.split('/')
+      if (templateParts.length != resolvedParts.length) Map.empty
+      else
+        templateParts
+          .zip(resolvedParts)
+          .collect {
+            case (t, r) if t.startsWith("{") && t.endsWith("}") =>
+              t.substring(1, t.length - 1) -> java.net.URLDecoder.decode(r, "UTF-8")
+          }
+          .toMap
+    }
+  }
+
+  private object BaklavaQueryParamValues {
+    def apply(resolvedPath: String): Map[String, String] = {
+      val queryPart = resolvedPath.split('?').drop(1).headOption.getOrElse("")
+      if (queryPart.isEmpty) Map.empty
+      else
+        queryPart
+          .split('&')
+          .filter(_.nonEmpty)
+          .toSeq
+          .map { kv =>
+            val eq = kv.indexOf('=')
+            if (eq < 0) java.net.URLDecoder.decode(kv, "UTF-8")           -> ""
+            else java.net.URLDecoder.decode(kv.substring(0, eq), "UTF-8") -> java.net.URLDecoder.decode(kv.substring(eq + 1), "UTF-8")
+          }
+          .groupBy(_._1)
+          .view
+          .mapValues(_.map(_._2).mkString(","))
+          .toMap
+    }
+  }
+}

--- a/openapi/src/test/scala/pl/iterators/baklava/openapi/ParameterExampleSpec.scala
+++ b/openapi/src/test/scala/pl/iterators/baklava/openapi/ParameterExampleSpec.scala
@@ -4,6 +4,7 @@ import io.swagger.v3.oas.models.OpenAPI
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
 import pl.iterators.baklava.*
+import sttp.model.{Header => SttpHeader, Method, StatusCode}
 
 import scala.jdk.CollectionConverters.*
 
@@ -191,7 +192,7 @@ class ParameterExampleSpec extends AnyFunSpec with Matchers {
       path = resolvedPath,
       pathDescription = None,
       pathSummary = None,
-      method = Some(BaklavaHttpMethod("GET")),
+      method = Some(Method("GET")),
       operationDescription = None,
       operationSummary = None,
       operationId = None,
@@ -199,7 +200,7 @@ class ParameterExampleSpec extends AnyFunSpec with Matchers {
       securitySchemes = Nil,
       body = None,
       bodySchema = None,
-      headers = BaklavaHttpHeaders(Map.empty),
+      headers = Seq.empty[SttpHeader],
       headersDefinition = (),
       headersProvided = (),
       headersSeq = Nil,
@@ -236,7 +237,7 @@ class ParameterExampleSpec extends AnyFunSpec with Matchers {
         path = resolvedPath,
         pathDescription = None,
         pathSummary = None,
-        method = Some(BaklavaHttpMethod("GET")),
+        method = Some(Method("GET")),
         operationDescription = None,
         operationSummary = None,
         operationId = None,
@@ -262,8 +263,8 @@ class ParameterExampleSpec extends AnyFunSpec with Matchers {
       ),
       response = BaklavaResponseContextSerializable(
         protocol = BaklavaHttpProtocol("HTTP/1.1"),
-        status = BaklavaHttpStatus(200),
-        headers = BaklavaHttpHeaders(sentHeaders),
+        status = StatusCode(200),
+        headers = sentHeaders.map { case (k, v) => SttpHeader(k, v) }.toSeq,
         requestBodyString = "",
         responseBodyString = "",
         requestContentType = None,

--- a/openapi/src/test/scala/pl/iterators/baklava/openapi/ParameterMergingSpec.scala
+++ b/openapi/src/test/scala/pl/iterators/baklava/openapi/ParameterMergingSpec.scala
@@ -1,0 +1,107 @@
+package pl.iterators.baklava.openapi
+
+import io.swagger.v3.oas.models.OpenAPI
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
+import pl.iterators.baklava.*
+
+import scala.jdk.CollectionConverters.*
+
+/** Regression suite for #66: parameter declarations from non-head calls used to be silently dropped because the generator read only
+  * `calls.head.request.*Seq`. Now it merges across every call in the (path, method) group.
+  */
+class ParameterMergingSpec extends AnyFunSpec with Matchers {
+
+  describe("OpenAPI parameter merging across multiple supports (regression for #66)") {
+
+    it("merges query parameters from every variant, alphabetically sorted, deduped by name") {
+      val call1 = synthCall(queryParams = Seq("q" -> stringSchema))
+      val call2 = synthCall(queryParams = Seq("limit" -> intSchema, "q" -> stringSchema))
+
+      val openAPI = new OpenAPI()
+      BaklavaDslFormatterOpenAPIWorker.generateForCalls(openAPI, Seq(call1, call2))
+
+      val params = openAPI.getPaths.get("/search").getGet.getParameters.asScala.filter(_.getIn == "query").map(_.getName).toList
+      params shouldBe List("limit", "q")
+    }
+
+    it("merges path parameters from every variant") {
+      val call1 = synthCall(path = "/items/{id}", pathParams = Seq("id" -> stringSchema))
+      val call2 = synthCall(path = "/items/{id}", pathParams = Seq("id" -> stringSchema))
+
+      val openAPI = new OpenAPI()
+      BaklavaDslFormatterOpenAPIWorker.generateForCalls(openAPI, Seq(call1, call2))
+
+      val params = openAPI.getPaths.get("/items/{id}").getGet.getParameters.asScala.filter(_.getIn == "path").map(_.getName).toList
+      params shouldBe List("id")
+    }
+
+    it("merges request headers case-insensitively, excluding Content-Type/Accept/Authorization") {
+      val call1 = synthCall(headers = Seq("X-Request-Id" -> stringSchema))
+      val call2 = synthCall(headers = Seq("x-request-id" -> stringSchema, "X-Custom" -> stringSchema, "Accept" -> stringSchema))
+
+      val openAPI = new OpenAPI()
+      BaklavaDslFormatterOpenAPIWorker.generateForCalls(openAPI, Seq(call1, call2))
+
+      val params = openAPI.getPaths.get("/search").getGet.getParameters.asScala.filter(_.getIn == "header").map(_.getName).toList
+      params should contain("X-Custom")
+      params.count(_.toLowerCase == "x-request-id") shouldBe 1
+      params should not contain "Accept"
+    }
+
+    it("is deterministic regardless of input call order") {
+      val a = synthCall(queryParams = Seq("alpha" -> stringSchema))
+      val b = synthCall(queryParams = Seq("bravo" -> stringSchema))
+      val c = synthCall(queryParams = Seq("charlie" -> stringSchema))
+
+      val outputs = Seq(Seq(a, b, c), Seq(c, a, b), Seq(b, c, a)).map { perm =>
+        val openAPI = new OpenAPI()
+        BaklavaDslFormatterOpenAPIWorker.generateForCalls(openAPI, perm)
+        openAPI.getPaths.get("/search").getGet.getParameters.asScala.filter(_.getIn == "query").map(_.getName).toList
+      }
+
+      outputs.distinct should have size 1
+      outputs.head shouldBe List("alpha", "bravo", "charlie")
+    }
+  }
+
+  private val stringSchema = BaklavaSchemaSerializable(Schema.stringSchema)
+  private val intSchema    = BaklavaSchemaSerializable(Schema.intSchema)
+
+  private def synthCall(
+      path: String = "/search",
+      queryParams: Seq[(String, BaklavaSchemaSerializable)] = Nil,
+      pathParams: Seq[(String, BaklavaSchemaSerializable)] = Nil,
+      headers: Seq[(String, BaklavaSchemaSerializable)] = Nil
+  ): BaklavaSerializableCall =
+    BaklavaSerializableCall(
+      request = BaklavaRequestContextSerializable(
+        symbolicPath = path,
+        path = path,
+        pathDescription = None,
+        pathSummary = None,
+        method = Some(BaklavaHttpMethod("GET")),
+        operationDescription = None,
+        operationSummary = None,
+        operationId = None,
+        operationTags = Nil,
+        securitySchemes = Nil,
+        bodySchema = None,
+        headersSeq = headers.map { case (name, schema) => BaklavaHeaderSerializable(name, None, schema) },
+        pathParametersSeq = pathParams.map { case (name, schema) => BaklavaPathParamSerializable(name, None, schema) },
+        queryParametersSeq = queryParams.map { case (name, schema) => BaklavaQueryParamSerializable(name, None, schema) },
+        responseDescription = Some("ok"),
+        responseHeaders = Nil
+      ),
+      response = BaklavaResponseContextSerializable(
+        protocol = BaklavaHttpProtocol("HTTP/1.1"),
+        status = BaklavaHttpStatus(200),
+        headers = BaklavaHttpHeaders(Map.empty),
+        requestBodyString = "",
+        responseBodyString = "",
+        requestContentType = None,
+        responseContentType = None,
+        bodySchema = None
+      )
+    )
+}

--- a/openapi/src/test/scala/pl/iterators/baklava/openapi/ParameterMergingSpec.scala
+++ b/openapi/src/test/scala/pl/iterators/baklava/openapi/ParameterMergingSpec.scala
@@ -4,6 +4,7 @@ import io.swagger.v3.oas.models.OpenAPI
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
 import pl.iterators.baklava.*
+import sttp.model.{Method, StatusCode}
 
 import scala.jdk.CollectionConverters.*
 
@@ -102,7 +103,7 @@ class ParameterMergingSpec extends AnyFunSpec with Matchers {
         path = path,
         pathDescription = None,
         pathSummary = None,
-        method = Some(BaklavaHttpMethod("GET")),
+        method = Some(Method("GET")),
         operationDescription = None,
         operationSummary = None,
         operationId = None,
@@ -117,8 +118,8 @@ class ParameterMergingSpec extends AnyFunSpec with Matchers {
       ),
       response = BaklavaResponseContextSerializable(
         protocol = BaklavaHttpProtocol("HTTP/1.1"),
-        status = BaklavaHttpStatus(200),
-        headers = BaklavaHttpHeaders(Map.empty),
+        status = StatusCode(200),
+        headers = Seq.empty,
         requestBodyString = "",
         responseBodyString = "",
         requestContentType = None,

--- a/openapi/src/test/scala/pl/iterators/baklava/openapi/ParameterMergingSpec.scala
+++ b/openapi/src/test/scala/pl/iterators/baklava/openapi/ParameterMergingSpec.scala
@@ -38,7 +38,15 @@ class ParameterMergingSpec extends AnyFunSpec with Matchers {
 
     it("merges request headers case-insensitively, excluding Content-Type/Accept/Authorization") {
       val call1 = synthCall(headers = Seq("X-Request-Id" -> stringSchema))
-      val call2 = synthCall(headers = Seq("x-request-id" -> stringSchema, "X-Custom" -> stringSchema, "Accept" -> stringSchema))
+      val call2 = synthCall(headers =
+        Seq(
+          "x-request-id"  -> stringSchema,
+          "X-Custom"      -> stringSchema,
+          "Accept"        -> stringSchema,
+          "Content-Type"  -> stringSchema,
+          "Authorization" -> stringSchema
+        )
+      )
 
       val openAPI = new OpenAPI()
       BaklavaDslFormatterOpenAPIWorker.generateForCalls(openAPI, Seq(call1, call2))
@@ -46,7 +54,21 @@ class ParameterMergingSpec extends AnyFunSpec with Matchers {
       val params = openAPI.getPaths.get("/search").getGet.getParameters.asScala.filter(_.getIn == "header").map(_.getName).toList
       params should contain("X-Custom")
       params.count(_.toLowerCase == "x-request-id") shouldBe 1
-      params should not contain "Accept"
+      params.map(_.toLowerCase) should not contain "accept"
+      params.map(_.toLowerCase) should not contain "content-type"
+      params.map(_.toLowerCase) should not contain "authorization"
+    }
+
+    it("marks path parameters as required: true even when their schema is optional (OAS 3.x)") {
+      val optionalPathParamSchema = stringSchema.copy(required = false)
+      val call                    = synthCall(path = "/items/{id}", pathParams = Seq("id" -> optionalPathParamSchema))
+
+      val openAPI = new OpenAPI()
+      BaklavaDslFormatterOpenAPIWorker.generateForCalls(openAPI, Seq(call))
+
+      val pathParam =
+        openAPI.getPaths.get("/items/{id}").getGet.getParameters.asScala.find(p => p.getIn == "path" && p.getName == "id").get
+      pathParam.getRequired shouldBe true
     }
 
     it("is deterministic regardless of input call order") {

--- a/simple/src/main/scala/pl/iterators/baklava/simple/BaklavaDslFormatterSimple.scala
+++ b/simple/src/main/scala/pl/iterators/baklava/simple/BaklavaDslFormatterSimple.scala
@@ -42,6 +42,8 @@ class BaklavaDslFormatterSimple extends BaklavaDslFormatter {
       |  .status-badge { display: inline-block; padding: 2px 8px; border-radius: 4px; font-weight: 600; font-size: 0.8rem; color: #fff; }
       |  .status-2xx { background: #198754; } .status-3xx { background: #0dcaf0; color: #000; } .status-4xx { background: #fd7e14; } .status-5xx { background: #dc3545; }
       |  .back-link { display: inline-block; margin-bottom: 16px; font-size: 0.85rem; }
+      |  ul.examples { list-style: none; padding: 0; margin: 4px 0 0; font-size: 0.85rem; }
+      |  ul.examples li { padding: 2px 0; }
       |</style>""".stripMargin
 
   override def create(config: Map[String, String], calls: Seq[BaklavaSerializableCall]): Unit = {
@@ -97,24 +99,40 @@ class BaklavaDslFormatterSimple extends BaklavaDslFormatter {
       )
     }
 
+    // Collect captured `(scenarioName, exampleValue)` pairs for each named parameter across every
+    // call, so when values differ between scenarios we can show the reader all of them inline (the
+    // OpenAPI generator already does the same for `parameter.examples`).
+    def collectExamples(extract: BaklavaRequestContextSerializable => Seq[(String, Option[String])]): Map[String, Seq[(String, String)]] =
+      calls
+        .flatMap { c =>
+          val label = c.request.responseDescription.getOrElse("")
+          extract(c.request).collect { case (name, Some(value)) => name -> (label -> value) }
+        }
+        .groupMap(_._1)(_._2)
+
+    val headerExamples = collectExamples(r => r.headersSeq.map(h => h.name -> h.example))
+    val pathExamples   = collectExamples(r => r.pathParametersSeq.map(p => p.name -> p.example))
+    val queryExamples  = collectExamples(r => r.queryParametersSeq.map(p => p.name -> p.example))
+
     val headersSection = Option.when(request.headersSeq.nonEmpty) {
       card(
         "Headers",
-        s"<dl class=\"meta-grid\">${request.headersSeq.map { h =>
-            metaRow(
-              escHtml(h.name) + (if (h.schema.required) " <span class=\"required\">*</span>" else ""),
-              s"<code>${escHtml(h.schema.className)}</code>"
-            )
-          }.mkString}</dl>"
+        s"<dl class=\"meta-grid\">${request.headersSeq.map(h => paramRow(h.name, h.schema, headerExamples.getOrElse(h.name, Nil))).mkString}</dl>"
       )
     }
 
     val pathParamsSection = Option.when(request.pathParametersSeq.nonEmpty) {
-      card("Path Parameters", s"<dl class=\"meta-grid\">${request.pathParametersSeq.map(paramRow).mkString}</dl>")
+      card(
+        "Path Parameters",
+        s"<dl class=\"meta-grid\">${request.pathParametersSeq.map(p => paramRow(p.name, p.schema, pathExamples.getOrElse(p.name, Nil))).mkString}</dl>"
+      )
     }
 
     val queryParamsSection = Option.when(request.queryParametersSeq.nonEmpty) {
-      card("Query Parameters", s"<dl class=\"meta-grid\">${request.queryParametersSeq.map(paramRow).mkString}</dl>")
+      card(
+        "Query Parameters",
+        s"<dl class=\"meta-grid\">${request.queryParametersSeq.map(p => paramRow(p.name, p.schema, queryExamples.getOrElse(p.name, Nil))).mkString}</dl>"
+      )
     }
 
     // Shared request-schema block (same for every call on this endpoint).
@@ -183,16 +201,32 @@ class BaklavaDslFormatterSimple extends BaklavaDslFormatter {
   private def metaRow(label: String, value: String): String =
     s"<dt>$label</dt><dd>$value</dd>"
 
-  private def paramRow(name: String, schema: BaklavaSchemaSerializable): String = {
+  /** Render one parameter row.
+    *
+    * `examples` is a list of `(scenarioLabel, exampleValue)` pairs captured across all calls for the named parameter. When all calls
+    * captured the same value we print a single inline `= value`; when they diverge we print a small list so the reader sees each
+    * scenario's value. An empty list produces just the type (no examples captured).
+    */
+  private def paramRow(name: String, schema: BaklavaSchemaSerializable, examples: Seq[(String, String)]): String = {
     val arrayFlag = if (schema.`type` == SchemaType.ArrayType) "[]" else ""
     val req       = if (schema.required) " <span class=\"required\">*</span>" else ""
     val enumInfo  =
       schema.`enum`.map(enums => s""" <span class="tag">${escHtml(enums.toSeq.sorted.mkString(" | "))}</span>""").getOrElse("")
-    metaRow(s"${escHtml(name)}$arrayFlag$req", s"<code>${escHtml(schema.className)}$arrayFlag</code>$enumInfo")
-  }
 
-  private def paramRow(p: BaklavaPathParamSerializable): String  = paramRow(p.name, p.schema)
-  private def paramRow(p: BaklavaQueryParamSerializable): String = paramRow(p.name, p.schema)
+    val distinctValues = examples.map(_._2).distinct
+    val exampleRender  =
+      if (distinctValues.isEmpty) ""
+      else if (distinctValues.size == 1) s" = <code>${escHtml(distinctValues.head)}</code>"
+      else {
+        val rows = examples.zipWithIndex.map { case ((label, value), idx) =>
+          val key = if (label.isEmpty) s"Example ${idx + 1}" else label
+          s"<li><em>${escHtml(key)}:</em> <code>${escHtml(value)}</code></li>"
+        }
+        s"""<ul class="examples">${rows.mkString}</ul>"""
+      }
+
+    metaRow(s"${escHtml(name)}$arrayFlag$req", s"<code>${escHtml(schema.className)}$arrayFlag</code>$enumInfo$exampleRender")
+  }
 
   /** Collision-resistant filename from a (method + path) combination. The slash/space/brace substitutions are lossy, so we append a
     * deterministic 32-bit hex hash of the original input to distinguish otherwise-equivalent names. Common collisions (`/a/b` vs `/a_b`,

--- a/simple/src/test/scala/pl/iterators/baklava/simple/BaklavaDslFormatterSimpleSpec.scala
+++ b/simple/src/test/scala/pl/iterators/baklava/simple/BaklavaDslFormatterSimpleSpec.scala
@@ -55,6 +55,29 @@ class BaklavaDslFormatterSimpleSpec extends AnyFunSpec with Matchers {
       json.downField("properties").downField("b").downField("required").succeeded shouldBe false
     }
 
+    it("renders captured parameter examples inline when calls agree, as a scenario list when they diverge") {
+      val base      = jsonCall(status = 200, desc = "A", requestBody = "", responseBody = "{}")
+      val callWithQ = base.copy(
+        request = base.request.copy(
+          queryParametersSeq = Seq(BaklavaQueryParamSerializable("page", None, stringRequired, Some("1")))
+        )
+      )
+      val singleHtml = generator.generateEndpointPage(Seq(callWithQ))
+      singleHtml should include("<code>String</code> = <code>1</code>")
+      singleHtml should not include """ul class="examples""""
+
+      val callB = callWithQ.copy(
+        request = callWithQ.request.copy(
+          responseDescription = Some("B"),
+          queryParametersSeq = Seq(BaklavaQueryParamSerializable("page", None, stringRequired, Some("2")))
+        )
+      )
+      val multiHtml = generator.generateEndpointPage(Seq(callWithQ, callB))
+      multiHtml should include("""ul class="examples"""")
+      multiHtml should include("<em>A:</em> <code>1</code>")
+      multiHtml should include("<em>B:</em> <code>2</code>")
+    }
+
     it("renders declared response headers with their captured example values (regression for C7)") {
       val base     = jsonCall(status = 200, desc = "ok", requestBody = "", responseBody = "")
       val withHdrs = base.copy(


### PR DESCRIPTION
## Summary

Closes #66. Query, path, and header parameter declarations at the operation level used `calls.head.request.*Seq` — variants with different parameter sets silently lost every declaration but the first call's. Same pattern as #55 (operation metadata) and #63 (response content types), which already got the fix.

## Fix

Gathers parameter declarations across all calls in the (path, method) group:
- **Query params**: `distinctBy(_.name)` (case-sensitive — URL params are case-sensitive), sorted alphabetically.
- **Path params**: same.
- **Headers**: `distinctBy(_.name.toLowerCase)` (HTTP headers are case-insensitive), existing Content-Type/Accept/Authorization filter preserved, sorted by lowercase name.

Also replaces the three `// TODO: we could add example best on provided in test case :shrug:` comments with a pointer to #68 (which tracks that separately).

## Test plan

- [x] 4 new regression scenarios in `ParameterMergingSpec`: query merge + sort, path merge, case-insensitive header dedup + header filter, input-order determinism
- [x] All existing tests pass (64/64 openapi with `CI=true`)
- [x] Consistent with PR #60 / #62 / #65 pattern

Closes #66