### PR TITLE
chore: TODO sweep — case-insensitive header assertion + stale marker removal

### DIFF
--- a/core/src/main/scala/pl/iterators/baklava/BaklavaQueryParams.scala
+++ b/core/src/main/scala/pl/iterators/baklava/BaklavaQueryParams.scala
@@ -2353,7 +2353,6 @@ trait BaklavaQueryParams {
       }
     }
 
-  // TODO: created by chatgpt, check later
   def addQueryParametersToUri(uri: String, queryParameters: Map[String, Seq[String]]): String = {
     if (queryParameters.isEmpty) {
       uri

--- a/core/src/main/scala/pl/iterators/baklava/BaklavaTestFrameworkDsl.scala
+++ b/core/src/main/scala/pl/iterators/baklava/BaklavaTestFrameworkDsl.scala
@@ -314,7 +314,8 @@ trait BaklavaTestFrameworkDsl[RouteType, ToRequestBodyType[_], FromResponseBodyT
     }
 
     val headersParsed = expectedResponseHeaders.map { h =>
-      responseContext.headers.headers.get(h.name) match { // TODO: should be case insensitive
+      val lowered = h.name.toLowerCase
+      responseContext.headers.headers.find(_._1.toLowerCase == lowered).map(_._2) match {
         case None        => throw new BaklavaAssertionException(s"Header ${h.name} not found but expected")
         case Some(value) =>
           h.name ->


### PR DESCRIPTION
## Summary

Two small cleanups from the TODO inventory in the core module:

1. **\`BaklavaTestFrameworkDsl.scala:317\` — case-insensitive response-header assertion.**
   The eager \`.assert\` path's response-header validation looked up captured headers via case-sensitive \`Map#apply\`. HTTP headers are case-insensitive. PR #65 already fixed the same pattern in the OpenAPI generator; this PR extends the fix to the DSL-level assertion.

2. **\`BaklavaQueryParams.scala:2356\` — stale \"created by chatgpt, check later\" marker.**
   Walked through the \`addQueryParametersToUri\` logic: handles no-params, empty URI, existing query string, fragment, multi-value, and URL encoding correctly. Removing the stale warning.

## Test plan

- [x] \`CI=true sbt '+test'\` green on Scala 2.13.18 and 3.3.7

## Not touched

Larger TODOs deferred — security-scheme duplication, schema array/collection support, OpenAPI body-method placement question. Those aren't sweep-shaped.