### PR TITLE
withSetup: rename eager .request to .onRequest for Scala 2.13 inference (#69)

### DIFF
--- a/core/src/main/scala/pl/iterators/baklava/BaklavaTestFrameworkDsl.scala
+++ b/core/src/main/scala/pl/iterators/baklava/BaklavaTestFrameworkDsl.scala
@@ -505,11 +505,16 @@ trait BaklavaTestFrameworkDsl[RouteType, ToRequestBodyType[_], FromResponseBodyT
   }
 
   trait WithSetupBuilder[S] {
+
+    /** Lazy form: construct the request from the setup value at test-execution time. */
     def request[RequestBody: ToRequestBodyType: Schema, PathParametersProvided, QueryParametersProvided, HeadersProvided](
         f: S => OnRequest[RequestBody, PathParametersProvided, QueryParametersProvided, HeadersProvided]
     ): WithSetupRequestBuilder[S, RequestBody, PathParametersProvided, QueryParametersProvided, HeadersProvided]
 
-    def request[RequestBody: ToRequestBodyType: Schema, PathParametersProvided, QueryParametersProvided, HeadersProvided](
+    /** Eager form: when the request values don't depend on the setup value, use the same named arguments as the top-level
+      * `onRequest(...)`. The setup value still flows to `.assert`.
+      */
+    def onRequest[RequestBody: ToRequestBodyType: Schema, PathParametersProvided, QueryParametersProvided, HeadersProvided](
         body: RequestBody = EmptyBodyInstance: EmptyBody,
         security: AppliedSecurity = AppliedSecurity(NoopSecurity, Map.empty),
         pathParameters: PathParametersProvided = (),
@@ -526,7 +531,7 @@ trait BaklavaTestFrameworkDsl[RouteType, ToRequestBodyType[_], FromResponseBodyT
       ): WithSetupRequestBuilder[S, RequestBody, PathParametersProvided, QueryParametersProvided, HeadersProvided] =
         makeRequestBuilder(setupThunk, f)
 
-      override def request[RequestBody: ToRequestBodyType: Schema, PathParametersProvided, QueryParametersProvided, HeadersProvided](
+      override def onRequest[RequestBody: ToRequestBodyType: Schema, PathParametersProvided, QueryParametersProvided, HeadersProvided](
           body: RequestBody,
           security: AppliedSecurity,
           pathParameters: PathParametersProvided,

--- a/docs/dsl-reference.md
+++ b/docs/dsl-reference.md
@@ -332,14 +332,15 @@ When a scenario needs to produce request values from setup logic — for example
 def withSetup[S](setup: => S): WithSetupBuilder[S]
 ```
 
-`WithSetupBuilder[S]` has two overloaded `.request` methods:
+`WithSetupBuilder[S]` exposes two methods:
 
 ```scala
 // Lazy form — function of the setup value
 def request[...](f: S => OnRequest[...]): WithSetupRequestBuilder[...]
 
-// Eager form — static fields, same named arguments as the top-level onRequest(...)
-def request[...](
+// Eager form — static fields, same named arguments as the top-level onRequest(...).
+// Distinct method name (not an overload) so Scala 2.13 can infer the lazy lambda's type.
+def onRequest[...](
     body: RequestBody            = EmptyBodyInstance: EmptyBody,
     security: AppliedSecurity    = AppliedSecurity(NoopSecurity, Map.empty),
     pathParameters: ...          = (),
@@ -363,7 +364,7 @@ path("/v1/auctions/{auctionId}")(
       application.transactor
         .inSession(seedUser(seller) *> seedAuction(AuctionId(UUID.randomUUID()), seller.id))
         .unsafeRunSync()
-    }.request { (auction: Auction) =>
+    }.request { auction =>
       onRequest(pathParameters = auction.id)
     }.respondsWith[AuctionDto](OK, description = "Auction found")
       .assert { case (ctx, auction) =>
@@ -382,7 +383,7 @@ When the request values are static but the assertion needs data from setup:
 withSetup {
   application.transactor.inSession(seedUser(seller)).unsafeRunSync()
   seller
-}.request(body = sampleCreateRequest(), security = bearer.apply(validJwt(sellerAuth)))
+}.onRequest(body = sampleCreateRequest(), security = bearer.apply(validJwt(sellerAuth)))
   .respondsWith[AuctionDto](Created)
   .assert { case (ctx, seller) =>
     val response = ctx.performRequest(allRoutes)
@@ -394,7 +395,7 @@ withSetup {
 
 - `setup` is synchronous. If it runs IO, call `.unsafeRunSync()` (or equivalent) inside the block.
 - The setup block runs once per scenario, at test-execution time — not at class-construction time. Each scenario's setup is independent.
-- **Scala 2.13** requires an explicit type annotation on the lambda parameter of the lazy `.request { ... }` form (e.g., `.request { (id: Long) => ... }`). Scala 3 does not require this.
+- The lazy form uses `.request { s => onRequest(...) }` and the eager form uses `.onRequest(body = ..., ...)` — two distinct method names so Scala 2.13 infers the lazy lambda's parameter type without an explicit annotation.
 - OpenAPI output is unaffected by `withSetup`: parameter schemas still come from `supports(...)`, and request/response body examples still come from the live HTTP transaction.
 - The existing `onRequest(...).respondsWith(...).assert { ctx => ... }` chain remains fully supported and unchanged — `withSetup` is additive.
 

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -359,7 +359,7 @@ path("/v1/auctions/{auctionId}")(
       application.transactor
         .inSession(seedUser(seller) *> seedAuction(AuctionId(UUID.randomUUID()), seller.id))
         .unsafeRunSync()
-    }.request { (auction: Auction) =>
+    }.request { auction =>
       onRequest(pathParameters = auction.id)
     }.respondsWith[AuctionDto](OK, description = "Auction found")
       .assert { case (ctx, auction) =>
@@ -372,5 +372,5 @@ path("/v1/auctions/{auctionId}")(
 
 The setup block runs once per scenario at test execution time. Its return value is threaded into both `.request` (to construct the `OnRequest`) and `.assert` (as the second argument of the two-argument lambda).
 
-On Scala 2.13, the lambda parameter must be explicitly typed (`(auction: Auction) => ...`). On Scala 3, type inference resolves it automatically.
+When the request doesn't depend on the setup value, use the eager `.onRequest(body = ..., pathParameters = ..., ...)` form instead of the lazy `.request { ... }`.
 

--- a/openapi/src/test/scala/pl/iterators/baklava/openapi/WithSetupFlowSpec.scala
+++ b/openapi/src/test/scala/pl/iterators/baklava/openapi/WithSetupFlowSpec.scala
@@ -66,9 +66,10 @@ class WithSetupFlowSpec
       securitySchemes = Seq(bearerScheme),
       tags = Seq("Things")
     )(
-      // Scenario 1: lazy path parameter produced by setup.
-      // Since PR #73 removed the overloaded `.request` in favor of a single lazy method, this
-      // lambda no longer needs an explicit parameter type annotation on Scala 2.13.
+      // Scenario 1: lazy path parameter produced by setup. Now that the eager `.request(...)` overload
+      // has been renamed to `.onRequest(...)`, the remaining lazy `.request { s => ... }` is
+      // unambiguous and this lambda no longer needs an explicit parameter type annotation on
+      // Scala 2.13.
       withSetup {
         42L // pretend this is `seedThing().unsafeRunSync().id`
       }.request { id =>

--- a/openapi/src/test/scala/pl/iterators/baklava/openapi/WithSetupFlowSpec.scala
+++ b/openapi/src/test/scala/pl/iterators/baklava/openapi/WithSetupFlowSpec.scala
@@ -66,10 +66,12 @@ class WithSetupFlowSpec
       securitySchemes = Seq(bearerScheme),
       tags = Seq("Things")
     )(
-      // Scenario 1: lazy path parameter produced by setup
+      // Scenario 1: lazy path parameter produced by setup.
+      // Since PR #73 removed the overloaded `.request` in favor of a single lazy method, this
+      // lambda no longer needs an explicit parameter type annotation on Scala 2.13.
       withSetup {
         42L // pretend this is `seedThing().unsafeRunSync().id`
-      }.request { (id: Long) =>
+      }.request { id =>
         onRequest(pathParameters = id, security = bearer("tok"))
       }.respondsWith[Thing](OK, description = "Thing found via setup id")
         .assert { case (ctx, id) =>
@@ -87,10 +89,10 @@ class WithSetupFlowSpec
       securitySchemes = Seq(bearerScheme),
       tags = Seq("Things")
     )(
-      // Scenario 2: lazy body produced by setup (tuple)
+      // Scenario 2: lazy body produced by setup (tuple) — no lambda annotation needed.
       withSetup {
         ("Bob", 7L) // (name, expectedId)
-      }.request { (setup: (String, Long)) =>
+      }.request { setup =>
         val (name, _) = setup
         onRequest(body = CreateThing(name), security = bearer("tok"))
       }.respondsWith[Thing](Created, description = "Created via setup-derived body")
@@ -110,11 +112,13 @@ class WithSetupFlowSpec
       securitySchemes = Seq(bearerScheme),
       tags = Seq("Things")
     )(
-      // Scenario 3: setup yields Unit (side-effect only); eager .request is used.
+      // Scenario 3: setup yields Unit (side-effect only); eager `.onRequest` is used —
+      // distinct method name from the lazy `.request` so Scala 2.13 can infer lambda types
+      // cleanly without forcing a single overloaded method.
       withSetup {
         val _ = 1 + 1 // side-effect stand-in
         ()
-      }.request(pathParameters = 99L, security = bearer("tok"))
+      }.onRequest(pathParameters = 99L, security = bearer("tok"))
         .respondsWith[Thing](OK, description = "Eager request override with Unit setup")
         .assert { case (ctx, _) =>
           nextResponse = jsonResponse(OK, Thing(99L, "Zed").asJson.noSpaces)


### PR DESCRIPTION
## Summary

Closes #69. The lazy `.request { s => onRequest(...) }` form previously required an explicit parameter type annotation on Scala 2.13 (`.request { (id: Long) => ... }`). Root cause: the two overloaded `.request` methods on `WithSetupBuilder[S]` prevented Scala 2.13's inferencer from resolving the lambda's input type.

## Root cause investigation

Minimal repro in `sbt console` with `-Xsource:3.0.0` (project setting) confirmed:
- Single-method `.request` → lambda infers cleanly (no annotation needed).
- Two overloads (lazy + eager) → Scala 2.13 can't pick which to apply until it knows the argument type, so it fails with `missing parameter type`.

## Fix

Renamed the eager overload to `.onRequest`, mirroring the top-level `onRequest(...)` API. The lazy `.request` becomes the sole method with that name, so overload resolution isn't blocking inference anymore.

**Before:**
```scala
withSetup { ... }.request { (id: Long) => onRequest(pathParameters = id) }  // lambda annotation required
withSetup { ... }.request(body = ..., pathParameters = ...)                 // eager
```

**After:**
```scala
withSetup { ... }.request { id => onRequest(pathParameters = id) }          // inference works
withSetup { ... }.onRequest(body = ..., pathParameters = ...)               // eager, renamed
```

## Migration

One-line change for anyone on PR #58's eager form: `.request(...)` → `.onRequest(...)`. The lazy form is unchanged (in fact now cleaner — no required annotations).

## Test plan

- [x] Updated \`WithSetupFlowSpec\` to drop the previously-required \`(id: Long)\` and \`(setup: (String, Long))\` annotations; scenario 3 uses \`.onRequest(...)\`.
- [x] Cross-build \`+test\` with \`CI=true\` green on Scala 2.13.18 and 3.3.7.
- [x] Minimal repro confirmed the single-method fix works.

## Docs

- `docs/dsl-reference.md`: signature block updated, "Scala 2.13 requires explicit annotation" caveat removed.
- `docs/examples.md`: example lambda dropped its explicit type, concluding paragraph updated.

Closes #69