### PR TITLE
openapi: emit parameter example values from captured test inputs (#68)

### DIFF
--- a/core/src/main/scala/pl/iterators/baklava/BaklavaSerialize.scala
+++ b/core/src/main/scala/pl/iterators/baklava/BaklavaSerialize.scala
@@ -134,32 +134,41 @@ object BaklavaSchemaSerializable {
 case class BaklavaHeaderSerializable(
     name: String,
     description: Option[String],
-    schema: BaklavaSchemaSerializable
+    schema: BaklavaSchemaSerializable,
+    example: Option[String] = None
 ) extends Serializable
 object BaklavaHeaderSerializable {
   def apply[T](h: Header[T]): BaklavaHeaderSerializable =
     BaklavaHeaderSerializable(h.name, h.description, BaklavaSchemaSerializable(h.schema))
+  def apply[T](h: Header[T], example: Option[String]): BaklavaHeaderSerializable =
+    BaklavaHeaderSerializable(h.name, h.description, BaklavaSchemaSerializable(h.schema), example)
 }
 
 case class BaklavaPathParamSerializable(
     name: String,
     description: Option[String],
-    schema: BaklavaSchemaSerializable
+    schema: BaklavaSchemaSerializable,
+    example: Option[String] = None
 ) extends Serializable
 
 object BaklavaPathParamSerializable {
   def apply[T](h: PathParam[T]): BaklavaPathParamSerializable =
     BaklavaPathParamSerializable(h.name, h.description, BaklavaSchemaSerializable(h.schema))
+  def apply[T](h: PathParam[T], example: Option[String]): BaklavaPathParamSerializable =
+    BaklavaPathParamSerializable(h.name, h.description, BaklavaSchemaSerializable(h.schema), example)
 }
 
 case class BaklavaQueryParamSerializable(
     name: String,
     description: Option[String],
-    schema: BaklavaSchemaSerializable
+    schema: BaklavaSchemaSerializable,
+    example: Option[String] = None
 ) extends Serializable
 object BaklavaQueryParamSerializable {
   def apply[T](h: QueryParam[T]): BaklavaQueryParamSerializable =
     BaklavaQueryParamSerializable(h.name, h.description, BaklavaSchemaSerializable(h.schema))
+  def apply[T](h: QueryParam[T], example: Option[String]): BaklavaQueryParamSerializable =
+    BaklavaQueryParamSerializable(h.name, h.description, BaklavaSchemaSerializable(h.schema), example)
 }
 
 case class BaklavaRequestContextSerializable(
@@ -191,24 +200,82 @@ case class BaklavaRequestContextSerializable(
 ) extends Serializable
 
 object BaklavaRequestContextSerializable {
-  def apply(c: BaklavaRequestContext[_, _, _, _, _, _, _]): BaklavaRequestContextSerializable = BaklavaRequestContextSerializable(
-    symbolicPath = c.symbolicPath,
-    path = c.path,
-    pathDescription = c.pathDescription,
-    pathSummary = c.pathSummary,
-    method = c.method,
-    operationDescription = c.operationDescription,
-    operationSummary = c.operationSummary,
-    operationId = c.operationId,
-    operationTags = c.operationTags,
-    securitySchemes = c.securitySchemes.map(s => BaklavaSecuritySchemaSerializable(s)),
-    bodySchema = c.bodySchema.filter(_ != Schema.emptyBodySchema).map(s => BaklavaSchemaSerializable(s)),
-    headersSeq = c.headersSeq.map(h => BaklavaHeaderSerializable(h)),
-    pathParametersSeq = c.pathParametersSeq.map(p => BaklavaPathParamSerializable(p)),
-    queryParametersSeq = c.queryParametersSeq.map(p => BaklavaQueryParamSerializable(p)),
-    responseDescription = c.responseDescription,
-    responseHeaders = c.responseHeaders.map(h => BaklavaHeaderSerializable(h))
-  )
+  def apply(c: BaklavaRequestContext[_, _, _, _, _, _, _]): BaklavaRequestContextSerializable = {
+    val pathParamValues  = extractPathParamValues(c.symbolicPath, c.path)
+    val queryParamValues = extractQueryParamValues(c.path)
+
+    BaklavaRequestContextSerializable(
+      symbolicPath = c.symbolicPath,
+      path = c.path,
+      pathDescription = c.pathDescription,
+      pathSummary = c.pathSummary,
+      method = c.method,
+      operationDescription = c.operationDescription,
+      operationSummary = c.operationSummary,
+      operationId = c.operationId,
+      operationTags = c.operationTags,
+      securitySchemes = c.securitySchemes.map(s => BaklavaSecuritySchemaSerializable(s)),
+      bodySchema = c.bodySchema.filter(_ != Schema.emptyBodySchema).map(s => BaklavaSchemaSerializable(s)),
+      headersSeq = c.headersSeq.map { h =>
+        BaklavaHeaderSerializable(h, caseInsensitiveHeaderValue(c.headers.headers, h.name))
+      },
+      pathParametersSeq = c.pathParametersSeq.map { p =>
+        BaklavaPathParamSerializable(p, pathParamValues.get(p.name))
+      },
+      queryParametersSeq = c.queryParametersSeq.map { p =>
+        BaklavaQueryParamSerializable(p, queryParamValues.get(p.name))
+      },
+      responseDescription = c.responseDescription,
+      responseHeaders = c.responseHeaders.map(h => BaklavaHeaderSerializable(h))
+    )
+  }
+
+  /** Extract `{name} -> actualValue` from a resolved URL by matching against its symbolic template. Both inputs are split on `/`; the
+    * resolved path is stripped of its query string first. A segment `{name}` in the template maps to whatever appears in the same position
+    * in the resolved path. URL-decoding is applied to the extracted values so `%20` etc. round-trip.
+    */
+  private def extractPathParamValues(symbolicPath: String, resolvedPath: String): Map[String, String] = {
+    val pathOnly      = resolvedPath.split('?').headOption.getOrElse(resolvedPath)
+    val templateParts = symbolicPath.split('/')
+    val resolvedParts = pathOnly.split('/')
+    if (templateParts.length != resolvedParts.length) Map.empty
+    else
+      templateParts
+        .zip(resolvedParts)
+        .collect {
+          case (t, r) if t.startsWith("{") && t.endsWith("}") =>
+            val name = t.substring(1, t.length - 1)
+            name -> java.net.URLDecoder.decode(r, "UTF-8")
+        }
+        .toMap
+  }
+
+  /** Parse a URL query string into `name -> value` pairs. If a key appears multiple times (e.g. `?tag=a&tag=b`), the values are joined
+    * with commas — matching OpenAPI's default explode=true representation reasonably well for a single example value.
+    */
+  private def extractQueryParamValues(resolvedPath: String): Map[String, String] = {
+    val queryPart = resolvedPath.split('?').drop(1).headOption.getOrElse("")
+    if (queryPart.isEmpty) Map.empty
+    else
+      queryPart
+        .split('&')
+        .filter(_.nonEmpty)
+        .toSeq
+        .map { kv =>
+          val eq = kv.indexOf('=')
+          if (eq < 0) java.net.URLDecoder.decode(kv, "UTF-8")           -> ""
+          else java.net.URLDecoder.decode(kv.substring(0, eq), "UTF-8") -> java.net.URLDecoder.decode(kv.substring(eq + 1), "UTF-8")
+        }
+        .groupBy(_._1)
+        .view
+        .mapValues(_.map(_._2).mkString(","))
+        .toMap
+  }
+
+  private def caseInsensitiveHeaderValue(headers: Map[String, String], name: String): Option[String] = {
+    val lowered = name.toLowerCase
+    headers.find(_._1.toLowerCase == lowered).map(_._2)
+  }
 }
 
 case class BaklavaResponseContextSerializable(

--- a/core/src/main/scala/pl/iterators/baklava/BaklavaSerialize.scala
+++ b/core/src/main/scala/pl/iterators/baklava/BaklavaSerialize.scala
@@ -230,12 +230,20 @@ object BaklavaRequestContextSerializable {
     )
   }
 
+  /** Strip any `#fragment` and `?query` from a resolved path, in that order. */
+  private def stripFragmentAndQuery(resolvedPath: String): String =
+    resolvedPath.split('#').headOption.getOrElse(resolvedPath).split('?').headOption.getOrElse("")
+
+  /** Strip any `#fragment` from a resolved path. */
+  private def stripFragment(resolvedPath: String): String =
+    resolvedPath.split('#').headOption.getOrElse(resolvedPath)
+
   /** Extract `{name} -> actualValue` from a resolved URL by matching against its symbolic template. Both inputs are split on `/`; the
-    * resolved path is stripped of its query string first. A segment `{name}` in the template maps to whatever appears in the same position
-    * in the resolved path. URL-decoding is applied to the extracted values so `%20` etc. round-trip.
+    * resolved path is stripped of its fragment and query string first. A segment `{name}` in the template maps to whatever appears in the
+    * same position in the resolved path. URL-decoding is applied to the extracted values so `%20` etc. round-trip.
     */
   private def extractPathParamValues(symbolicPath: String, resolvedPath: String): Map[String, String] = {
-    val pathOnly      = resolvedPath.split('?').headOption.getOrElse(resolvedPath)
+    val pathOnly      = stripFragmentAndQuery(resolvedPath)
     val templateParts = symbolicPath.split('/')
     val resolvedParts = pathOnly.split('/')
     if (templateParts.length != resolvedParts.length) Map.empty
@@ -250,11 +258,12 @@ object BaklavaRequestContextSerializable {
         .toMap
   }
 
-  /** Parse a URL query string into `name -> value` pairs. If a key appears multiple times (e.g. `?tag=a&tag=b`), the values are joined
-    * with commas — matching OpenAPI's default explode=true representation reasonably well for a single example value.
+  /** Parse a URL query string into `name -> value` pairs. The resolved path is stripped of its `#fragment` first so a trailing fragment
+    * doesn't leak into the last query value. If a key appears multiple times (e.g. `?tag=a&tag=b`), the values are joined with commas —
+    * matching OpenAPI's default explode=true representation reasonably well for a single example value.
     */
   private def extractQueryParamValues(resolvedPath: String): Map[String, String] = {
-    val queryPart = resolvedPath.split('?').drop(1).headOption.getOrElse("")
+    val queryPart = stripFragment(resolvedPath).split('?').drop(1).headOption.getOrElse("")
     if (queryPart.isEmpty) Map.empty
     else
       queryPart

--- a/openapi/src/main/scala/pl/iterators/baklava/openapi/BaklavaDslFormatterOpenAPIWorker.scala
+++ b/openapi/src/main/scala/pl/iterators/baklava/openapi/BaklavaDslFormatterOpenAPIWorker.scala
@@ -313,7 +313,8 @@ object BaklavaDslFormatterOpenAPIWorker {
   }
 
   /** Collect `(scenarioName -> exampleValue)` pairs for a named parameter across all calls. The scenario name comes from
-    * `responseDescription`; calls without a description are skipped. Calls whose example is `None` (no captured value) are also skipped.
+    * `responseDescription` when present; calls without a description are included with an empty scenario name (which
+    * `attachParameterExamples` later fills in with `Example <idx>`). Calls whose example is `None` (no captured value) are skipped.
     */
   private def collectQueryExamples(calls: Seq[BaklavaSerializableCall], name: String): Seq[(String, String)] =
     calls.flatMap { c =>

--- a/openapi/src/main/scala/pl/iterators/baklava/openapi/BaklavaDslFormatterOpenAPIWorker.scala
+++ b/openapi/src/main/scala/pl/iterators/baklava/openapi/BaklavaDslFormatterOpenAPIWorker.scala
@@ -227,7 +227,7 @@ object BaklavaDslFormatterOpenAPIWorker {
             parameter.setExplode(true) // I guess this is default?
             parameter.setSchema(baklavaSchemaToOpenAPISchema(queryParam.schema))
             queryParam.description.foreach(parameter.setDescription)
-            // Example values from captured test inputs are tracked separately in #68.
+            attachParameterExamples(parameter, collectQueryExamples(calls, queryParam.name))
             parameter
           }
           .foreach(operation.addParametersItem)
@@ -241,7 +241,7 @@ object BaklavaDslFormatterOpenAPIWorker {
             parameter.setRequired(pathParam.schema.required)
             parameter.setSchema(baklavaSchemaToOpenAPISchema(pathParam.schema))
             pathParam.description.foreach(parameter.setDescription)
-            // Example values from captured test inputs are tracked separately in #68.
+            attachParameterExamples(parameter, collectPathExamples(calls, pathParam.name))
             parameter
           }
           .foreach(operation.addParametersItem)
@@ -259,7 +259,7 @@ object BaklavaDslFormatterOpenAPIWorker {
             parameter.setRequired(header.schema.required)
             parameter.setSchema(baklavaSchemaToOpenAPISchema(header.schema))
             header.description.foreach(parameter.setDescription)
-            // Example values from captured test inputs are tracked separately in #68.
+            attachParameterExamples(parameter, collectHeaderExamples(calls, header.name))
             parameter
           }
           .foreach(operation.addParametersItem)
@@ -310,6 +310,53 @@ object BaklavaDslFormatterOpenAPIWorker {
     }
 
     oauthFlows
+  }
+
+  /** Collect `(scenarioName -> exampleValue)` pairs for a named parameter across all calls. The scenario name comes from
+    * `responseDescription`; calls without a description are skipped. Calls whose example is `None` (no captured value) are also skipped.
+    */
+  private def collectQueryExamples(calls: Seq[BaklavaSerializableCall], name: String): Seq[(String, String)] =
+    calls.flatMap { c =>
+      val label    = c.request.responseDescription.getOrElse("")
+      val maybeVal = c.request.queryParametersSeq.find(_.name == name).flatMap(_.example)
+      maybeVal.map(label -> _)
+    }
+
+  private def collectPathExamples(calls: Seq[BaklavaSerializableCall], name: String): Seq[(String, String)] =
+    calls.flatMap { c =>
+      val label    = c.request.responseDescription.getOrElse("")
+      val maybeVal = c.request.pathParametersSeq.find(_.name == name).flatMap(_.example)
+      maybeVal.map(label -> _)
+    }
+
+  private def collectHeaderExamples(calls: Seq[BaklavaSerializableCall], name: String): Seq[(String, String)] =
+    calls.flatMap { c =>
+      val label    = c.request.responseDescription.getOrElse("")
+      val lowered  = name.toLowerCase
+      val maybeVal = c.request.headersSeq.find(_.name.toLowerCase == lowered).flatMap(_.example)
+      maybeVal.map(label -> _)
+    }
+
+  /** Attach example values to an OpenAPI `Parameter`. If all captured values are identical, use the singular `example`. If they differ,
+    * emit a named `examples` map keyed by scenario name (with disambiguation for duplicate / missing labels). Nothing is emitted when no
+    * examples were captured.
+    */
+  private def attachParameterExamples(
+      parameter: io.swagger.v3.oas.models.parameters.Parameter,
+      examples: Seq[(String, String)]
+  ): Unit = {
+    val distinctValues = examples.map(_._2).distinct
+    if (distinctValues.isEmpty) () // nothing to attach
+    else if (distinctValues.size == 1) {
+      val _ = parameter.example(distinctValues.head)
+    } else {
+      val used = scala.collection.mutable.Set.empty[String]
+      examples.zipWithIndex.foreach { case ((label, value), idx) =>
+        val baseKey  = if (label.isEmpty) s"Example $idx" else label
+        val finalKey = disambiguateKey(baseKey, used)
+        val _        = parameter.addExample(finalKey, new io.swagger.v3.oas.models.examples.Example().value(value))
+      }
+    }
   }
 
   private def disambiguateKey(baseKey: String, used: scala.collection.mutable.Set[String]): String = {

--- a/openapi/src/test/scala/pl/iterators/baklava/openapi/ParameterExampleSpec.scala
+++ b/openapi/src/test/scala/pl/iterators/baklava/openapi/ParameterExampleSpec.scala
@@ -128,6 +128,92 @@ class ParameterExampleSpec extends AnyFunSpec with Matchers {
     }
   }
 
+  describe("end-to-end extraction through BaklavaRequestContextSerializable.apply") {
+    // These tests drive the real serializer — no duplicated extraction logic — to catch regressions
+    // in the URL parsing that the synthCall-based tests above can't see.
+
+    it("extracts path and query examples from a real resolved URL") {
+      val ctx = buildRequestContext(
+        symbolicPath = "/users/{id}",
+        resolvedPath = "/users/42?limit=10&offset=20",
+        pathParamNames = Seq("id"),
+        queryParamNames = Seq("limit", "offset")
+      )
+      val serialized = BaklavaRequestContextSerializable(ctx)
+
+      serialized.pathParametersSeq.find(_.name == "id").flatMap(_.example) shouldBe Some("42")
+      serialized.queryParametersSeq.find(_.name == "limit").flatMap(_.example) shouldBe Some("10")
+      serialized.queryParametersSeq.find(_.name == "offset").flatMap(_.example) shouldBe Some("20")
+    }
+
+    it("strips URL fragments before extracting path params (regression for #72 review)") {
+      val ctx = buildRequestContext(
+        symbolicPath = "/users/{id}",
+        resolvedPath = "/users/42#section-3",
+        pathParamNames = Seq("id")
+      )
+      val serialized = BaklavaRequestContextSerializable(ctx)
+
+      serialized.pathParametersSeq.find(_.name == "id").flatMap(_.example) shouldBe Some("42")
+    }
+
+    it("strips URL fragments before extracting query params (regression for #72 review)") {
+      val ctx = buildRequestContext(
+        symbolicPath = "/search",
+        resolvedPath = "/search?q=1#frag",
+        queryParamNames = Seq("q")
+      )
+      val serialized = BaklavaRequestContextSerializable(ctx)
+
+      serialized.queryParametersSeq.find(_.name == "q").flatMap(_.example) shouldBe Some("1")
+    }
+  }
+
+  // PathParam/QueryParam have `ToPathParam`/`ToQueryParam` implicits that live in traits, not
+  // companion objects, so they aren't found by implicit resolution from a non-mixin test. Supply
+  // them explicitly — the actual `unapply` logic is immaterial here, we only need the name to
+  // flow through and the URL parser on the serializer side to do its job.
+  private implicit val stringPathParam: ToPathParam[String] = new ToPathParam[String] {
+    override def apply(s: String): String = s
+  }
+  private implicit val stringQueryParam: ToQueryParam[String] = new ToQueryParam[String] {
+    override def apply(s: String): Seq[String] = Seq(s)
+  }
+
+  private def buildRequestContext(
+      symbolicPath: String,
+      resolvedPath: String,
+      pathParamNames: Seq[String] = Nil,
+      queryParamNames: Seq[String] = Nil
+  ): BaklavaRequestContext[Unit, Unit, Unit, Unit, Unit, Unit, Unit] =
+    BaklavaRequestContext[Unit, Unit, Unit, Unit, Unit, Unit, Unit](
+      symbolicPath = symbolicPath,
+      path = resolvedPath,
+      pathDescription = None,
+      pathSummary = None,
+      method = Some(BaklavaHttpMethod("GET")),
+      operationDescription = None,
+      operationSummary = None,
+      operationId = None,
+      operationTags = Nil,
+      securitySchemes = Nil,
+      body = None,
+      bodySchema = None,
+      headers = BaklavaHttpHeaders(Map.empty),
+      headersDefinition = (),
+      headersProvided = (),
+      headersSeq = Nil,
+      security = AppliedSecurity(NoopSecurity, Map.empty),
+      pathParameters = (),
+      pathParametersProvided = (),
+      pathParametersSeq = pathParamNames.map(n => PathParam[String](n, None)),
+      queryParameters = (),
+      queryParametersProvided = (),
+      queryParametersSeq = queryParamNames.map(n => QueryParam[String](n, None)),
+      responseDescription = None,
+      responseHeaders = Nil
+    )
+
   private val stringSchema = BaklavaSchemaSerializable(Schema.stringSchema)
 
   private def synthCall(

--- a/openapi/src/test/scala/pl/iterators/baklava/openapi/ParameterExampleSpec.scala
+++ b/openapi/src/test/scala/pl/iterators/baklava/openapi/ParameterExampleSpec.scala
@@ -1,0 +1,229 @@
+package pl.iterators.baklava.openapi
+
+import io.swagger.v3.oas.models.OpenAPI
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
+import pl.iterators.baklava.*
+
+import scala.jdk.CollectionConverters.*
+
+/** Regression suite for #68: query/path/header parameter example values flow from captured test-case inputs into the generated OpenAPI
+  * `parameter.example` / `parameter.examples` fields.
+  */
+class ParameterExampleSpec extends AnyFunSpec with Matchers {
+
+  describe("OpenAPI parameter example emission (regression for #68)") {
+
+    it("emits a singular example for a path parameter when all calls captured the same value") {
+      val call1 = synthCall(
+        symbolicPath = "/items/{id}",
+        resolvedPath = "/items/42",
+        pathParams = Seq(("id", "42"))
+      )
+      val call2 = synthCall(
+        symbolicPath = "/items/{id}",
+        resolvedPath = "/items/42",
+        pathParams = Seq(("id", "42"))
+      )
+
+      val openAPI = new OpenAPI()
+      BaklavaDslFormatterOpenAPIWorker.generateForCalls(openAPI, Seq(call1, call2))
+
+      val idParam = openAPI.getPaths
+        .get("/items/{id}")
+        .getGet
+        .getParameters
+        .asScala
+        .find(p => p.getName == "id" && p.getIn == "path")
+        .getOrElse(fail("id parameter missing"))
+      idParam.getExample shouldBe "42"
+      Option(idParam.getExamples) shouldBe None
+    }
+
+    it("emits named examples (keyed by responseDescription) when calls captured different values") {
+      val call1 = synthCall(
+        symbolicPath = "/items/{id}",
+        resolvedPath = "/items/42",
+        pathParams = Seq(("id", "42")),
+        scenarioName = Some("found")
+      )
+      val call2 = synthCall(
+        symbolicPath = "/items/{id}",
+        resolvedPath = "/items/zzz",
+        pathParams = Seq(("id", "zzz")),
+        scenarioName = Some("not-found")
+      )
+
+      val openAPI = new OpenAPI()
+      BaklavaDslFormatterOpenAPIWorker.generateForCalls(openAPI, Seq(call1, call2))
+
+      val idParam = openAPI.getPaths
+        .get("/items/{id}")
+        .getGet
+        .getParameters
+        .asScala
+        .find(p => p.getName == "id" && p.getIn == "path")
+        .getOrElse(fail("id parameter missing"))
+      Option(idParam.getExample) shouldBe None
+      val examples = idParam.getExamples.asScala
+      examples.keySet should contain theSameElementsAs Set("found", "not-found")
+      examples("found").getValue shouldBe "42"
+      examples("not-found").getValue shouldBe "zzz"
+    }
+
+    it("emits query parameter examples parsed from the resolved URL") {
+      val call1 = synthCall(
+        symbolicPath = "/search",
+        resolvedPath = "/search?q=hello&limit=10",
+        queryParams = Seq(("q", ""), ("limit", ""))
+      )
+
+      val openAPI = new OpenAPI()
+      BaklavaDslFormatterOpenAPIWorker.generateForCalls(openAPI, Seq(call1))
+
+      val params = openAPI.getPaths.get("/search").getGet.getParameters.asScala.filter(_.getIn == "query")
+      params.find(_.getName == "q").get.getExample shouldBe "hello"
+      params.find(_.getName == "limit").get.getExample shouldBe "10"
+    }
+
+    it("emits header parameter examples from the captured headers map (case-insensitive)") {
+      val call = synthCall(
+        symbolicPath = "/h",
+        resolvedPath = "/h",
+        headers = Seq(("X-Request-Id", "req-42")),
+        sentHeaders = Map("x-request-id" -> "req-42")
+      )
+
+      val openAPI = new OpenAPI()
+      BaklavaDslFormatterOpenAPIWorker.generateForCalls(openAPI, Seq(call))
+
+      val headerParam = openAPI.getPaths
+        .get("/h")
+        .getGet
+        .getParameters
+        .asScala
+        .find(p => p.getName == "X-Request-Id" && p.getIn == "header")
+        .getOrElse(fail("header param missing"))
+      headerParam.getExample shouldBe "req-42"
+    }
+
+    it("URL-decodes path parameter values so %20 round-trips to space") {
+      val call = synthCall(
+        symbolicPath = "/users/{name}",
+        resolvedPath = "/users/John%20Doe",
+        pathParams = Seq(("name", "ignored-at-test-level-actual-value-comes-from-URL"))
+      )
+
+      val openAPI = new OpenAPI()
+      BaklavaDslFormatterOpenAPIWorker.generateForCalls(openAPI, Seq(call))
+
+      val nameParam = openAPI.getPaths
+        .get("/users/{name}")
+        .getGet
+        .getParameters
+        .asScala
+        .find(p => p.getName == "name" && p.getIn == "path")
+        .getOrElse(fail("name parameter missing"))
+      nameParam.getExample shouldBe "John Doe"
+    }
+  }
+
+  private val stringSchema = BaklavaSchemaSerializable(Schema.stringSchema)
+
+  private def synthCall(
+      symbolicPath: String,
+      resolvedPath: String,
+      queryParams: Seq[(String, String)] = Nil,
+      pathParams: Seq[(String, String)] = Nil,
+      headers: Seq[(String, String)] = Nil,
+      sentHeaders: Map[String, String] = Map.empty,
+      scenarioName: Option[String] = None
+  ): BaklavaSerializableCall = {
+    // The test directly constructs BaklavaSerializableCall bypassing the normal extraction path,
+    // so we can exercise the generator-side emission independently. We still manually plug in
+    // example values matching what the real extractor would produce, where relevant.
+    val path  = BaklavaPathParamValues(symbolicPath, resolvedPath)
+    val query = BaklavaQueryParamValues(resolvedPath)
+    BaklavaSerializableCall(
+      request = BaklavaRequestContextSerializable(
+        symbolicPath = symbolicPath,
+        path = resolvedPath,
+        pathDescription = None,
+        pathSummary = None,
+        method = Some(BaklavaHttpMethod("GET")),
+        operationDescription = None,
+        operationSummary = None,
+        operationId = None,
+        operationTags = Nil,
+        securitySchemes = Nil,
+        bodySchema = None,
+        headersSeq = headers.map { case (name, _) =>
+          BaklavaHeaderSerializable(
+            name,
+            None,
+            stringSchema,
+            sentHeaders.find(_._1.toLowerCase == name.toLowerCase).map(_._2)
+          )
+        },
+        pathParametersSeq = pathParams.map { case (name, _) =>
+          BaklavaPathParamSerializable(name, None, stringSchema, path.get(name))
+        },
+        queryParametersSeq = queryParams.map { case (name, _) =>
+          BaklavaQueryParamSerializable(name, None, stringSchema, query.get(name))
+        },
+        responseDescription = scenarioName.orElse(Some("ok")),
+        responseHeaders = Nil
+      ),
+      response = BaklavaResponseContextSerializable(
+        protocol = BaklavaHttpProtocol("HTTP/1.1"),
+        status = BaklavaHttpStatus(200),
+        headers = BaklavaHttpHeaders(sentHeaders),
+        requestBodyString = "",
+        responseBodyString = "",
+        requestContentType = None,
+        responseContentType = None,
+        bodySchema = None
+      )
+    )
+  }
+
+  // Mirror of the private extractors in BaklavaSerialize so the test can construct examples
+  // exactly as the runtime does, without relying on the full serialize round-trip.
+  private object BaklavaPathParamValues {
+    def apply(symbolicPath: String, resolvedPath: String): Map[String, String] = {
+      val pathOnly      = resolvedPath.split('?').headOption.getOrElse(resolvedPath)
+      val templateParts = symbolicPath.split('/')
+      val resolvedParts = pathOnly.split('/')
+      if (templateParts.length != resolvedParts.length) Map.empty
+      else
+        templateParts
+          .zip(resolvedParts)
+          .collect {
+            case (t, r) if t.startsWith("{") && t.endsWith("}") =>
+              t.substring(1, t.length - 1) -> java.net.URLDecoder.decode(r, "UTF-8")
+          }
+          .toMap
+    }
+  }
+
+  private object BaklavaQueryParamValues {
+    def apply(resolvedPath: String): Map[String, String] = {
+      val queryPart = resolvedPath.split('?').drop(1).headOption.getOrElse("")
+      if (queryPart.isEmpty) Map.empty
+      else
+        queryPart
+          .split('&')
+          .filter(_.nonEmpty)
+          .toSeq
+          .map { kv =>
+            val eq = kv.indexOf('=')
+            if (eq < 0) java.net.URLDecoder.decode(kv, "UTF-8")           -> ""
+            else java.net.URLDecoder.decode(kv.substring(0, eq), "UTF-8") -> java.net.URLDecoder.decode(kv.substring(eq + 1), "UTF-8")
+          }
+          .groupBy(_._1)
+          .view
+          .mapValues(_.map(_._2).mkString(","))
+          .toMap
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Closes #68. Query/path/header parameters in the generated OpenAPI spec now carry example values extracted from the actual test-case inputs. This addresses three long-standing \`// TODO: we could add example best on provided in test case :shrug:\` markers in the generator.

**Based on** PR #71 (#66 parameter merging) — rebase after #71 lands.

## What changes

**Serialization (core):**
- \`BaklavaHeaderSerializable\` / \`BaklavaPathParamSerializable\` / \`BaklavaQueryParamSerializable\` gain an optional \`example: Option[String]\` field (default \`None\` — back-compat with existing JSON).
- \`BaklavaRequestContextSerializable.apply\` extracts values from the captured request state:
  - **Path params:** parse the resolved URL against the symbolic template, pull each \`{name}\` segment, URL-decode (\`%20\` etc.).
  - **Query params:** parse the \`?\` portion of the resolved URL.
  - **Headers:** case-insensitive lookup in the \`BaklavaHttpHeaders\` map.

**Generator (openapi):**
- Per parameter: collect \`(scenario -> value)\` pairs across all calls in the operation.
- If all values agree → emit singular \`parameter.example\`.
- If they differ → emit named \`parameter.examples\` keyed by \`responseDescription\` (disambiguated for duplicate / empty labels — same pattern as body examples).
- No emission when nothing was captured.

## Test plan

- [x] 5 new regression scenarios in \`ParameterExampleSpec\`:
  - singular example when all calls agree
  - named examples when values differ
  - query examples parsed from URL
  - header example via case-insensitive map lookup
  - URL-decoding of path values (\`%20\` → space)
- [x] All existing tests pass with \`CI=true\` (98 Scala 2.13, 105 Scala 3 tests)

Closes #68