### PR TITLE
feat!: replace BaklavaHttpMethod/Status/Headers with sttp-model types (#34)

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -71,6 +71,7 @@ val testcontainersV = "0.44.1"
 val webjarsLocatorV = "0.52"
 val swaggerUiV      = "5.32.1"
 val typesafeConfigV = "1.4.6"
+val sttpModelV      = "1.7.17"
 
 lazy val core = project
   .in(file("core"))
@@ -83,6 +84,7 @@ lazy val core = project
         "io.circe"                              %% "circe-parser"          % circeV,
         "com.github.plokhotnyuk.jsoniter-scala" %% "jsoniter-scala-core"   % jsoniterV,
         "com.github.plokhotnyuk.jsoniter-scala" %% "jsoniter-scala-macros" % jsoniterV  % "provided",
+        "com.softwaremill.sttp.model"           %% "core"                  % sttpModelV,
         "org.scalatest"                         %% "scalatest"             % scalatestV % "test",
         if (scalaVersion.value.startsWith("3")) "com.softwaremill.magnolia1_3" %% "magnolia" % magnoliaS3V
         else "com.softwaremill.magnolia1_2"                                    %% "magnolia" % magnoliaS2V

--- a/core/src/main/scala/pl/iterators/baklava/BaklavaHttpDsl.scala
+++ b/core/src/main/scala/pl/iterators/baklava/BaklavaHttpDsl.scala
@@ -1,18 +1,15 @@
 package pl.iterators.baklava
 
+import sttp.model.{Header => SttpHeader, Method, StatusCode}
+
 import scala.reflect.ClassTag
 
 sealed trait EmptyBody
 
 case object EmptyBodyInstance extends EmptyBody
 
-case class BaklavaHttpMethod(value: String)
-
+// Kept as a Baklava-specific wrapper since sttp-model has no HTTP-protocol equivalent.
 case class BaklavaHttpProtocol(protocol: String)
-
-case class BaklavaHttpStatus(status: Int)
-
-case class BaklavaHttpHeaders(headers: Map[String, String])
 
 case class FormOf[T](fields: (String, String)*)(implicit val schema: Schema[T])
 
@@ -44,7 +41,7 @@ case class BaklavaRequestContext[
     path: String,
     pathDescription: Option[String],
     pathSummary: Option[String],
-    method: Option[BaklavaHttpMethod],
+    method: Option[Method],
     operationDescription: Option[String],
     operationSummary: Option[String],
     operationId: Option[String],
@@ -52,7 +49,7 @@ case class BaklavaRequestContext[
     securitySchemes: Seq[SecurityScheme],
     body: Option[Body],
     bodySchema: Option[Schema[Body]],
-    headers: BaklavaHttpHeaders,
+    headers: Seq[SttpHeader],
     headersDefinition: Headers,
     headersProvided: HeadersProvided,
     headersSeq: Seq[Header[?]],
@@ -69,8 +66,8 @@ case class BaklavaRequestContext[
 
 case class BaklavaResponseContext[ResponseBody, RequestType, ResponseType](
     protocol: BaklavaHttpProtocol,
-    status: BaklavaHttpStatus,
-    headers: BaklavaHttpHeaders,
+    status: StatusCode,
+    headers: Seq[SttpHeader],
     body: ResponseBody,
     rawRequest: RequestType,
     requestBodyString: String,
@@ -182,17 +179,17 @@ trait BaklavaHttpDsl[
 
   protected implicit def emptyToResponseBodyType: FromResponseBodyType[EmptyBody]
 
-  implicit def statusCodeToBaklavaStatusCodes(statusCode: HttpStatusCode): BaklavaHttpStatus
-  implicit def baklavaStatusCodeToStatusCode(baklavaHttpStatus: BaklavaHttpStatus): HttpStatusCode
+  implicit def statusCodeToBaklavaStatusCodes(statusCode: HttpStatusCode): StatusCode
+  implicit def baklavaStatusCodeToStatusCode(status: StatusCode): HttpStatusCode
 
-  implicit def httpMethodToBaklavaHttpMethod(method: HttpMethod): BaklavaHttpMethod
-  implicit def baklavaHttpMethodToHttpMethod(baklavaHttpMethod: BaklavaHttpMethod): HttpMethod
+  implicit def httpMethodToBaklavaHttpMethod(method: HttpMethod): Method
+  implicit def baklavaHttpMethodToHttpMethod(method: Method): HttpMethod
 
   implicit def baklavaHttpProtocolToHttpProtocol(baklavaHttpProtocol: BaklavaHttpProtocol): HttpProtocol
   implicit def httpProtocolToBaklavaHttpProtocol(protocol: HttpProtocol): BaklavaHttpProtocol
 
-  implicit def baklavaHeadersToHttpHeaders(headers: BaklavaHttpHeaders): HttpHeaders
-  implicit def httpHeadersToBaklavaHeaders(headers: HttpHeaders): BaklavaHttpHeaders
+  implicit def baklavaHeadersToHttpHeaders(headers: Seq[SttpHeader]): HttpHeaders
+  implicit def httpHeadersToBaklavaHeaders(headers: HttpHeaders): Seq[SttpHeader]
 
   def httpResponseToBaklavaResponseContext[T: FromResponseBodyType: ClassTag](
       request: HttpRequest,

--- a/core/src/main/scala/pl/iterators/baklava/BaklavaSerialize.scala
+++ b/core/src/main/scala/pl/iterators/baklava/BaklavaSerialize.scala
@@ -2,6 +2,7 @@ package pl.iterators.baklava
 
 import com.github.plokhotnyuk.jsoniter_scala.core.*
 import com.github.plokhotnyuk.jsoniter_scala.macros.*
+import sttp.model.{Header => SttpHeader, Method, StatusCode}
 
 import java.io.File
 import java.nio.file.Files
@@ -167,7 +168,7 @@ case class BaklavaRequestContextSerializable(
     path: String,
     pathDescription: Option[String],
     pathSummary: Option[String],
-    method: Option[BaklavaHttpMethod],
+    method: Option[Method],
     operationDescription: Option[String],
     operationSummary: Option[String],
     operationId: Option[String],
@@ -213,8 +214,8 @@ object BaklavaRequestContextSerializable {
 
 case class BaklavaResponseContextSerializable(
     protocol: BaklavaHttpProtocol,
-    status: BaklavaHttpStatus,
-    headers: BaklavaHttpHeaders,
+    status: StatusCode,
+    headers: Seq[SttpHeader],
     // body: ResponseBody, //maybe byte array? or maybe not needed
     // rawRequest: RequestType,//todo probably not needed
     requestBodyString: String,

--- a/core/src/main/scala/pl/iterators/baklava/BaklavaTestFrameworkDsl.scala
+++ b/core/src/main/scala/pl/iterators/baklava/BaklavaTestFrameworkDsl.scala
@@ -1,5 +1,7 @@
 package pl.iterators.baklava
 
+import sttp.model.{Header => SttpHeader, Method, StatusCode}
+
 import java.util.Base64
 import java.util.concurrent.atomic.AtomicReference
 import scala.reflect.ClassTag
@@ -32,7 +34,7 @@ trait BaklavaTestFrameworkDsl[RouteType, ToRequestBodyType[_], FromResponseBodyT
       securitySchemes = Seq.empty,
       body = None,
       bodySchema = None,
-      headers = BaklavaHttpHeaders(Map.empty),
+      headers = Seq.empty,
       headersDefinition = (),
       headersProvided = (),
       headersSeq = Seq.empty,
@@ -61,7 +63,7 @@ trait BaklavaTestFrameworkDsl[RouteType, ToRequestBodyType[_], FromResponseBodyT
   }
 
   def supports[PathParameters, QueryParameters, Headers](
-      method: BaklavaHttpMethod,
+      method: Method,
       securitySchemes: Seq[SecurityScheme] = Seq.empty,
       pathParameters: PathParameters = (),
       queryParameters: QueryParameters = (),
@@ -107,7 +109,7 @@ trait BaklavaTestFrameworkDsl[RouteType, ToRequestBodyType[_], FromResponseBodyT
           responseDescription = None,
           responseHeaders = Seq.empty
         )
-        methodLevelTextWithFragments(s"support ${method.value}" + finalSummary, newCtx, fragmentsFromSeq(steps.map(_.apply(newCtx))))
+        methodLevelTextWithFragments(s"support ${method.method}" + finalSummary, newCtx, fragmentsFromSeq(steps.map(_.apply(newCtx))))
       }
     }
 
@@ -241,7 +243,7 @@ trait BaklavaTestFrameworkDsl[RouteType, ToRequestBodyType[_], FromResponseBodyT
       ),
       body = if (body != EmptyBodyInstance) Some(body) else None,
       bodySchema = Some(bodySchema),
-      headers = BaklavaHttpHeaders(headersWithCookieModifiedForSecurity ++ additionalSecurityHeaders),
+      headers = (headersWithCookieModifiedForSecurity ++ additionalSecurityHeaders).map { case (n, v) => SttpHeader(n, v) }.toSeq,
       headersProvided = headersProvided,
       security = security,
       pathParametersProvided = pathParametersProvided,
@@ -274,7 +276,7 @@ trait BaklavaTestFrameworkDsl[RouteType, ToRequestBodyType[_], FromResponseBodyT
       responseContext: BaklavaResponseContext[ResponseBody, HttpRequest, HttpResponse],
       requestBodySchema: Schema[RequestBody],
       responseBodySchema: Schema[ResponseBody],
-      statusCode: BaklavaHttpStatus,
+      statusCode: StatusCode,
       expectedResponseHeaders: Seq[Header[?]],
       strictHeaderCheck: Boolean
   ): Unit = {
@@ -303,7 +305,7 @@ trait BaklavaTestFrameworkDsl[RouteType, ToRequestBodyType[_], FromResponseBodyT
 
     if (responseContext.status != statusCode) {
       throw new BaklavaAssertionException(
-        s"Expected ${statusCode.status} -> ${responseBodySchema.className}, but got ${responseContext.status.status} -> ${responseContext.responseBodyString.take(maxBodyLengthInAssertion)}"
+        s"Expected ${statusCode.code} -> ${responseBodySchema.className}, but got ${responseContext.status.code} -> ${responseContext.responseBodyString.take(maxBodyLengthInAssertion)}"
       )
     }
 
@@ -314,7 +316,8 @@ trait BaklavaTestFrameworkDsl[RouteType, ToRequestBodyType[_], FromResponseBodyT
     }
 
     val headersParsed = expectedResponseHeaders.map { h =>
-      responseContext.headers.headers.get(h.name) match { // TODO: should be case insensitive
+      val lowered = h.name.toLowerCase
+      responseContext.headers.find(_.name.toLowerCase == lowered).map(_.value) match {
         case None        => throw new BaklavaAssertionException(s"Header ${h.name} not found but expected")
         case Some(value) =>
           h.name ->
@@ -327,12 +330,12 @@ trait BaklavaTestFrameworkDsl[RouteType, ToRequestBodyType[_], FromResponseBodyT
             )
       }
     }
-    if (strictHeaderCheck && headersParsed.distinctBy(_._1).length != responseContext.headers.headers.size) {
+    if (strictHeaderCheck && headersParsed.distinctBy(_._1).length != responseContext.headers.size) {
       throw new BaklavaAssertionException(
         s"Strict headers check is on, expected following headers: [${expectedResponseHeaders
             .map(h => h.name)
             .sorted
-            .mkString(", ")}], but got: [${responseContext.headers.headers.keys.toList.sorted.mkString(", ")}]"
+            .mkString(", ")}], but got: [${responseContext.headers.map(_.name).toList.sorted.mkString(", ")}]"
       )
     }
 
@@ -356,7 +359,7 @@ trait BaklavaTestFrameworkDsl[RouteType, ToRequestBodyType[_], FromResponseBodyT
       queryParametersProvided: QueryParametersProvided
   ) {
     def respondsWith[ResponseBody: FromResponseBodyType: Schema: ClassTag](
-        statusCode: BaklavaHttpStatus,
+        statusCode: StatusCode,
         headers: Seq[Header[?]] = Seq.empty,
         description: String = "",
         strictHeaderCheck: Boolean = strictHeaderCheckDefault
@@ -406,7 +409,7 @@ trait BaklavaTestFrameworkDsl[RouteType, ToRequestBodyType[_], FromResponseBodyT
               )
 
               requestLevelTextWithExecution(
-                statusCode.status.toString + finalDescription,
+                statusCode.code.toString + finalDescription,
                 finalRequestCtx, {
                   val wrappedPerformRequest = (
                       requestContext: BaklavaRequestContext[
@@ -497,7 +500,7 @@ trait BaklavaTestFrameworkDsl[RouteType, ToRequestBodyType[_], FromResponseBodyT
 
   trait WithSetupRequestBuilder[S, RequestBody, PathParametersProvided, QueryParametersProvided, HeadersProvided] {
     def respondsWith[ResponseBody: FromResponseBodyType: Schema: ClassTag](
-        statusCode: BaklavaHttpStatus,
+        statusCode: StatusCode,
         headers: Seq[Header[?]] = Seq.empty,
         description: String = "",
         strictHeaderCheck: Boolean = strictHeaderCheckDefault
@@ -559,7 +562,7 @@ trait BaklavaTestFrameworkDsl[RouteType, ToRequestBodyType[_], FromResponseBodyT
   ): WithSetupRequestBuilder[S, RequestBody, PathParametersProvided, QueryParametersProvided, HeadersProvided] =
     new WithSetupRequestBuilder[S, RequestBody, PathParametersProvided, QueryParametersProvided, HeadersProvided] {
       override def respondsWith[ResponseBody: FromResponseBodyType: Schema: ClassTag](
-          statusCode: BaklavaHttpStatus,
+          statusCode: StatusCode,
           headers: Seq[Header[?]],
           description: String,
           strictHeaderCheck: Boolean
@@ -577,7 +580,7 @@ trait BaklavaTestFrameworkDsl[RouteType, ToRequestBodyType[_], FromResponseBodyT
   ](
       setupThunk: () => S,
       requestFn: S => OnRequest[RequestBody, PathParametersProvided, QueryParametersProvided, HeadersProvided],
-      statusCode: BaklavaHttpStatus,
+      statusCode: StatusCode,
       expectedResponseHeaders: Seq[Header[?]],
       description: String,
       strictHeaderCheck: Boolean
@@ -627,7 +630,7 @@ trait BaklavaTestFrameworkDsl[RouteType, ToRequestBodyType[_], FromResponseBodyT
   ](
       setupThunk: () => S,
       requestFn: S => OnRequest[RequestBody, PathParametersProvided, QueryParametersProvided, HeadersProvided],
-      statusCode: BaklavaHttpStatus,
+      statusCode: StatusCode,
       expectedResponseHeaders: Seq[Header[?]],
       description: String,
       strictHeaderCheck: Boolean,
@@ -657,7 +660,7 @@ trait BaklavaTestFrameworkDsl[RouteType, ToRequestBodyType[_], FromResponseBodyT
         var timesCalled: Int = 0
 
         requestLevelTextWithExecution(
-          statusCode.status.toString + finalDescription,
+          statusCode.code.toString + finalDescription,
           requestContext, {
             val setupValue = setupThunk()
             val onReq      = requestFn(setupValue)

--- a/core/src/main/scala/pl/iterators/baklava/BaklavaTestFrameworkDsl.scala
+++ b/core/src/main/scala/pl/iterators/baklava/BaklavaTestFrameworkDsl.scala
@@ -315,13 +315,12 @@ trait BaklavaTestFrameworkDsl[RouteType, ToRequestBodyType[_], FromResponseBodyT
       )
     }
 
-    val headersParsed = expectedResponseHeaders.map { h =>
-      val lowered = h.name.toLowerCase
-      responseContext.headers.find(_.name.toLowerCase == lowered).map(_.value) match {
+    expectedResponseHeaders.foreach { h =>
+      val lowered = h.name.toLowerCase(java.util.Locale.ROOT)
+      responseContext.headers.find(_.name.toLowerCase(java.util.Locale.ROOT) == lowered).map(_.value) match {
         case None        => throw new BaklavaAssertionException(s"Header ${h.name} not found but expected")
         case Some(value) =>
-          h.name ->
-          h.tsm
+          val _ = h.tsm
             .unapply(value)
             .getOrElse(
               throw new BaklavaAssertionException(
@@ -330,13 +329,17 @@ trait BaklavaTestFrameworkDsl[RouteType, ToRequestBodyType[_], FromResponseBodyT
             )
       }
     }
-    if (strictHeaderCheck && headersParsed.distinctBy(_._1).length != responseContext.headers.size) {
-      throw new BaklavaAssertionException(
-        s"Strict headers check is on, expected following headers: [${expectedResponseHeaders
-            .map(h => h.name)
-            .sorted
-            .mkString(", ")}], but got: [${responseContext.headers.map(_.name).toList.sorted.mkString(", ")}]"
-      )
+    if (strictHeaderCheck) {
+      val expectedDistinctNames = expectedResponseHeaders.map(_.name.toLowerCase(java.util.Locale.ROOT)).distinct
+      val actualDistinctNames   = responseContext.headers.map(_.name.toLowerCase(java.util.Locale.ROOT)).distinct
+      if (expectedDistinctNames.length != actualDistinctNames.length) {
+        throw new BaklavaAssertionException(
+          s"Strict headers check is on, expected following headers: [${expectedResponseHeaders
+              .map(h => h.name)
+              .sorted
+              .mkString(", ")}], but got: [${responseContext.headers.map(_.name).toList.sorted.mkString(", ")}]"
+        )
+      }
     }
 
     if (

--- a/http4s/src/main/scala/pl/iterators/baklava/http4s/BaklavaHttp4s.scala
+++ b/http4s/src/main/scala/pl/iterators/baklava/http4s/BaklavaHttp4s.scala
@@ -21,10 +21,7 @@ import org.typelevel.ci.CIString
 import pl.iterators.baklava.{
   BaklavaAssertionException,
   BaklavaHttpDsl,
-  BaklavaHttpHeaders,
-  BaklavaHttpMethod,
   BaklavaHttpProtocol,
-  BaklavaHttpStatus,
   BaklavaRequestContext,
   BaklavaResponseContext,
   BaklavaTestFrameworkDsl,
@@ -34,6 +31,9 @@ import pl.iterators.baklava.{
   FreeFormSchema,
   Schema
 }
+import sttp.model.{Header => SttpHeader, Method => SttpMethod, StatusCode => SttpStatus}
+
+import scala.language.implicitConversions
 
 import scala.reflect.ClassTag
 import scala.util.{Failure, Success, Try}
@@ -78,16 +78,16 @@ trait BaklavaHttp4s[TestFrameworkFragmentType, TestFrameworkFragmentsType, TestF
   override implicit protected def emptyToResponseBodyType: BaklavaHttp4s.FromEntityUnmarshaller[EmptyBody] =
     EntityDecoder.void[IO].map(_ => EmptyBodyInstance)
 
-  override implicit def statusCodeToBaklavaStatusCodes(statusCode: Status): BaklavaHttpStatus = BaklavaHttpStatus(statusCode.code)
+  override implicit def statusCodeToBaklavaStatusCodes(statusCode: Status): SttpStatus = SttpStatus(statusCode.code)
 
-  override implicit def baklavaStatusCodeToStatusCode(baklavaHttpStatus: BaklavaHttpStatus): Status = Status
-    .fromInt(baklavaHttpStatus.status)
-    .getOrElse(throw new IllegalStateException(s"Invalid status code: ${baklavaHttpStatus.status}"))
+  override implicit def baklavaStatusCodeToStatusCode(status: SttpStatus): Status = Status
+    .fromInt(status.code)
+    .getOrElse(throw new IllegalStateException(s"Invalid status code: ${status.code}"))
 
-  override implicit def httpMethodToBaklavaHttpMethod(method: Method): BaklavaHttpMethod = BaklavaHttpMethod(method.name)
+  override implicit def httpMethodToBaklavaHttpMethod(method: Method): SttpMethod = SttpMethod(method.name)
 
-  override implicit def baklavaHttpMethodToHttpMethod(baklavaHttpMethod: BaklavaHttpMethod): Method =
-    Method.fromString(baklavaHttpMethod.value).getOrElse(throw new IllegalStateException(s"Invalid method: ${baklavaHttpMethod.value}"))
+  override implicit def baklavaHttpMethodToHttpMethod(method: SttpMethod): Method =
+    Method.fromString(method.method).getOrElse(throw new IllegalStateException(s"Invalid method: ${method.method}"))
 
   override implicit def baklavaHttpProtocolToHttpProtocol(baklavaHttpProtocol: BaklavaHttpProtocol): HttpVersion =
     baklavaHttpProtocol.protocol match {
@@ -103,13 +103,11 @@ trait BaklavaHttp4s[TestFrameworkFragmentType, TestFrameworkFragmentsType, TestF
     protocol.toString
   )
 
-  override implicit def baklavaHeadersToHttpHeaders(headers: BaklavaHttpHeaders): Headers = Headers(headers.headers.map { case (k, v) =>
-    Header.Raw(CIString(k), v)
-  }.toList)
+  override implicit def baklavaHeadersToHttpHeaders(headers: Seq[SttpHeader]): Headers =
+    Headers(headers.toList.map(h => Header.Raw(CIString(h.name), h.value)))
 
-  override implicit def httpHeadersToBaklavaHeaders(headers: Headers): BaklavaHttpHeaders = BaklavaHttpHeaders(
-    headers.headers.map(h => h.name.toString -> h.value).toMap
-  )
+  override implicit def httpHeadersToBaklavaHeaders(headers: Headers): Seq[SttpHeader] =
+    headers.headers.map(h => SttpHeader(h.name.toString, h.value))
 
   override def httpResponseToBaklavaResponseContext[T: BaklavaHttp4s.FromEntityUnmarshaller: ClassTag](
       request: Request[IO],
@@ -123,9 +121,9 @@ trait BaklavaHttp4s[TestFrameworkFragmentType, TestFrameworkFragmentsType, TestF
     val newResponse    = response.withBodyStream(fs2.Stream.emits(responseBytes))
 
     BaklavaResponseContext(
-      response.httpVersion,
-      response.status,
-      response.headers,
+      httpProtocolToBaklavaHttpProtocol(response.httpVersion),
+      statusCodeToBaklavaStatusCodes(response.status),
+      httpHeadersToBaklavaHeaders(response.headers),
       Try(newResponse.as[T].unsafeRunSync()) match {
         case Success(value)     => value
         case Failure(exception) =>
@@ -167,15 +165,15 @@ trait BaklavaHttp4s[TestFrameworkFragmentType, TestFrameworkFragmentsType, TestF
     ctx.body match {
       case Some(body) =>
         Request[IO](
-          method = ctx.method.get,
+          method = baklavaHttpMethodToHttpMethod(ctx.method.get),
           uri = Uri.fromString(ctx.path).fold(throw _, identity),
-          headers = ctx.headers
+          headers = baklavaHeadersToHttpHeaders(ctx.headers)
         ).withEntity(body)
       case None =>
         Request[IO](
-          method = ctx.method.get,
+          method = baklavaHttpMethodToHttpMethod(ctx.method.get),
           uri = Uri.fromString(ctx.path).fold(throw _, identity),
-          headers = ctx.headers
+          headers = baklavaHeadersToHttpHeaders(ctx.headers)
         )
     }
   }

--- a/http4s/src/main/scala/pl/iterators/baklava/http4s/BaklavaHttp4s.scala
+++ b/http4s/src/main/scala/pl/iterators/baklava/http4s/BaklavaHttp4s.scala
@@ -33,8 +33,6 @@ import pl.iterators.baklava.{
 }
 import sttp.model.{Header => SttpHeader, Method => SttpMethod, StatusCode => SttpStatus}
 
-import scala.language.implicitConversions
-
 import scala.reflect.ClassTag
 import scala.util.{Failure, Success, Try}
 

--- a/munit/src/main/scala/pl/iterators/baklava/munit/BaklavaMunit.scala
+++ b/munit/src/main/scala/pl/iterators/baklava/munit/BaklavaMunit.scala
@@ -23,7 +23,7 @@ trait BaklavaMunit[RouteType, ToRequestBodyType[_], FromResponseBodyType[_]]
       context: BaklavaRequestContext[?, ?, ?, ?, ?, ?, ?],
       r: => R
   ): Unit =
-    test(s"${context.method.get.value} ${context.symbolicPath} should respond with -> " + text)(r)
+    test(s"${context.method.get.method} ${context.symbolicPath} should respond with -> " + text)(r)
 }
 
 trait MunitAsExecution[T]

--- a/openapi/src/main/scala/pl/iterators/baklava/openapi/BaklavaDslFormatterOpenAPIWorker.scala
+++ b/openapi/src/main/scala/pl/iterators/baklava/openapi/BaklavaDslFormatterOpenAPIWorker.scala
@@ -73,10 +73,10 @@ object BaklavaDslFormatterOpenAPIWorker {
 
     calls.groupBy(_.request.symbolicPath).toList.sortBy(_._1).foreach { case (path, calls) =>
       val pathItem = new io.swagger.v3.oas.models.PathItem()
-      calls.groupBy(_.request.method).toList.sortBy(_._1.map(_.value)).foreach { case (method, calls) =>
+      calls.groupBy(_.request.method).toList.sortBy(_._1.map(_.method)).foreach { case (method, calls) =>
         val operation          = new io.swagger.v3.oas.models.Operation()
         val operationResponses = new ApiResponses()
-        calls.groupBy(_.response.status).toList.sortBy(_._1.status).foreach { case (status, commonStatusCalls) =>
+        calls.groupBy(_.response.status).toList.sortBy(_._1.code).foreach { case (status, commonStatusCalls) =>
           // One ApiResponse per status; all contentType media types accumulate into it.
           val r       = new io.swagger.v3.oas.models.responses.ApiResponse()
           val content = new Content()
@@ -133,7 +133,7 @@ object BaklavaDslFormatterOpenAPIWorker {
             }
 
           if (anyMediaTypeEmitted) { val _ = r.setContent(content) }
-          val _ = operationResponses.addApiResponse(status.status.toString, r)
+          val _ = operationResponses.addApiResponse(status.code.toString, r)
         }
         val _ = operation.responses(operationResponses)
 
@@ -142,7 +142,7 @@ object BaklavaDslFormatterOpenAPIWorker {
         val requestBody = new io.swagger.v3.oas.models.parameters.RequestBody()
         val content     = new Content()
 
-        val successfulCalls    = calls.filter(_.response.status.status / 100 == 2).sortBy(_.response.status.status)
+        val successfulCalls    = calls.filter(_.response.status.code / 100 == 2).sortBy(_.response.status.code)
         val responsesToProcess =
           if (successfulCalls.isEmpty) calls else successfulCalls // sometimes there are no successful responses
         responsesToProcess
@@ -257,7 +257,7 @@ object BaklavaDslFormatterOpenAPIWorker {
           .foreach(operation.addParametersItem)
 
         method.foreach { m =>
-          pathItem.operation(io.swagger.v3.oas.models.PathItem.HttpMethod.valueOf(m.value.toUpperCase), operation)
+          pathItem.operation(io.swagger.v3.oas.models.PathItem.HttpMethod.valueOf(m.method.toUpperCase), operation)
         }
         calls.head.request.pathSummary.foreach(pathItem.setSummary)
         calls.head.request.pathDescription.foreach(pathItem.setDescription)
@@ -323,7 +323,7 @@ object BaklavaDslFormatterOpenAPIWorker {
   ): Option[String] = {
     val lowered = name.toLowerCase
     calls.iterator
-      .flatMap(_.response.headers.headers.find(_._1.toLowerCase == lowered).map(_._2))
+      .flatMap(_.response.headers.find(_.name.toLowerCase == lowered).map(_.value))
       .nextOption()
   }
 

--- a/openapi/src/test/scala/pl/iterators/baklava/openapi/BaklavaDslFormatterOpenAPIWorkerSpec.scala
+++ b/openapi/src/test/scala/pl/iterators/baklava/openapi/BaklavaDslFormatterOpenAPIWorkerSpec.scala
@@ -4,7 +4,7 @@ import io.swagger.v3.oas.models.OpenAPI
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
 import pl.iterators.baklava.*
-import sttp.model.{Header => SttpHeader, Method, StatusCode}
+import sttp.model.{Method, StatusCode}
 
 import scala.jdk.CollectionConverters.*
 

--- a/openapi/src/test/scala/pl/iterators/baklava/openapi/BaklavaDslFormatterOpenAPIWorkerSpec.scala
+++ b/openapi/src/test/scala/pl/iterators/baklava/openapi/BaklavaDslFormatterOpenAPIWorkerSpec.scala
@@ -4,6 +4,7 @@ import io.swagger.v3.oas.models.OpenAPI
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
 import pl.iterators.baklava.*
+import sttp.model.{Header => SttpHeader, Method, StatusCode}
 
 import scala.jdk.CollectionConverters.*
 
@@ -30,7 +31,7 @@ class BaklavaDslFormatterOpenAPIWorkerSpec extends AnyFunSpec with Matchers {
         path = path,
         pathDescription = None,
         pathSummary = None,
-        method = Some(BaklavaHttpMethod(method)),
+        method = Some(Method(method)),
         operationDescription = description,
         operationSummary = summary,
         operationId = operationId,
@@ -45,8 +46,8 @@ class BaklavaDslFormatterOpenAPIWorkerSpec extends AnyFunSpec with Matchers {
       ),
       response = BaklavaResponseContextSerializable(
         protocol = BaklavaHttpProtocol("HTTP/1.1"),
-        status = BaklavaHttpStatus(status),
-        headers = BaklavaHttpHeaders(Map.empty),
+        status = StatusCode(status),
+        headers = Seq.empty,
         requestBodyString = "",
         responseBodyString = "",
         requestContentType = None,
@@ -164,7 +165,7 @@ class BaklavaDslFormatterOpenAPIWorkerSpec extends AnyFunSpec with Matchers {
             )
           ),
           response = call("GET", "/v1/ct", None, None, Nil, None, Nil).response.copy(
-            headers = BaklavaHttpHeaders(Map("x-request-id" -> "req-42"))
+            headers = Seq(sttp.model.Header("x-request-id", "req-42"))
           )
         )
 

--- a/openapi/src/test/scala/pl/iterators/baklava/openapi/OptionQueryParameterDefaultSpec.scala
+++ b/openapi/src/test/scala/pl/iterators/baklava/openapi/OptionQueryParameterDefaultSpec.scala
@@ -4,6 +4,7 @@ import io.swagger.v3.oas.models.OpenAPI
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
 import pl.iterators.baklava.*
+import sttp.model.{Header => SttpHeader, Method, StatusCode}
 
 import scala.jdk.CollectionConverters.*
 
@@ -31,7 +32,7 @@ class OptionQueryParameterDefaultSpec extends AnyFunSpec with Matchers {
         path = "/items",
         pathDescription = None,
         pathSummary = None,
-        method = Some(BaklavaHttpMethod("GET")),
+        method = Some(Method("GET")),
         operationDescription = None,
         operationSummary = None,
         operationId = None,
@@ -46,8 +47,8 @@ class OptionQueryParameterDefaultSpec extends AnyFunSpec with Matchers {
       ),
       response = BaklavaResponseContextSerializable(
         protocol = BaklavaHttpProtocol("HTTP/1.1"),
-        status = BaklavaHttpStatus(200),
-        headers = BaklavaHttpHeaders(Map.empty),
+        status = StatusCode(200),
+        headers = Seq.empty,
         requestBodyString = "",
         responseBodyString = "",
         requestContentType = None,

--- a/openapi/src/test/scala/pl/iterators/baklava/openapi/OptionQueryParameterDefaultSpec.scala
+++ b/openapi/src/test/scala/pl/iterators/baklava/openapi/OptionQueryParameterDefaultSpec.scala
@@ -4,7 +4,7 @@ import io.swagger.v3.oas.models.OpenAPI
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
 import pl.iterators.baklava.*
-import sttp.model.{Header => SttpHeader, Method, StatusCode}
+import sttp.model.{Method, StatusCode}
 
 import scala.jdk.CollectionConverters.*
 

--- a/openapi/src/test/scala/pl/iterators/baklava/openapi/RequestContentTypeSpec.scala
+++ b/openapi/src/test/scala/pl/iterators/baklava/openapi/RequestContentTypeSpec.scala
@@ -4,6 +4,7 @@ import io.swagger.v3.oas.models.OpenAPI
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
 import pl.iterators.baklava.*
+import sttp.model.{Header => SttpHeader, Method, StatusCode}
 
 import scala.jdk.CollectionConverters.*
 
@@ -18,7 +19,7 @@ class RequestContentTypeSpec extends AnyFunSpec with Matchers {
           path = "/upload",
           pathDescription = None,
           pathSummary = None,
-          method = Some(BaklavaHttpMethod("POST")),
+          method = Some(Method("POST")),
           operationDescription = None,
           operationSummary = None,
           operationId = None,
@@ -33,8 +34,8 @@ class RequestContentTypeSpec extends AnyFunSpec with Matchers {
         ),
         response = BaklavaResponseContextSerializable(
           protocol = BaklavaHttpProtocol("HTTP/1.1"),
-          status = BaklavaHttpStatus(201),
-          headers = BaklavaHttpHeaders(Map.empty),
+          status = StatusCode(201),
+          headers = Seq.empty,
           requestBodyString = "raw binary payload",
           responseBodyString = "",
           requestContentType = Some("application/octet-stream"),
@@ -63,7 +64,7 @@ class RequestContentTypeSpec extends AnyFunSpec with Matchers {
           path = "/trigger",
           pathDescription = None,
           pathSummary = None,
-          method = Some(BaklavaHttpMethod("POST")),
+          method = Some(Method("POST")),
           operationDescription = None,
           operationSummary = None,
           operationId = None,
@@ -78,8 +79,8 @@ class RequestContentTypeSpec extends AnyFunSpec with Matchers {
         ),
         response = BaklavaResponseContextSerializable(
           protocol = BaklavaHttpProtocol("HTTP/1.1"),
-          status = BaklavaHttpStatus(202),
-          headers = BaklavaHttpHeaders(Map.empty),
+          status = StatusCode(202),
+          headers = Seq.empty,
           requestBodyString = "",
           responseBodyString = "",
           requestContentType = Some("application/json"),
@@ -104,7 +105,7 @@ class RequestContentTypeSpec extends AnyFunSpec with Matchers {
           path = "/ping",
           pathDescription = None,
           pathSummary = None,
-          method = Some(BaklavaHttpMethod("GET")),
+          method = Some(Method("GET")),
           operationDescription = None,
           operationSummary = None,
           operationId = None,
@@ -119,8 +120,8 @@ class RequestContentTypeSpec extends AnyFunSpec with Matchers {
         ),
         response = BaklavaResponseContextSerializable(
           protocol = BaklavaHttpProtocol("HTTP/1.1"),
-          status = BaklavaHttpStatus(200),
-          headers = BaklavaHttpHeaders(Map.empty),
+          status = StatusCode(200),
+          headers = Seq.empty,
           requestBodyString = "",
           responseBodyString = "",
           requestContentType = None,

--- a/openapi/src/test/scala/pl/iterators/baklava/openapi/RequestContentTypeSpec.scala
+++ b/openapi/src/test/scala/pl/iterators/baklava/openapi/RequestContentTypeSpec.scala
@@ -4,7 +4,7 @@ import io.swagger.v3.oas.models.OpenAPI
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
 import pl.iterators.baklava.*
-import sttp.model.{Header => SttpHeader, Method, StatusCode}
+import sttp.model.{Method, StatusCode}
 
 import scala.jdk.CollectionConverters.*
 

--- a/openapi/src/test/scala/pl/iterators/baklava/openapi/ResponseContentTypeMergeSpec.scala
+++ b/openapi/src/test/scala/pl/iterators/baklava/openapi/ResponseContentTypeMergeSpec.scala
@@ -4,6 +4,7 @@ import io.swagger.v3.oas.models.OpenAPI
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
 import pl.iterators.baklava.*
+import sttp.model.{Header => SttpHeader, Method, StatusCode}
 
 import scala.jdk.CollectionConverters.*
 
@@ -54,7 +55,7 @@ class ResponseContentTypeMergeSpec extends AnyFunSpec with Matchers {
         path = "/items",
         pathDescription = None,
         pathSummary = None,
-        method = Some(BaklavaHttpMethod("GET")),
+        method = Some(Method("GET")),
         operationDescription = None,
         operationSummary = None,
         operationId = None,
@@ -69,8 +70,8 @@ class ResponseContentTypeMergeSpec extends AnyFunSpec with Matchers {
       ),
       response = BaklavaResponseContextSerializable(
         protocol = BaklavaHttpProtocol("HTTP/1.1"),
-        status = BaklavaHttpStatus(status),
-        headers = BaklavaHttpHeaders(Map.empty),
+        status = StatusCode(status),
+        headers = Seq.empty,
         requestBodyString = "",
         responseBodyString = body,
         requestContentType = None,

--- a/openapi/src/test/scala/pl/iterators/baklava/openapi/ResponseContentTypeMergeSpec.scala
+++ b/openapi/src/test/scala/pl/iterators/baklava/openapi/ResponseContentTypeMergeSpec.scala
@@ -4,7 +4,7 @@ import io.swagger.v3.oas.models.OpenAPI
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
 import pl.iterators.baklava.*
-import sttp.model.{Header => SttpHeader, Method, StatusCode}
+import sttp.model.{Method, StatusCode}
 
 import scala.jdk.CollectionConverters.*
 

--- a/openapi/src/test/scala/pl/iterators/baklava/openapi/ResponseOrderAndDescriptionSpec.scala
+++ b/openapi/src/test/scala/pl/iterators/baklava/openapi/ResponseOrderAndDescriptionSpec.scala
@@ -4,7 +4,7 @@ import io.swagger.v3.oas.models.OpenAPI
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
 import pl.iterators.baklava.*
-import sttp.model.{Header => SttpHeader, Method, StatusCode}
+import sttp.model.{Method, StatusCode}
 
 import scala.jdk.CollectionConverters.*
 

--- a/openapi/src/test/scala/pl/iterators/baklava/openapi/ResponseOrderAndDescriptionSpec.scala
+++ b/openapi/src/test/scala/pl/iterators/baklava/openapi/ResponseOrderAndDescriptionSpec.scala
@@ -4,6 +4,7 @@ import io.swagger.v3.oas.models.OpenAPI
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
 import pl.iterators.baklava.*
+import sttp.model.{Header => SttpHeader, Method, StatusCode}
 
 import scala.jdk.CollectionConverters.*
 
@@ -84,7 +85,7 @@ class ResponseOrderAndDescriptionSpec extends AnyFunSpec with Matchers {
         path = "/users",
         pathDescription = None,
         pathSummary = None,
-        method = Some(BaklavaHttpMethod("GET")),
+        method = Some(Method("GET")),
         operationDescription = None,
         operationSummary = None,
         operationId = None,
@@ -99,8 +100,8 @@ class ResponseOrderAndDescriptionSpec extends AnyFunSpec with Matchers {
       ),
       response = BaklavaResponseContextSerializable(
         protocol = BaklavaHttpProtocol("HTTP/1.1"),
-        status = BaklavaHttpStatus(200),
-        headers = BaklavaHttpHeaders(Map.empty),
+        status = StatusCode(200),
+        headers = Seq.empty,
         requestBodyString = "",
         responseBodyString = body,
         requestContentType = None,

--- a/pekkohttp/src/main/scala/pl/iterators/baklava/pekkohttp/BaklavaPekkoHttp.scala
+++ b/pekkohttp/src/main/scala/pl/iterators/baklava/pekkohttp/BaklavaPekkoHttp.scala
@@ -23,8 +23,6 @@ import pl.iterators.baklava.{
 }
 import sttp.model.{Header => SttpHeader, Method, StatusCode}
 
-import scala.language.implicitConversions
-
 import scala.concurrent.duration.Duration
 import scala.concurrent.{Await, ExecutionContext}
 import scala.reflect.ClassTag

--- a/pekkohttp/src/main/scala/pl/iterators/baklava/pekkohttp/BaklavaPekkoHttp.scala
+++ b/pekkohttp/src/main/scala/pl/iterators/baklava/pekkohttp/BaklavaPekkoHttp.scala
@@ -11,10 +11,7 @@ import org.apache.pekko.util.ByteString
 import pl.iterators.baklava.{
   BaklavaAssertionException,
   BaklavaHttpDsl,
-  BaklavaHttpHeaders,
-  BaklavaHttpMethod,
   BaklavaHttpProtocol,
-  BaklavaHttpStatus,
   BaklavaRequestContext,
   BaklavaResponseContext,
   BaklavaTestFrameworkDsl,
@@ -24,6 +21,9 @@ import pl.iterators.baklava.{
   FreeFormSchema,
   Schema
 }
+import sttp.model.{Header => SttpHeader, Method, StatusCode}
+
+import scala.language.implicitConversions
 
 import scala.concurrent.duration.Duration
 import scala.concurrent.{Await, ExecutionContext}
@@ -55,19 +55,13 @@ trait BaklavaPekkoHttp[TestFrameworkFragmentType, TestFrameworkFragmentsType, Te
   override type HttpRequest    = org.apache.pekko.http.scaladsl.model.HttpRequest
   override type HttpResponse   = org.apache.pekko.http.scaladsl.model.HttpResponse
 
-  override implicit def statusCodeToBaklavaStatusCodes(statusCode: HttpStatusCode): BaklavaHttpStatus = BaklavaHttpStatus(
-    statusCode.intValue()
-  )
-  override implicit def baklavaStatusCodeToStatusCode(baklavaHttpStatus: BaklavaHttpStatus): HttpStatusCode =
-    org.apache.pekko.http.scaladsl.model.StatusCode.int2StatusCode(
-      baklavaHttpStatus.status
-    )
+  override implicit def statusCodeToBaklavaStatusCodes(statusCode: HttpStatusCode): StatusCode = StatusCode(statusCode.intValue())
+  override implicit def baklavaStatusCodeToStatusCode(status: StatusCode): HttpStatusCode      =
+    org.apache.pekko.http.scaladsl.model.StatusCode.int2StatusCode(status.code)
 
-  override implicit def httpMethodToBaklavaHttpMethod(method: HttpMethod): BaklavaHttpMethod = BaklavaHttpMethod(
-    method.value
-  )
-  override implicit def baklavaHttpMethodToHttpMethod(baklavaHttpMethod: BaklavaHttpMethod): HttpMethod =
-    baklavaHttpMethod.value match {
+  override implicit def httpMethodToBaklavaHttpMethod(method: HttpMethod): Method = Method(method.value)
+  override implicit def baklavaHttpMethodToHttpMethod(method: Method): HttpMethod =
+    method.method match {
       case "GET"     => org.apache.pekko.http.scaladsl.model.HttpMethods.GET
       case "POST"    => org.apache.pekko.http.scaladsl.model.HttpMethods.POST
       case "PUT"     => org.apache.pekko.http.scaladsl.model.HttpMethods.PUT
@@ -77,7 +71,7 @@ trait BaklavaPekkoHttp[TestFrameworkFragmentType, TestFrameworkFragmentsType, Te
       case "HEAD"    => org.apache.pekko.http.scaladsl.model.HttpMethods.HEAD
       case "TRACE"   => org.apache.pekko.http.scaladsl.model.HttpMethods.TRACE
       case "CONNECT" => org.apache.pekko.http.scaladsl.model.HttpMethods.CONNECT
-      case _         => org.apache.pekko.http.scaladsl.model.HttpMethod.custom(baklavaHttpMethod.value)
+      case other     => org.apache.pekko.http.scaladsl.model.HttpMethod.custom(other)
     }
 
   override implicit def baklavaHttpProtocolToHttpProtocol(baklavaHttpProtocol: BaklavaHttpProtocol): HttpProtocol =
@@ -88,21 +82,16 @@ trait BaklavaPekkoHttp[TestFrameworkFragmentType, TestFrameworkFragmentsType, Te
       case _          => throw new IllegalArgumentException(s"Unsupported protocol: ${baklavaHttpProtocol.protocol}")
     }
 
-  override implicit def httpProtocolToBaklavaHttpProtocol(protocol: HttpProtocol): BaklavaHttpProtocol = BaklavaHttpProtocol(
-    protocol.value
-  )
+  override implicit def httpProtocolToBaklavaHttpProtocol(protocol: HttpProtocol): BaklavaHttpProtocol =
+    BaklavaHttpProtocol(protocol.value)
 
-  override implicit def baklavaHeadersToHttpHeaders(headers: BaklavaHttpHeaders): HttpHeaders = headers.headers
-    .map { case (k, v) =>
-      HttpHeader.parse(k, v)
-    }
-    .toSeq
-    .collect { case HttpHeader.ParsingResult.Ok(header, _) =>
-      header
-    }
-  override implicit def httpHeadersToBaklavaHeaders(headers: HttpHeaders): BaklavaHttpHeaders = BaklavaHttpHeaders(
-    headers.map(h => h.name() -> h.value()).toMap
-  )
+  override implicit def baklavaHeadersToHttpHeaders(headers: Seq[SttpHeader]): HttpHeaders =
+    headers
+      .map(h => HttpHeader.parse(h.name, h.value))
+      .collect { case HttpHeader.ParsingResult.Ok(header, _) => header }
+
+  override implicit def httpHeadersToBaklavaHeaders(headers: HttpHeaders): Seq[SttpHeader] =
+    headers.map(h => SttpHeader(h.name(), h.value())).toSeq
 
   override def httpResponseToBaklavaResponseContext[T: FromEntityUnmarshaller: ClassTag](
       request: HttpRequest,
@@ -122,9 +111,9 @@ trait BaklavaPekkoHttp[TestFrameworkFragmentType, TestFrameworkFragmentsType, Te
     val requestString  = Await.result(implicitly[FromEntityUnmarshaller[String]].apply(request.entity), Duration.Inf)
 
     BaklavaResponseContext(
-      response.protocol,
-      response.status,
-      response.headers,
+      httpProtocolToBaklavaHttpProtocol(response.protocol),
+      statusCodeToBaklavaStatusCodes(response.status),
+      httpHeadersToBaklavaHeaders(response.headers),
       Try(Await.result(implicitly[FromEntityUnmarshaller[T]].apply(firstResponseEntity), Duration.Inf)) match {
         case Success(value)     => value
         case Failure(exception) =>
@@ -167,8 +156,8 @@ trait BaklavaPekkoHttp[TestFrameworkFragmentType, TestFrameworkFragmentsType, Te
   )(implicit
       requestBody: ToEntityMarshaller[RequestBody]
   ): HttpRequest = {
-    new RequestBuilder(ctx.method.get)(ctx.path, ctx.body)
-      .withHeaders(ctx.headers)
+    new RequestBuilder(baklavaHttpMethodToHttpMethod(ctx.method.get))(ctx.path, ctx.body)
+      .withHeaders(baklavaHeadersToHttpHeaders(ctx.headers))
   }
 
   override implicit protected def emptyToRequestBodyType: ToEntityMarshaller[EmptyBody] =

--- a/simple/src/main/scala/pl/iterators/baklava/simple/BaklavaDslFormatterSimple.scala
+++ b/simple/src/main/scala/pl/iterators/baklava/simple/BaklavaDslFormatterSimple.scala
@@ -50,13 +50,13 @@ class BaklavaDslFormatterSimple extends BaklavaDslFormatter {
     val endpoints = calls
       .groupBy(c => (c.request.method, c.request.symbolicPath))
       .toList
-      .sortBy(s => (s._1._2, s._1._1.map(_.value).getOrElse("UNDEFINED")))
+      .sortBy(s => (s._1._2, s._1._1.map(_.method).getOrElse("UNDEFINED")))
 
     val indexRows = endpoints.map { case ((method, symbolicPath), endpointCalls) =>
-      val methodName = method.map(_.value).getOrElse("UNDEFINED")
+      val methodName = method.map(_.method).getOrElse("UNDEFINED")
       val filename   = toFilename(s"$methodName $symbolicPath")
 
-      writeFile(s"$dirName/$filename", generateEndpointPage(endpointCalls.sortBy(_.response.status.status)))
+      writeFile(s"$dirName/$filename", generateEndpointPage(endpointCalls.sortBy(_.response.status.code)))
 
       s"""<li><a href="${escHtmlAttr(filename)}"><span class="method method-${escHtmlAttr(methodName)}">${escHtml(
           methodName
@@ -77,7 +77,7 @@ class BaklavaDslFormatterSimple extends BaklavaDslFormatter {
   private[simple] def generateEndpointPage(calls: Seq[BaklavaSerializableCall]): String = {
     require(calls.nonEmpty, "generateEndpointPage called with empty calls")
     val request    = calls.head.request
-    val methodName = request.method.map(_.value).getOrElse("UNDEFINED")
+    val methodName = request.method.map(_.method).getOrElse("UNDEFINED")
 
     val metaRows = List(
       request.operationSummary.map(s => metaRow("Summary", escHtml(s))),
@@ -123,8 +123,8 @@ class BaklavaDslFormatterSimple extends BaklavaDslFormatter {
         s"<details><summary>Request schema (JSON Schema v7)</summary><pre>${escHtml(baklavaSchemaToJsonSchemaV7(schema))}</pre></details>"
       )
 
-    val responseSections = calls.sortBy(c => (c.response.status.status, c.request.responseDescription.getOrElse(""))).map { c =>
-      val status    = c.response.status.status
+    val responseSections = calls.sortBy(c => (c.response.status.code, c.request.responseDescription.getOrElse(""))).map { c =>
+      val status    = c.response.status.code
       val statusCss = if (status < 300) "2xx" else if (status < 400) "3xx" else if (status < 500) "4xx" else "5xx"
       val desc      = c.request.responseDescription.map(d => s"<p>${escHtml(d)}</p>").getOrElse("")
 
@@ -144,9 +144,9 @@ class BaklavaDslFormatterSimple extends BaklavaDslFormatter {
       // Declared response headers (from the DSL) with their captured example values.
       val responseHeadersSection = Option.when(c.request.responseHeaders.nonEmpty) {
         val rows = c.request.responseHeaders.sortBy(_.name).map { h =>
-          val example = c.response.headers.headers
-            .find(_._1.toLowerCase == h.name.toLowerCase)
-            .map { case (_, v) => s" = <code>${escHtml(v)}</code>" }
+          val example = c.response.headers
+            .find(_.name.toLowerCase == h.name.toLowerCase)
+            .map(sent => s" = <code>${escHtml(sent.value)}</code>")
             .getOrElse("")
           metaRow(
             escHtml(h.name) + (if (h.schema.required) " <span class=\"required\">*</span>" else ""),

--- a/simple/src/test/scala/pl/iterators/baklava/simple/BaklavaDslFormatterSimpleSpec.scala
+++ b/simple/src/test/scala/pl/iterators/baklava/simple/BaklavaDslFormatterSimpleSpec.scala
@@ -4,6 +4,7 @@ import io.circe.parser
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
 import pl.iterators.baklava.*
+import sttp.model.{Header => SttpHeader, Method, StatusCode}
 
 class BaklavaDslFormatterSimpleSpec extends AnyFunSpec with Matchers {
 
@@ -50,7 +51,7 @@ class BaklavaDslFormatterSimpleSpec extends AnyFunSpec with Matchers {
           )
         ),
         response = base.response.copy(
-          headers = BaklavaHttpHeaders(Map("x-rate-limit" -> "100", "X-Request-Id" -> "req-42"))
+          headers = Seq(sttp.model.Header("x-rate-limit", "100"), sttp.model.Header("X-Request-Id", "req-42"))
         )
       )
       val html = generator.generateEndpointPage(Seq(withHdrs))
@@ -129,7 +130,7 @@ class BaklavaDslFormatterSimpleSpec extends AnyFunSpec with Matchers {
         path = "/users",
         pathDescription = None,
         pathSummary = None,
-        method = Some(BaklavaHttpMethod("POST")),
+        method = Some(Method("POST")),
         operationDescription = None,
         operationSummary = None,
         operationId = None,
@@ -144,8 +145,8 @@ class BaklavaDslFormatterSimpleSpec extends AnyFunSpec with Matchers {
       ),
       response = BaklavaResponseContextSerializable(
         protocol = BaklavaHttpProtocol("HTTP/1.1"),
-        status = BaklavaHttpStatus(status),
-        headers = BaklavaHttpHeaders(Map.empty),
+        status = StatusCode(status),
+        headers = Seq.empty,
         requestBodyString = requestBody,
         responseBodyString = responseBody,
         requestContentType = Some("application/json"),

--- a/simple/src/test/scala/pl/iterators/baklava/simple/BaklavaDslFormatterSimpleSpec.scala
+++ b/simple/src/test/scala/pl/iterators/baklava/simple/BaklavaDslFormatterSimpleSpec.scala
@@ -4,7 +4,7 @@ import io.circe.parser
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
 import pl.iterators.baklava.*
-import sttp.model.{Header => SttpHeader, Method, StatusCode}
+import sttp.model.{Method, StatusCode}
 
 class BaklavaDslFormatterSimpleSpec extends AnyFunSpec with Matchers {
 

--- a/tsrest/src/main/scala/pl/iterators/baklava/tsrest/BaklavaDslFormatterTsRest.scala
+++ b/tsrest/src/main/scala/pl/iterators/baklava/tsrest/BaklavaDslFormatterTsRest.scala
@@ -1,6 +1,7 @@
 package pl.iterators.baklava.tsrest
 
 import pl.iterators.baklava.*
+import sttp.model.Method
 
 import java.io.{File, FileWriter, PrintWriter}
 import scala.util.Using
@@ -127,7 +128,7 @@ class BaklavaDslFormatterTsRest extends BaklavaDslFormatter {
 
   private def createContractForGroup(
       contractName: String,
-      endpointsWithCalls: Seq[((Option[BaklavaHttpMethod], String), Seq[BaklavaSerializableCall])]
+      endpointsWithCalls: Seq[((Option[Method], String), Seq[BaklavaSerializableCall])]
   ): String = {
     val contractConstName = toCamelCase(contractName) + "Contract"
     val code              =
@@ -146,14 +147,14 @@ class BaklavaDslFormatterTsRest extends BaklavaDslFormatter {
 
   // Contract endpoint generator
   private def createContractForEndpoint(
-      endpoint: ((Option[BaklavaHttpMethod], String), Seq[BaklavaSerializableCall])
+      endpoint: ((Option[Method], String), Seq[BaklavaSerializableCall])
   ): String = {
     val ((httpMethodOpt, _), calls) = endpoint
     require(
       calls.nonEmpty,
-      s"createContractForEndpoint called with empty calls for method=${httpMethodOpt.map(_.value)}"
+      s"createContractForEndpoint called with empty calls for method=${httpMethodOpt.map(_.method)}"
     )
-    val httpMethod = httpMethodOpt.map(_.value).getOrElse("ANY").toLowerCase
+    val httpMethod = httpMethodOpt.map(_.method).getOrElse("ANY").toLowerCase
 
     val firstCall   = calls.head
     val req         = firstCall.request
@@ -192,7 +193,7 @@ class BaklavaDslFormatterTsRest extends BaklavaDslFormatter {
 
     // --- Responses ---
     val responses = calls
-      .groupBy(_.response.status.status)
+      .groupBy(_.response.status.code)
       .toList
       .sortBy(_._1)
       .map { case (status, respCalls) =>


### PR DESCRIPTION
## Summary

**Breaking change.** Closes #34. Per discussion on the issue, Option A (full replacement) is implemented.

The three wrapper types from \`BaklavaHttpDsl\` are removed entirely and replaced with sttp-model's idiomatic equivalents:

| Before | After |
|---|---|
| \`BaklavaHttpMethod(value: String)\` | \`sttp.model.Method\` (\`.method\` accessor) |
| \`BaklavaHttpStatus(status: Int)\` | \`sttp.model.StatusCode\` (\`.code\` accessor) |
| \`BaklavaHttpHeaders(headers: Map[String, String])\` | \`Seq[sttp.model.Header]\` |

\`BaklavaHttpProtocol\` is kept as-is (sttp-model has no HTTP-protocol equivalent; it's a simple string wrapper for the HTTP version).

## Why

- **Idiomatic sttp types everywhere.** sttp-model is the Scala HTTP lingua-franca; now Baklava consumers can pass Baklava types directly to other sttp-adjacent libraries.
- **\`Seq[Header]\` preserves duplicate header names.** The old Map-based representation silently lost multiple \`Set-Cookie\` headers etc.
- **Constants.** \`Method.GET\`, \`StatusCode.Ok\`, etc. replace the stringly-typed construction.

## Migration

User-facing migration is a one-time search-and-replace:

\`\`\`scala
// before
BaklavaHttpMethod(\"GET\")
BaklavaHttpStatus(200)
BaklavaHttpHeaders(Map(\"X-Id\" -> \"abc\"))

// after
sttp.model.Method(\"GET\")        // or Method.GET directly
sttp.model.StatusCode(200)      // or StatusCode.Ok etc.
Seq(sttp.model.Header(\"X-Id\", \"abc\"))
\`\`\`

Field accessors: \`.value\` → \`.method\`, \`.status\` → \`.code\`, and map-style header lookups become Seq \`.find\` calls.

## Scope

- New dependency on baklava-core: \`com.softwaremill.sttp.model:core:1.7.17\` (transitively on all consumers).
- pekko-http and http4s adapters updated to convert between their native types and sttp-model. Explicit conversion calls at construction sites avoid a Scala 3 implicit-resolution quirk over type aliases like \`type HttpHeaders = Seq[HttpHeader]\`.
- On-disk serialized calls under \`target/baklava/calls/*.json\` are incompatible across the upgrade — transient artifacts, cleaned on every test run, so no real-world user impact.

## Test plan

- [x] \`CI=true sbt '+test'\` green on Scala 2.13.18 and 3.3.7
  - Scala 2.13: 89 tests (core 7, simple 7, tsrest 15, openapi 60)
  - Scala 3.3.7: 96 tests (core 14, simple 7, tsrest 15, openapi 60)
- [x] All existing adapter conversions (pekko-http, http4s) exercised via PetStore specs end-to-end

## Versioning

Suggest a minor version bump (\`1.1.x → 1.2.0\`) to reflect the breaking API change.

Closes #34