### PR TITLE
test: comprehensive gold/snapshot test for all three generators

### DIFF
--- a/openapi/src/test/resources/gold/openapi/openapi.yaml
+++ b/openapi/src/test/resources/gold/openapi/openapi.yaml
@@ -1,0 +1,1033 @@
+openapi: 3.0.1
+paths:
+  /auth/login:
+    summary: Authentication
+    description: Authenticate against the API
+    post:
+      tags:
+      - Auth
+      summary: Login
+      description: Exchange HTTP Basic credentials for a JWT token
+      operationId: login
+      requestBody:
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              required:
+              - client_id
+              - grant_type
+              type: object
+              properties:
+                client_id:
+                  type: string
+                grant_type:
+                  type: string
+              x-class: LoginForm
+            examples:
+              Successful login:
+                value: client_id=web&grant_type=password
+      responses:
+        "200":
+          description: Successful login
+          content:
+            application/json:
+              schema:
+                required:
+                - token
+                - user
+                type: object
+                properties:
+                  token:
+                    type: string
+                  user:
+                    required:
+                    - email
+                    - id
+                    - name
+                    - role
+                    type: object
+                    properties:
+                      id:
+                        type: string
+                        format: uuid
+                      email:
+                        type: string
+                      name:
+                        type: string
+                      role:
+                        type: string
+                        description: User role within the system
+                        enum:
+                        - admin
+                        - member
+                        - guest
+                    x-class: User
+                x-class: LoginResponse
+              examples:
+                Successful login:
+                  value: |-
+                    {
+                      "token" : "jwt.token.xyz",
+                      "user" : {
+                        "id" : "00000000-0000-0000-0000-000000000001",
+                        "email" : "alice@example.com",
+                        "name" : "Alice",
+                        "role" : "admin"
+                      }
+                    }
+        "401":
+          description: Invalid credentials
+          content:
+            application/json:
+              schema:
+                required:
+                - code
+                - message
+                type: object
+                properties:
+                  code:
+                    type: string
+                  message:
+                    type: string
+                  details:
+                    type: array
+                    items:
+                      type: string
+                x-class: ErrorResponse
+              examples:
+                Invalid credentials:
+                  value: |-
+                    {
+                      "code" : "unauthorized",
+                      "message" : "Bad credentials",
+                      "details" : null
+                    }
+      security:
+      - basicAuth: []
+  /health:
+    summary: Health
+    description: Liveness probe
+    get:
+      tags:
+      - System
+      summary: Liveness probe
+      description: Return service liveness — no authentication required
+      operationId: health
+      responses:
+        "200":
+          description: Service is alive
+          content:
+            application/json:
+              schema:
+                required:
+                - status
+                - uptimeSeconds
+                type: object
+                properties:
+                  status:
+                    type: string
+                  uptimeSeconds:
+                    type: integer
+                    format: int64
+                x-class: HealthResponse
+              examples:
+                Service is alive:
+                  value: |-
+                    {
+                      "status" : "ok",
+                      "uptimeSeconds" : 12345
+                    }
+      security: []
+  /me:
+    summary: Current user
+    description: The authenticated caller
+    get:
+      tags:
+      - Auth
+      summary: Who am I
+      description: Return the profile of the currently authenticated user
+      operationId: me
+      responses:
+        "200":
+          description: Authenticated user profile
+          content:
+            application/json:
+              schema:
+                required:
+                - email
+                - id
+                - name
+                - role
+                type: object
+                properties:
+                  id:
+                    type: string
+                    format: uuid
+                  email:
+                    type: string
+                  name:
+                    type: string
+                  role:
+                    type: string
+                    description: User role within the system
+                    enum:
+                    - admin
+                    - member
+                    - guest
+                x-class: User
+              examples:
+                Authenticated user profile:
+                  value: |-
+                    {
+                      "id" : "00000000-0000-0000-0000-000000000001",
+                      "email" : "alice@example.com",
+                      "name" : "Alice",
+                      "role" : "admin"
+                    }
+      security:
+      - bearerAuth: []
+  /projects:
+    summary: Projects
+    description: Project collection
+    get:
+      tags:
+      - Projects
+      summary: List projects
+      description: "List projects, optionally filtered by status"
+      operationId: listProjects
+      parameters:
+      - name: status
+        in: query
+        description: Filter by lifecycle state
+        required: false
+        explode: true
+        schema:
+          type: string
+          description: Lifecycle state of a project
+          enum:
+          - active
+          - archived
+          - draft
+      responses:
+        "200":
+          description: All active projects / All archived projects
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  required:
+                  - createdAt
+                  - id
+                  - name
+                  - ownerId
+                  - status
+                  type: object
+                  properties:
+                    name:
+                      type: string
+                    description:
+                      type: string
+                    id:
+                      type: integer
+                      format: int64
+                    status:
+                      type: string
+                      description: Lifecycle state of a project
+                      enum:
+                      - active
+                      - archived
+                      - draft
+                    createdAt:
+                      type: string
+                    ownerId:
+                      type: string
+                      format: uuid
+                  x-class: Project
+              examples:
+                All active projects:
+                  value: |-
+                    [
+                      {
+                        "id" : 42,
+                        "name" : "Apollo",
+                        "description" : "Mission control",
+                        "status" : "active",
+                        "ownerId" : "00000000-0000-0000-0000-000000000001",
+                        "createdAt" : "2026-01-01T00:00:00Z"
+                      }
+                    ]
+                All archived projects:
+                  value: |-
+                    [
+                      {
+                        "id" : 7,
+                        "name" : "Gemini",
+                        "description" : null,
+                        "status" : "archived",
+                        "ownerId" : "00000000-0000-0000-0000-000000000001",
+                        "createdAt" : "2025-06-01T00:00:00Z"
+                      }
+                    ]
+      security:
+      - oauth2:
+        - projects:read
+        - projects:write
+    post:
+      tags:
+      - Projects
+      summary: Create project
+      description: Create a new project
+      operationId: createProject
+      requestBody:
+        content:
+          application/json:
+            schema:
+              required:
+              - name
+              - status
+              type: object
+              properties:
+                name:
+                  type: string
+                description:
+                  type: string
+                status:
+                  type: string
+                  description: Lifecycle state of a project
+                  enum:
+                  - active
+                  - archived
+                  - draft
+              x-class: CreateProjectRequest
+            examples:
+              Project created:
+                value: |-
+                  {
+                    "name" : "Apollo",
+                    "description" : "Mission control",
+                    "status" : "active"
+                  }
+      responses:
+        "201":
+          description: Project created
+          content:
+            application/json:
+              schema:
+                required:
+                - createdAt
+                - id
+                - name
+                - ownerId
+                - status
+                type: object
+                properties:
+                  name:
+                    type: string
+                  description:
+                    type: string
+                  id:
+                    type: integer
+                    format: int64
+                  status:
+                    type: string
+                    description: Lifecycle state of a project
+                    enum:
+                    - active
+                    - archived
+                    - draft
+                  createdAt:
+                    type: string
+                  ownerId:
+                    type: string
+                    format: uuid
+                x-class: Project
+              examples:
+                Project created:
+                  value: |-
+                    {
+                      "id" : 42,
+                      "name" : "Apollo",
+                      "description" : "Mission control",
+                      "status" : "active",
+                      "ownerId" : "00000000-0000-0000-0000-000000000001",
+                      "createdAt" : "2026-01-01T00:00:00Z"
+                    }
+        "400":
+          description: Validation failed
+          content:
+            application/json:
+              schema:
+                required:
+                - code
+                - message
+                type: object
+                properties:
+                  code:
+                    type: string
+                  message:
+                    type: string
+                  details:
+                    type: array
+                    items:
+                      type: string
+                x-class: ErrorResponse
+              examples:
+                Validation failed:
+                  value: |-
+                    {
+                      "code" : "validation",
+                      "message" : "One or more fields are invalid",
+                      "details" : [
+                        "name: must not be blank"
+                      ]
+                    }
+      security:
+      - oauth2:
+        - projects:read
+        - projects:write
+  /projects/{projectId}:
+    summary: Project by ID
+    description: Project detail
+    patch:
+      tags:
+      - Projects
+      summary: Patch project
+      description: Partially update a project
+      operationId: patchProject
+      parameters:
+      - name: projectId
+        in: path
+        description: The project ID
+        required: true
+        schema:
+          type: integer
+          format: int64
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                name:
+                  type: string
+                description:
+                  type: string
+                status:
+                  type: string
+                  description: Lifecycle state of a project
+                  enum:
+                  - active
+                  - archived
+                  - draft
+              x-class: PatchProjectRequest
+            examples:
+              Project updated:
+                value: |-
+                  {
+                    "name" : null,
+                    "description" : "Updated desc",
+                    "status" : null
+                  }
+      responses:
+        "200":
+          description: Project updated
+          content:
+            application/json:
+              schema:
+                required:
+                - createdAt
+                - id
+                - name
+                - ownerId
+                - status
+                type: object
+                properties:
+                  name:
+                    type: string
+                  description:
+                    type: string
+                  id:
+                    type: integer
+                    format: int64
+                  status:
+                    type: string
+                    description: Lifecycle state of a project
+                    enum:
+                    - active
+                    - archived
+                    - draft
+                  createdAt:
+                    type: string
+                  ownerId:
+                    type: string
+                    format: uuid
+                x-class: Project
+              examples:
+                Project updated:
+                  value: |-
+                    {
+                      "id" : 42,
+                      "name" : "Apollo",
+                      "description" : "Updated desc",
+                      "status" : "active",
+                      "ownerId" : "00000000-0000-0000-0000-000000000001",
+                      "createdAt" : "2026-01-01T00:00:00Z"
+                    }
+      security:
+      - oauth2:
+        - projects:read
+        - projects:write
+  /projects/{projectId}/tasks:
+    summary: Project tasks
+    description: Tasks within a project
+    get:
+      tags:
+      - Tasks
+      summary: List tasks
+      description: List all tasks in a project
+      operationId: listTasks
+      parameters:
+      - name: projectId
+        in: path
+        description: The project ID
+        required: true
+        schema:
+          type: integer
+          format: int64
+      responses:
+        "200":
+          description: All tasks in the project
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  required:
+                  - done
+                  - id
+                  - priority
+                  - title
+                  type: object
+                  properties:
+                    priority:
+                      type: string
+                      description: Task priority level
+                      enum:
+                      - low
+                      - medium
+                      - high
+                    description:
+                      type: string
+                    id:
+                      type: integer
+                      format: int64
+                    done:
+                      type: boolean
+                    title:
+                      type: string
+                  x-class: Task
+              examples:
+                All tasks in the project:
+                  value: |-
+                    [
+                      {
+                        "id" : 101,
+                        "title" : "Wire up telemetry",
+                        "description" : "Prometheus + Grafana",
+                        "done" : false,
+                        "priority" : "high"
+                      },
+                      {
+                        "id" : 102,
+                        "title" : "Write docs",
+                        "description" : null,
+                        "done" : true,
+                        "priority" : "low"
+                      }
+                    ]
+      security:
+      - oauth2:
+        - projects:read
+        - projects:write
+    post:
+      tags:
+      - Tasks
+      summary: Create task
+      description: Create a task in a project
+      operationId: createTask
+      parameters:
+      - name: projectId
+        in: path
+        description: The project ID
+        required: true
+        schema:
+          type: integer
+          format: int64
+      requestBody:
+        content:
+          application/json:
+            schema:
+              required:
+              - priority
+              - title
+              type: object
+              properties:
+                title:
+                  type: string
+                description:
+                  type: string
+                priority:
+                  type: string
+                  description: Task priority level
+                  enum:
+                  - low
+                  - medium
+                  - high
+              x-class: CreateTaskRequest
+            examples:
+              Task created:
+                value: |-
+                  {
+                    "title" : "New task",
+                    "description" : null,
+                    "priority" : "medium"
+                  }
+      responses:
+        "201":
+          description: Task created
+          headers:
+            Location:
+              description: URL of the newly created task
+              required: true
+              schema:
+                type: string
+              example: /projects/42/tasks/101
+          content:
+            application/json:
+              schema:
+                required:
+                - done
+                - id
+                - priority
+                - title
+                type: object
+                properties:
+                  priority:
+                    type: string
+                    description: Task priority level
+                    enum:
+                    - low
+                    - medium
+                    - high
+                  description:
+                    type: string
+                  id:
+                    type: integer
+                    format: int64
+                  done:
+                    type: boolean
+                  title:
+                    type: string
+                x-class: Task
+              examples:
+                Task created:
+                  value: |-
+                    {
+                      "id" : 101,
+                      "title" : "Wire up telemetry",
+                      "description" : "Prometheus + Grafana",
+                      "done" : false,
+                      "priority" : "high"
+                    }
+      security:
+      - oauth2:
+        - projects:read
+        - projects:write
+  /users:
+    summary: Users
+    description: User collection
+    get:
+      tags:
+      - Users
+      summary: List users
+      description: List users with pagination and optional role filter
+      operationId: listUsers
+      parameters:
+      - name: page
+        in: query
+        description: Page number (1-indexed)
+        required: false
+        explode: true
+        schema:
+          type: integer
+          format: int32
+      - name: limit
+        in: query
+        description: Items per page (max 100)
+        required: false
+        explode: true
+        schema:
+          type: integer
+          format: int32
+      - name: role
+        in: query
+        description: Filter by role
+        required: false
+        explode: true
+        schema:
+          type: string
+          description: User role within the system
+          enum:
+          - admin
+          - member
+          - guest
+      responses:
+        "200":
+          description: First page of users
+          headers:
+            X-Rate-Limit-Remaining:
+              description: Calls remaining in the current window
+              required: true
+              schema:
+                type: integer
+                format: int32
+              example: "59"
+          content:
+            application/json:
+              schema:
+                required:
+                - limit
+                - page
+                - total
+                - users
+                type: object
+                properties:
+                  users:
+                    type: array
+                    items:
+                      required:
+                      - email
+                      - id
+                      - name
+                      - role
+                      type: object
+                      properties:
+                        id:
+                          type: string
+                          format: uuid
+                        email:
+                          type: string
+                        name:
+                          type: string
+                        role:
+                          type: string
+                          description: User role within the system
+                          enum:
+                          - admin
+                          - member
+                          - guest
+                      x-class: User
+                  total:
+                    type: integer
+                    format: int32
+                  page:
+                    type: integer
+                    format: int32
+                  limit:
+                    type: integer
+                    format: int32
+                x-class: PaginatedUsers
+              examples:
+                First page of users:
+                  value: |-
+                    {
+                      "users" : [
+                        {
+                          "id" : "00000000-0000-0000-0000-000000000001",
+                          "email" : "alice@example.com",
+                          "name" : "Alice",
+                          "role" : "admin"
+                        },
+                        {
+                          "id" : "00000000-0000-0000-0000-000000000002",
+                          "email" : "bob@example.com",
+                          "name" : "Bob",
+                          "role" : "member"
+                        }
+                      ],
+                      "total" : 2,
+                      "page" : 1,
+                      "limit" : 20
+                    }
+      security:
+      - bearerAuth: []
+  /users/{userId}:
+    summary: User by ID
+    description: Single user operations
+    get:
+      tags:
+      - Users
+      summary: Get user
+      description: Fetch a single user by UUID
+      operationId: getUser
+      parameters:
+      - name: userId
+        in: path
+        description: The user's UUID
+        required: true
+        schema:
+          type: string
+          format: uuid
+      responses:
+        "200":
+          description: User found
+          content:
+            application/json:
+              schema:
+                required:
+                - email
+                - id
+                - name
+                - role
+                type: object
+                properties:
+                  id:
+                    type: string
+                    format: uuid
+                  email:
+                    type: string
+                  name:
+                    type: string
+                  role:
+                    type: string
+                    description: User role within the system
+                    enum:
+                    - admin
+                    - member
+                    - guest
+                x-class: User
+              examples:
+                User found:
+                  value: |-
+                    {
+                      "id" : "00000000-0000-0000-0000-000000000001",
+                      "email" : "alice@example.com",
+                      "name" : "Alice",
+                      "role" : "admin"
+                    }
+        "404":
+          description: User not found
+          content:
+            application/json:
+              schema:
+                required:
+                - code
+                - message
+                type: object
+                properties:
+                  code:
+                    type: string
+                  message:
+                    type: string
+                  details:
+                    type: array
+                    items:
+                      type: string
+                x-class: ErrorResponse
+              examples:
+                User not found:
+                  value: |-
+                    {
+                      "code" : "not_found",
+                      "message" : "No such user",
+                      "details" : null
+                    }
+      security:
+      - bearerAuth: []
+    put:
+      tags:
+      - Users
+      summary: Update user
+      description: Replace a user's profile (admin only)
+      operationId: updateUser
+      parameters:
+      - name: userId
+        in: path
+        description: The user's UUID
+        required: true
+        schema:
+          type: string
+          format: uuid
+      requestBody:
+        content:
+          application/json:
+            schema:
+              required:
+              - name
+              - role
+              type: object
+              properties:
+                name:
+                  type: string
+                role:
+                  type: string
+                  description: User role within the system
+                  enum:
+                  - admin
+                  - member
+                  - guest
+              x-class: UpdateUserRequest
+            examples:
+              User updated:
+                value: |-
+                  {
+                    "name" : "Alice Updated",
+                    "role" : "admin"
+                  }
+      responses:
+        "200":
+          description: User updated
+          content:
+            application/json:
+              schema:
+                required:
+                - email
+                - id
+                - name
+                - role
+                type: object
+                properties:
+                  id:
+                    type: string
+                    format: uuid
+                  email:
+                    type: string
+                  name:
+                    type: string
+                  role:
+                    type: string
+                    description: User role within the system
+                    enum:
+                    - admin
+                    - member
+                    - guest
+                x-class: User
+              examples:
+                User updated:
+                  value: |-
+                    {
+                      "id" : "00000000-0000-0000-0000-000000000001",
+                      "email" : "alice@example.com",
+                      "name" : "Alice Updated",
+                      "role" : "admin"
+                    }
+      security:
+      - bearerAuth: []
+    delete:
+      tags:
+      - Users
+      summary: Delete user
+      description: Delete a user
+      operationId: deleteUser
+      parameters:
+      - name: userId
+        in: path
+        description: The user's UUID
+        required: true
+        schema:
+          type: string
+          format: uuid
+      responses:
+        "204":
+          description: User deleted
+      security:
+      - bearerAuth: []
+  /webhooks:
+    summary: Webhooks
+    description: Inbound webhooks
+    post:
+      tags:
+      - Webhooks
+      summary: Deliver webhook
+      description: Accept a webhook payload
+      operationId: deliverWebhook
+      requestBody:
+        content:
+          application/json:
+            schema:
+              required:
+              - data
+              - event
+              type: object
+              properties:
+                event:
+                  type: string
+                data:
+                  type: string
+              x-class: WebhookPayload
+            examples:
+              Legacy plain-text ack:
+                value: |-
+                  {
+                    "event" : "order.created",
+                    "data" : "{\"id\":1}"
+                  }
+              Webhook accepted:
+                value: |-
+                  {
+                    "event" : "order.created",
+                    "data" : "{\"id\":1}"
+                  }
+      responses:
+        "202":
+          description: Legacy plain-text ack / Webhook accepted
+          content:
+            application/json:
+              schema:
+                required:
+                - received
+                type: object
+                properties:
+                  received:
+                    type: boolean
+                x-class: WebhookAck
+              examples:
+                Webhook accepted:
+                  value: |-
+                    {
+                      "received" : true
+                    }
+            text/plain; charset=UTF-8:
+              schema:
+                type: string
+              examples:
+                Legacy plain-text ack:
+                  value: ACK
+      security:
+      - apiKey: []
+components:
+  securitySchemes:
+    basicAuth:
+      type: http
+      description: HTTP Basic for the login endpoint only
+      scheme: basic
+    bearerAuth:
+      type: http
+      description: JWT token issued by /auth/login
+      scheme: bearer
+      bearerFormat: JWT
+    oauth2:
+      type: oauth2
+      flows:
+        authorizationCode:
+          authorizationUrl: https://example.com/oauth/authorize
+          tokenUrl: https://example.com/oauth/token
+          scopes:
+            projects:read: Read projects
+            projects:write: Create/update projects
+    apiKey:
+      type: apiKey
+      description: API key for webhook delivery
+      name: X-API-Key
+      in: header

--- a/openapi/src/test/resources/gold/openapi/openapi.yml
+++ b/openapi/src/test/resources/gold/openapi/openapi.yml
@@ -1,4 +1,10 @@
 openapi: 3.0.1
+info:
+  title: Baklava Comprehensive Gold Spec
+  description: Fixture API used by the gold test to exercise all three generators.
+  version: 0.0.0-test
+servers:
+- url: /
 paths:
   /auth/login:
     summary: Authentication

--- a/openapi/src/test/resources/gold/simple/DELETE__users___userId__-cf0347bd.html
+++ b/openapi/src/test/resources/gold/simple/DELETE__users___userId__-cf0347bd.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html><html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1"><title>DELETE /users/{userId}</title><style>
+  *, *::before, *::after { box-sizing: border-box; }
+  body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif; margin: 0; padding: 20px 40px; background: #f8f9fa; color: #1a1a2e; line-height: 1.5; }
+  h1 { font-size: 1.6rem; font-weight: 600; margin: 0 0 20px; color: #16213e; }
+  a { color: #0d6efd; text-decoration: none; }
+  a:hover { text-decoration: underline; }
+  .endpoint-list { list-style: none; padding: 0; margin: 0; }
+  .endpoint-list li { background: #fff; border: 1px solid #dee2e6; border-radius: 6px; margin-bottom: 8px; padding: 10px 16px; display: flex; align-items: center; gap: 12px; }
+  .endpoint-list li:hover { border-color: #0d6efd; }
+  .method { display: inline-block; font-size: 0.75rem; font-weight: 700; padding: 2px 8px; border-radius: 4px; min-width: 56px; text-align: center; color: #fff; }
+  .method-GET { background: #198754; } .method-POST { background: #0d6efd; } .method-PUT { background: #fd7e14; }
+  .method-PATCH { background: #6f42c1; } .method-DELETE { background: #dc3545; } .method-HEAD { background: #6c757d; }
+  .method-OPTIONS { background: #20c997; } .method-TRACE { background: #6c757d; } .method-CONNECT { background: #6c757d; }
+  .path { font-family: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace; font-size: 0.9rem; }
+  .card { background: #fff; border: 1px solid #dee2e6; border-radius: 8px; margin-bottom: 16px; overflow: hidden; }
+  .card-header { padding: 12px 16px; font-weight: 600; font-size: 0.85rem; color: #495057; background: #f1f3f5; border-bottom: 1px solid #dee2e6; text-transform: uppercase; letter-spacing: 0.05em; }
+  .card-body { padding: 16px; }
+  .card-body p { margin: 0 0 8px; }
+  .meta-grid { display: grid; grid-template-columns: 140px 1fr; gap: 0; }
+  .meta-grid dt { padding: 8px 12px; font-weight: 600; font-size: 0.8rem; color: #495057; background: #f8f9fa; border-bottom: 1px solid #eee; }
+  .meta-grid dd { padding: 8px 12px; margin: 0; border-bottom: 1px solid #eee; font-size: 0.9rem; }
+  .tag { display: inline-block; background: #e9ecef; color: #495057; padding: 1px 8px; border-radius: 4px; font-size: 0.8rem; margin-right: 4px; }
+  .required { color: #dc3545; font-weight: 700; }
+  pre { background: #212529; color: #e9ecef; padding: 14px; border-radius: 6px; overflow-x: auto; font-size: 0.82rem; line-height: 1.5; margin: 0; }
+  .status-badge { display: inline-block; padding: 2px 8px; border-radius: 4px; font-weight: 600; font-size: 0.8rem; color: #fff; }
+  .status-2xx { background: #198754; } .status-3xx { background: #0dcaf0; color: #000; } .status-4xx { background: #fd7e14; } .status-5xx { background: #dc3545; }
+  .back-link { display: inline-block; margin-bottom: 16px; font-size: 0.85rem; }
+</style></head><body>
+<a href="index.html" class="back-link">&larr; Back to index</a>
+<h1><span class="method method-DELETE">DELETE</span> <span class="path">/users/{userId}</span></h1>
+<div class="card"><div class="card-header">Overview</div><div class="card-body"><dl class="meta-grid"><dt>Summary</dt><dd>Delete user</dd><dt>Description</dt><dd>Delete a user</dd><dt>Operation ID</dt><dd><code>deleteUser</code></dd><dt>Tags</dt><dd><span class="tag">Users</span></dd></dl></div></div>
+<div class="card"><div class="card-header">Security</div><div class="card-body"><p>bearerAuth <span class="tag">http</span></p></div></div>
+<div class="card"><div class="card-header">Path Parameters</div><div class="card-body"><dl class="meta-grid"><dt>userId <span class="required">*</span></dt><dd><code>UUID</code></dd></dl></div></div>
+<div class="card"><div class="card-header"><span class="status-badge status-2xx">204</span> Response</div><div class="card-body"><p>User deleted</p></div></div>
+</body></html>

--- a/openapi/src/test/resources/gold/simple/GET__health-334cfc61.html
+++ b/openapi/src/test/resources/gold/simple/GET__health-334cfc61.html
@@ -39,15 +39,11 @@
   "type" : "object",
   "properties" : {
     "status" : {
-      "type" : "string",
-      "required" : [
-      ]
+      "type" : "string"
     },
     "uptimeSeconds" : {
       "type" : "integer",
-      "format" : "int64",
-      "required" : [
-      ]
+      "format" : "int64"
     }
   },
   "required" : [

--- a/openapi/src/test/resources/gold/simple/GET__health-334cfc61.html
+++ b/openapi/src/test/resources/gold/simple/GET__health-334cfc61.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html><html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1"><title>GET /health</title><style>
+  *, *::before, *::after { box-sizing: border-box; }
+  body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif; margin: 0; padding: 20px 40px; background: #f8f9fa; color: #1a1a2e; line-height: 1.5; }
+  h1 { font-size: 1.6rem; font-weight: 600; margin: 0 0 20px; color: #16213e; }
+  a { color: #0d6efd; text-decoration: none; }
+  a:hover { text-decoration: underline; }
+  .endpoint-list { list-style: none; padding: 0; margin: 0; }
+  .endpoint-list li { background: #fff; border: 1px solid #dee2e6; border-radius: 6px; margin-bottom: 8px; padding: 10px 16px; display: flex; align-items: center; gap: 12px; }
+  .endpoint-list li:hover { border-color: #0d6efd; }
+  .method { display: inline-block; font-size: 0.75rem; font-weight: 700; padding: 2px 8px; border-radius: 4px; min-width: 56px; text-align: center; color: #fff; }
+  .method-GET { background: #198754; } .method-POST { background: #0d6efd; } .method-PUT { background: #fd7e14; }
+  .method-PATCH { background: #6f42c1; } .method-DELETE { background: #dc3545; } .method-HEAD { background: #6c757d; }
+  .method-OPTIONS { background: #20c997; } .method-TRACE { background: #6c757d; } .method-CONNECT { background: #6c757d; }
+  .path { font-family: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace; font-size: 0.9rem; }
+  .card { background: #fff; border: 1px solid #dee2e6; border-radius: 8px; margin-bottom: 16px; overflow: hidden; }
+  .card-header { padding: 12px 16px; font-weight: 600; font-size: 0.85rem; color: #495057; background: #f1f3f5; border-bottom: 1px solid #dee2e6; text-transform: uppercase; letter-spacing: 0.05em; }
+  .card-body { padding: 16px; }
+  .card-body p { margin: 0 0 8px; }
+  .meta-grid { display: grid; grid-template-columns: 140px 1fr; gap: 0; }
+  .meta-grid dt { padding: 8px 12px; font-weight: 600; font-size: 0.8rem; color: #495057; background: #f8f9fa; border-bottom: 1px solid #eee; }
+  .meta-grid dd { padding: 8px 12px; margin: 0; border-bottom: 1px solid #eee; font-size: 0.9rem; }
+  .tag { display: inline-block; background: #e9ecef; color: #495057; padding: 1px 8px; border-radius: 4px; font-size: 0.8rem; margin-right: 4px; }
+  .required { color: #dc3545; font-weight: 700; }
+  pre { background: #212529; color: #e9ecef; padding: 14px; border-radius: 6px; overflow-x: auto; font-size: 0.82rem; line-height: 1.5; margin: 0; }
+  .status-badge { display: inline-block; padding: 2px 8px; border-radius: 4px; font-weight: 600; font-size: 0.8rem; color: #fff; }
+  .status-2xx { background: #198754; } .status-3xx { background: #0dcaf0; color: #000; } .status-4xx { background: #fd7e14; } .status-5xx { background: #dc3545; }
+  .back-link { display: inline-block; margin-bottom: 16px; font-size: 0.85rem; }
+</style></head><body>
+<a href="index.html" class="back-link">&larr; Back to index</a>
+<h1><span class="method method-GET">GET</span> <span class="path">/health</span></h1>
+<div class="card"><div class="card-header">Overview</div><div class="card-body"><dl class="meta-grid"><dt>Summary</dt><dd>Liveness probe</dd><dt>Description</dt><dd>Return service liveness — no authentication required</dd><dt>Operation ID</dt><dd><code>health</code></dd><dt>Tags</dt><dd><span class="tag">System</span></dd></dl></div></div>
+
+<div class="card"><div class="card-header"><span class="status-badge status-2xx">200</span> Response</div><div class="card-body"><p>Service is alive</p><h4>Response body</h4><pre>{
+  "status" : "ok",
+  "uptimeSeconds" : 12345
+}</pre><details><summary>Response schema</summary><pre>{
+  "$schema" : "http://json-schema.org/draft-07/schema#",
+  "title" : "HealthResponse",
+  "type" : "object",
+  "properties" : {
+    "status" : {
+      "type" : "string",
+      "required" : [
+      ]
+    },
+    "uptimeSeconds" : {
+      "type" : "integer",
+      "format" : "int64",
+      "required" : [
+      ]
+    }
+  },
+  "required" : [
+    "status",
+    "uptimeSeconds"
+  ],
+  "additionalProperties" : false
+}</pre></details></div></div>
+</body></html>

--- a/openapi/src/test/resources/gold/simple/GET__me-2647d21d.html
+++ b/openapi/src/test/resources/gold/simple/GET__me-2647d21d.html
@@ -42,19 +42,13 @@
   "properties" : {
     "id" : {
       "type" : "string",
-      "format" : "uuid",
-      "required" : [
-      ]
+      "format" : "uuid"
     },
     "email" : {
-      "type" : "string",
-      "required" : [
-      ]
+      "type" : "string"
     },
     "name" : {
-      "type" : "string",
-      "required" : [
-      ]
+      "type" : "string"
     },
     "role" : {
       "type" : "string",
@@ -63,8 +57,6 @@
         "admin",
         "member",
         "guest"
-      ],
-      "required" : [
       ]
     }
   },

--- a/openapi/src/test/resources/gold/simple/GET__me-2647d21d.html
+++ b/openapi/src/test/resources/gold/simple/GET__me-2647d21d.html
@@ -1,0 +1,79 @@
+<!DOCTYPE html><html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1"><title>GET /me</title><style>
+  *, *::before, *::after { box-sizing: border-box; }
+  body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif; margin: 0; padding: 20px 40px; background: #f8f9fa; color: #1a1a2e; line-height: 1.5; }
+  h1 { font-size: 1.6rem; font-weight: 600; margin: 0 0 20px; color: #16213e; }
+  a { color: #0d6efd; text-decoration: none; }
+  a:hover { text-decoration: underline; }
+  .endpoint-list { list-style: none; padding: 0; margin: 0; }
+  .endpoint-list li { background: #fff; border: 1px solid #dee2e6; border-radius: 6px; margin-bottom: 8px; padding: 10px 16px; display: flex; align-items: center; gap: 12px; }
+  .endpoint-list li:hover { border-color: #0d6efd; }
+  .method { display: inline-block; font-size: 0.75rem; font-weight: 700; padding: 2px 8px; border-radius: 4px; min-width: 56px; text-align: center; color: #fff; }
+  .method-GET { background: #198754; } .method-POST { background: #0d6efd; } .method-PUT { background: #fd7e14; }
+  .method-PATCH { background: #6f42c1; } .method-DELETE { background: #dc3545; } .method-HEAD { background: #6c757d; }
+  .method-OPTIONS { background: #20c997; } .method-TRACE { background: #6c757d; } .method-CONNECT { background: #6c757d; }
+  .path { font-family: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace; font-size: 0.9rem; }
+  .card { background: #fff; border: 1px solid #dee2e6; border-radius: 8px; margin-bottom: 16px; overflow: hidden; }
+  .card-header { padding: 12px 16px; font-weight: 600; font-size: 0.85rem; color: #495057; background: #f1f3f5; border-bottom: 1px solid #dee2e6; text-transform: uppercase; letter-spacing: 0.05em; }
+  .card-body { padding: 16px; }
+  .card-body p { margin: 0 0 8px; }
+  .meta-grid { display: grid; grid-template-columns: 140px 1fr; gap: 0; }
+  .meta-grid dt { padding: 8px 12px; font-weight: 600; font-size: 0.8rem; color: #495057; background: #f8f9fa; border-bottom: 1px solid #eee; }
+  .meta-grid dd { padding: 8px 12px; margin: 0; border-bottom: 1px solid #eee; font-size: 0.9rem; }
+  .tag { display: inline-block; background: #e9ecef; color: #495057; padding: 1px 8px; border-radius: 4px; font-size: 0.8rem; margin-right: 4px; }
+  .required { color: #dc3545; font-weight: 700; }
+  pre { background: #212529; color: #e9ecef; padding: 14px; border-radius: 6px; overflow-x: auto; font-size: 0.82rem; line-height: 1.5; margin: 0; }
+  .status-badge { display: inline-block; padding: 2px 8px; border-radius: 4px; font-weight: 600; font-size: 0.8rem; color: #fff; }
+  .status-2xx { background: #198754; } .status-3xx { background: #0dcaf0; color: #000; } .status-4xx { background: #fd7e14; } .status-5xx { background: #dc3545; }
+  .back-link { display: inline-block; margin-bottom: 16px; font-size: 0.85rem; }
+</style></head><body>
+<a href="index.html" class="back-link">&larr; Back to index</a>
+<h1><span class="method method-GET">GET</span> <span class="path">/me</span></h1>
+<div class="card"><div class="card-header">Overview</div><div class="card-body"><dl class="meta-grid"><dt>Summary</dt><dd>Who am I</dd><dt>Description</dt><dd>Return the profile of the currently authenticated user</dd><dt>Operation ID</dt><dd><code>me</code></dd><dt>Tags</dt><dd><span class="tag">Auth</span></dd></dl></div></div>
+<div class="card"><div class="card-header">Security</div><div class="card-body"><p>bearerAuth <span class="tag">http</span></p></div></div>
+<div class="card"><div class="card-header"><span class="status-badge status-2xx">200</span> Response</div><div class="card-body"><p>Authenticated user profile</p><h4>Response body</h4><pre>{
+  "id" : "00000000-0000-0000-0000-000000000001",
+  "email" : "alice@example.com",
+  "name" : "Alice",
+  "role" : "admin"
+}</pre><details><summary>Response schema</summary><pre>{
+  "$schema" : "http://json-schema.org/draft-07/schema#",
+  "title" : "User",
+  "type" : "object",
+  "properties" : {
+    "id" : {
+      "type" : "string",
+      "format" : "uuid",
+      "required" : [
+      ]
+    },
+    "email" : {
+      "type" : "string",
+      "required" : [
+      ]
+    },
+    "name" : {
+      "type" : "string",
+      "required" : [
+      ]
+    },
+    "role" : {
+      "type" : "string",
+      "description" : "User role within the system",
+      "enum" : [
+        "admin",
+        "member",
+        "guest"
+      ],
+      "required" : [
+      ]
+    }
+  },
+  "required" : [
+    "email",
+    "id",
+    "name",
+    "role"
+  ],
+  "additionalProperties" : false
+}</pre></details></div></div>
+</body></html>

--- a/openapi/src/test/resources/gold/simple/GET__projects-9a7aa53f.html
+++ b/openapi/src/test/resources/gold/simple/GET__projects-9a7aa53f.html
@@ -43,27 +43,19 @@
 ]</pre><details><summary>Response schema</summary><pre>{
   "$schema" : "http://json-schema.org/draft-07/schema#",
   "type" : "array",
-  "required" : [
-  ],
   "items" : {
     "title" : "Project",
     "type" : "object",
     "properties" : {
       "name" : {
-        "type" : "string",
-        "required" : [
-        ]
+        "type" : "string"
       },
       "description" : {
-        "type" : "string",
-        "required" : [
-        ]
+        "type" : "string"
       },
       "id" : {
         "type" : "integer",
-        "format" : "int64",
-        "required" : [
-        ]
+        "format" : "int64"
       },
       "status" : {
         "type" : "string",
@@ -72,20 +64,14 @@
           "active",
           "archived",
           "draft"
-        ],
-        "required" : [
         ]
       },
       "createdAt" : {
-        "type" : "string",
-        "required" : [
-        ]
+        "type" : "string"
       },
       "ownerId" : {
         "type" : "string",
-        "format" : "uuid",
-        "required" : [
-        ]
+        "format" : "uuid"
       }
     },
     "required" : [
@@ -110,27 +96,19 @@
 ]</pre><details><summary>Response schema</summary><pre>{
   "$schema" : "http://json-schema.org/draft-07/schema#",
   "type" : "array",
-  "required" : [
-  ],
   "items" : {
     "title" : "Project",
     "type" : "object",
     "properties" : {
       "name" : {
-        "type" : "string",
-        "required" : [
-        ]
+        "type" : "string"
       },
       "description" : {
-        "type" : "string",
-        "required" : [
-        ]
+        "type" : "string"
       },
       "id" : {
         "type" : "integer",
-        "format" : "int64",
-        "required" : [
-        ]
+        "format" : "int64"
       },
       "status" : {
         "type" : "string",
@@ -139,20 +117,14 @@
           "active",
           "archived",
           "draft"
-        ],
-        "required" : [
         ]
       },
       "createdAt" : {
-        "type" : "string",
-        "required" : [
-        ]
+        "type" : "string"
       },
       "ownerId" : {
         "type" : "string",
-        "format" : "uuid",
-        "required" : [
-        ]
+        "format" : "uuid"
       }
     },
     "required" : [

--- a/openapi/src/test/resources/gold/simple/GET__projects-9a7aa53f.html
+++ b/openapi/src/test/resources/gold/simple/GET__projects-9a7aa53f.html
@@ -1,0 +1,168 @@
+<!DOCTYPE html><html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1"><title>GET /projects</title><style>
+  *, *::before, *::after { box-sizing: border-box; }
+  body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif; margin: 0; padding: 20px 40px; background: #f8f9fa; color: #1a1a2e; line-height: 1.5; }
+  h1 { font-size: 1.6rem; font-weight: 600; margin: 0 0 20px; color: #16213e; }
+  a { color: #0d6efd; text-decoration: none; }
+  a:hover { text-decoration: underline; }
+  .endpoint-list { list-style: none; padding: 0; margin: 0; }
+  .endpoint-list li { background: #fff; border: 1px solid #dee2e6; border-radius: 6px; margin-bottom: 8px; padding: 10px 16px; display: flex; align-items: center; gap: 12px; }
+  .endpoint-list li:hover { border-color: #0d6efd; }
+  .method { display: inline-block; font-size: 0.75rem; font-weight: 700; padding: 2px 8px; border-radius: 4px; min-width: 56px; text-align: center; color: #fff; }
+  .method-GET { background: #198754; } .method-POST { background: #0d6efd; } .method-PUT { background: #fd7e14; }
+  .method-PATCH { background: #6f42c1; } .method-DELETE { background: #dc3545; } .method-HEAD { background: #6c757d; }
+  .method-OPTIONS { background: #20c997; } .method-TRACE { background: #6c757d; } .method-CONNECT { background: #6c757d; }
+  .path { font-family: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace; font-size: 0.9rem; }
+  .card { background: #fff; border: 1px solid #dee2e6; border-radius: 8px; margin-bottom: 16px; overflow: hidden; }
+  .card-header { padding: 12px 16px; font-weight: 600; font-size: 0.85rem; color: #495057; background: #f1f3f5; border-bottom: 1px solid #dee2e6; text-transform: uppercase; letter-spacing: 0.05em; }
+  .card-body { padding: 16px; }
+  .card-body p { margin: 0 0 8px; }
+  .meta-grid { display: grid; grid-template-columns: 140px 1fr; gap: 0; }
+  .meta-grid dt { padding: 8px 12px; font-weight: 600; font-size: 0.8rem; color: #495057; background: #f8f9fa; border-bottom: 1px solid #eee; }
+  .meta-grid dd { padding: 8px 12px; margin: 0; border-bottom: 1px solid #eee; font-size: 0.9rem; }
+  .tag { display: inline-block; background: #e9ecef; color: #495057; padding: 1px 8px; border-radius: 4px; font-size: 0.8rem; margin-right: 4px; }
+  .required { color: #dc3545; font-weight: 700; }
+  pre { background: #212529; color: #e9ecef; padding: 14px; border-radius: 6px; overflow-x: auto; font-size: 0.82rem; line-height: 1.5; margin: 0; }
+  .status-badge { display: inline-block; padding: 2px 8px; border-radius: 4px; font-weight: 600; font-size: 0.8rem; color: #fff; }
+  .status-2xx { background: #198754; } .status-3xx { background: #0dcaf0; color: #000; } .status-4xx { background: #fd7e14; } .status-5xx { background: #dc3545; }
+  .back-link { display: inline-block; margin-bottom: 16px; font-size: 0.85rem; }
+</style></head><body>
+<a href="index.html" class="back-link">&larr; Back to index</a>
+<h1><span class="method method-GET">GET</span> <span class="path">/projects</span></h1>
+<div class="card"><div class="card-header">Overview</div><div class="card-body"><dl class="meta-grid"><dt>Summary</dt><dd>List projects</dd><dt>Description</dt><dd>List projects, optionally filtered by status</dd><dt>Operation ID</dt><dd><code>listProjects</code></dd><dt>Tags</dt><dd><span class="tag">Projects</span></dd></dl></div></div>
+<div class="card"><div class="card-header">Security</div><div class="card-body"><p>oauth2 <span class="tag">oauth2</span></p></div></div>
+<div class="card"><div class="card-header">Query Parameters</div><div class="card-body"><dl class="meta-grid"><dt>status</dt><dd><code>ProjectStatus</code> <span class="tag">active | archived | draft</span></dd></dl></div></div>
+<div class="card"><div class="card-header"><span class="status-badge status-2xx">200</span> Response</div><div class="card-body"><p>All active projects</p><h4>Response body</h4><pre>[
+  {
+    "id" : 42,
+    "name" : "Apollo",
+    "description" : "Mission control",
+    "status" : "active",
+    "ownerId" : "00000000-0000-0000-0000-000000000001",
+    "createdAt" : "2026-01-01T00:00:00Z"
+  }
+]</pre><details><summary>Response schema</summary><pre>{
+  "$schema" : "http://json-schema.org/draft-07/schema#",
+  "type" : "array",
+  "required" : [
+  ],
+  "items" : {
+    "title" : "Project",
+    "type" : "object",
+    "properties" : {
+      "name" : {
+        "type" : "string",
+        "required" : [
+        ]
+      },
+      "description" : {
+        "type" : "string",
+        "required" : [
+        ]
+      },
+      "id" : {
+        "type" : "integer",
+        "format" : "int64",
+        "required" : [
+        ]
+      },
+      "status" : {
+        "type" : "string",
+        "description" : "Lifecycle state of a project",
+        "enum" : [
+          "active",
+          "archived",
+          "draft"
+        ],
+        "required" : [
+        ]
+      },
+      "createdAt" : {
+        "type" : "string",
+        "required" : [
+        ]
+      },
+      "ownerId" : {
+        "type" : "string",
+        "format" : "uuid",
+        "required" : [
+        ]
+      }
+    },
+    "required" : [
+      "createdAt",
+      "id",
+      "name",
+      "ownerId",
+      "status"
+    ],
+    "additionalProperties" : false
+  }
+}</pre></details></div></div>
+<div class="card"><div class="card-header"><span class="status-badge status-2xx">200</span> Response</div><div class="card-body"><p>All archived projects</p><h4>Response body</h4><pre>[
+  {
+    "id" : 7,
+    "name" : "Gemini",
+    "description" : null,
+    "status" : "archived",
+    "ownerId" : "00000000-0000-0000-0000-000000000001",
+    "createdAt" : "2025-06-01T00:00:00Z"
+  }
+]</pre><details><summary>Response schema</summary><pre>{
+  "$schema" : "http://json-schema.org/draft-07/schema#",
+  "type" : "array",
+  "required" : [
+  ],
+  "items" : {
+    "title" : "Project",
+    "type" : "object",
+    "properties" : {
+      "name" : {
+        "type" : "string",
+        "required" : [
+        ]
+      },
+      "description" : {
+        "type" : "string",
+        "required" : [
+        ]
+      },
+      "id" : {
+        "type" : "integer",
+        "format" : "int64",
+        "required" : [
+        ]
+      },
+      "status" : {
+        "type" : "string",
+        "description" : "Lifecycle state of a project",
+        "enum" : [
+          "active",
+          "archived",
+          "draft"
+        ],
+        "required" : [
+        ]
+      },
+      "createdAt" : {
+        "type" : "string",
+        "required" : [
+        ]
+      },
+      "ownerId" : {
+        "type" : "string",
+        "format" : "uuid",
+        "required" : [
+        ]
+      }
+    },
+    "required" : [
+      "createdAt",
+      "id",
+      "name",
+      "ownerId",
+      "status"
+    ],
+    "additionalProperties" : false
+  }
+}</pre></details></div></div>
+</body></html>

--- a/openapi/src/test/resources/gold/simple/GET__projects___projectId___tasks-b0b82093.html
+++ b/openapi/src/test/resources/gold/simple/GET__projects___projectId___tasks-b0b82093.html
@@ -49,8 +49,6 @@
 ]</pre><details><summary>Response schema</summary><pre>{
   "$schema" : "http://json-schema.org/draft-07/schema#",
   "type" : "array",
-  "required" : [
-  ],
   "items" : {
     "title" : "Task",
     "type" : "object",
@@ -62,30 +60,20 @@
           "low",
           "medium",
           "high"
-        ],
-        "required" : [
         ]
       },
       "description" : {
-        "type" : "string",
-        "required" : [
-        ]
+        "type" : "string"
       },
       "id" : {
         "type" : "integer",
-        "format" : "int64",
-        "required" : [
-        ]
+        "format" : "int64"
       },
       "done" : {
-        "type" : "boolean",
-        "required" : [
-        ]
+        "type" : "boolean"
       },
       "title" : {
-        "type" : "string",
-        "required" : [
-        ]
+        "type" : "string"
       }
     },
     "required" : [

--- a/openapi/src/test/resources/gold/simple/GET__projects___projectId___tasks-b0b82093.html
+++ b/openapi/src/test/resources/gold/simple/GET__projects___projectId___tasks-b0b82093.html
@@ -1,0 +1,100 @@
+<!DOCTYPE html><html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1"><title>GET /projects/{projectId}/tasks</title><style>
+  *, *::before, *::after { box-sizing: border-box; }
+  body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif; margin: 0; padding: 20px 40px; background: #f8f9fa; color: #1a1a2e; line-height: 1.5; }
+  h1 { font-size: 1.6rem; font-weight: 600; margin: 0 0 20px; color: #16213e; }
+  a { color: #0d6efd; text-decoration: none; }
+  a:hover { text-decoration: underline; }
+  .endpoint-list { list-style: none; padding: 0; margin: 0; }
+  .endpoint-list li { background: #fff; border: 1px solid #dee2e6; border-radius: 6px; margin-bottom: 8px; padding: 10px 16px; display: flex; align-items: center; gap: 12px; }
+  .endpoint-list li:hover { border-color: #0d6efd; }
+  .method { display: inline-block; font-size: 0.75rem; font-weight: 700; padding: 2px 8px; border-radius: 4px; min-width: 56px; text-align: center; color: #fff; }
+  .method-GET { background: #198754; } .method-POST { background: #0d6efd; } .method-PUT { background: #fd7e14; }
+  .method-PATCH { background: #6f42c1; } .method-DELETE { background: #dc3545; } .method-HEAD { background: #6c757d; }
+  .method-OPTIONS { background: #20c997; } .method-TRACE { background: #6c757d; } .method-CONNECT { background: #6c757d; }
+  .path { font-family: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace; font-size: 0.9rem; }
+  .card { background: #fff; border: 1px solid #dee2e6; border-radius: 8px; margin-bottom: 16px; overflow: hidden; }
+  .card-header { padding: 12px 16px; font-weight: 600; font-size: 0.85rem; color: #495057; background: #f1f3f5; border-bottom: 1px solid #dee2e6; text-transform: uppercase; letter-spacing: 0.05em; }
+  .card-body { padding: 16px; }
+  .card-body p { margin: 0 0 8px; }
+  .meta-grid { display: grid; grid-template-columns: 140px 1fr; gap: 0; }
+  .meta-grid dt { padding: 8px 12px; font-weight: 600; font-size: 0.8rem; color: #495057; background: #f8f9fa; border-bottom: 1px solid #eee; }
+  .meta-grid dd { padding: 8px 12px; margin: 0; border-bottom: 1px solid #eee; font-size: 0.9rem; }
+  .tag { display: inline-block; background: #e9ecef; color: #495057; padding: 1px 8px; border-radius: 4px; font-size: 0.8rem; margin-right: 4px; }
+  .required { color: #dc3545; font-weight: 700; }
+  pre { background: #212529; color: #e9ecef; padding: 14px; border-radius: 6px; overflow-x: auto; font-size: 0.82rem; line-height: 1.5; margin: 0; }
+  .status-badge { display: inline-block; padding: 2px 8px; border-radius: 4px; font-weight: 600; font-size: 0.8rem; color: #fff; }
+  .status-2xx { background: #198754; } .status-3xx { background: #0dcaf0; color: #000; } .status-4xx { background: #fd7e14; } .status-5xx { background: #dc3545; }
+  .back-link { display: inline-block; margin-bottom: 16px; font-size: 0.85rem; }
+</style></head><body>
+<a href="index.html" class="back-link">&larr; Back to index</a>
+<h1><span class="method method-GET">GET</span> <span class="path">/projects/{projectId}/tasks</span></h1>
+<div class="card"><div class="card-header">Overview</div><div class="card-body"><dl class="meta-grid"><dt>Summary</dt><dd>List tasks</dd><dt>Description</dt><dd>List all tasks in a project</dd><dt>Operation ID</dt><dd><code>listTasks</code></dd><dt>Tags</dt><dd><span class="tag">Tasks</span></dd></dl></div></div>
+<div class="card"><div class="card-header">Security</div><div class="card-body"><p>oauth2 <span class="tag">oauth2</span></p></div></div>
+<div class="card"><div class="card-header">Path Parameters</div><div class="card-body"><dl class="meta-grid"><dt>projectId <span class="required">*</span></dt><dd><code>Long</code></dd></dl></div></div>
+<div class="card"><div class="card-header"><span class="status-badge status-2xx">200</span> Response</div><div class="card-body"><p>All tasks in the project</p><h4>Response body</h4><pre>[
+  {
+    "id" : 101,
+    "title" : "Wire up telemetry",
+    "description" : "Prometheus + Grafana",
+    "done" : false,
+    "priority" : "high"
+  },
+  {
+    "id" : 102,
+    "title" : "Write docs",
+    "description" : null,
+    "done" : true,
+    "priority" : "low"
+  }
+]</pre><details><summary>Response schema</summary><pre>{
+  "$schema" : "http://json-schema.org/draft-07/schema#",
+  "type" : "array",
+  "required" : [
+  ],
+  "items" : {
+    "title" : "Task",
+    "type" : "object",
+    "properties" : {
+      "priority" : {
+        "type" : "string",
+        "description" : "Task priority level",
+        "enum" : [
+          "low",
+          "medium",
+          "high"
+        ],
+        "required" : [
+        ]
+      },
+      "description" : {
+        "type" : "string",
+        "required" : [
+        ]
+      },
+      "id" : {
+        "type" : "integer",
+        "format" : "int64",
+        "required" : [
+        ]
+      },
+      "done" : {
+        "type" : "boolean",
+        "required" : [
+        ]
+      },
+      "title" : {
+        "type" : "string",
+        "required" : [
+        ]
+      }
+    },
+    "required" : [
+      "done",
+      "id",
+      "priority",
+      "title"
+    ],
+    "additionalProperties" : false
+  }
+}</pre></details></div></div>
+</body></html>

--- a/openapi/src/test/resources/gold/simple/GET__users-c054bf63.html
+++ b/openapi/src/test/resources/gold/simple/GET__users-c054bf63.html
@@ -56,27 +56,19 @@
   "properties" : {
     "users" : {
       "type" : "array",
-      "required" : [
-      ],
       "items" : {
         "title" : "User",
         "type" : "object",
         "properties" : {
           "id" : {
             "type" : "string",
-            "format" : "uuid",
-            "required" : [
-            ]
+            "format" : "uuid"
           },
           "email" : {
-            "type" : "string",
-            "required" : [
-            ]
+            "type" : "string"
           },
           "name" : {
-            "type" : "string",
-            "required" : [
-            ]
+            "type" : "string"
           },
           "role" : {
             "type" : "string",
@@ -85,8 +77,6 @@
               "admin",
               "member",
               "guest"
-            ],
-            "required" : [
             ]
           }
         },
@@ -101,21 +91,15 @@
     },
     "total" : {
       "type" : "integer",
-      "format" : "int32",
-      "required" : [
-      ]
+      "format" : "int32"
     },
     "page" : {
       "type" : "integer",
-      "format" : "int32",
-      "required" : [
-      ]
+      "format" : "int32"
     },
     "limit" : {
       "type" : "integer",
-      "format" : "int32",
-      "required" : [
-      ]
+      "format" : "int32"
     }
   },
   "required" : [

--- a/openapi/src/test/resources/gold/simple/GET__users-c054bf63.html
+++ b/openapi/src/test/resources/gold/simple/GET__users-c054bf63.html
@@ -1,0 +1,129 @@
+<!DOCTYPE html><html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1"><title>GET /users</title><style>
+  *, *::before, *::after { box-sizing: border-box; }
+  body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif; margin: 0; padding: 20px 40px; background: #f8f9fa; color: #1a1a2e; line-height: 1.5; }
+  h1 { font-size: 1.6rem; font-weight: 600; margin: 0 0 20px; color: #16213e; }
+  a { color: #0d6efd; text-decoration: none; }
+  a:hover { text-decoration: underline; }
+  .endpoint-list { list-style: none; padding: 0; margin: 0; }
+  .endpoint-list li { background: #fff; border: 1px solid #dee2e6; border-radius: 6px; margin-bottom: 8px; padding: 10px 16px; display: flex; align-items: center; gap: 12px; }
+  .endpoint-list li:hover { border-color: #0d6efd; }
+  .method { display: inline-block; font-size: 0.75rem; font-weight: 700; padding: 2px 8px; border-radius: 4px; min-width: 56px; text-align: center; color: #fff; }
+  .method-GET { background: #198754; } .method-POST { background: #0d6efd; } .method-PUT { background: #fd7e14; }
+  .method-PATCH { background: #6f42c1; } .method-DELETE { background: #dc3545; } .method-HEAD { background: #6c757d; }
+  .method-OPTIONS { background: #20c997; } .method-TRACE { background: #6c757d; } .method-CONNECT { background: #6c757d; }
+  .path { font-family: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace; font-size: 0.9rem; }
+  .card { background: #fff; border: 1px solid #dee2e6; border-radius: 8px; margin-bottom: 16px; overflow: hidden; }
+  .card-header { padding: 12px 16px; font-weight: 600; font-size: 0.85rem; color: #495057; background: #f1f3f5; border-bottom: 1px solid #dee2e6; text-transform: uppercase; letter-spacing: 0.05em; }
+  .card-body { padding: 16px; }
+  .card-body p { margin: 0 0 8px; }
+  .meta-grid { display: grid; grid-template-columns: 140px 1fr; gap: 0; }
+  .meta-grid dt { padding: 8px 12px; font-weight: 600; font-size: 0.8rem; color: #495057; background: #f8f9fa; border-bottom: 1px solid #eee; }
+  .meta-grid dd { padding: 8px 12px; margin: 0; border-bottom: 1px solid #eee; font-size: 0.9rem; }
+  .tag { display: inline-block; background: #e9ecef; color: #495057; padding: 1px 8px; border-radius: 4px; font-size: 0.8rem; margin-right: 4px; }
+  .required { color: #dc3545; font-weight: 700; }
+  pre { background: #212529; color: #e9ecef; padding: 14px; border-radius: 6px; overflow-x: auto; font-size: 0.82rem; line-height: 1.5; margin: 0; }
+  .status-badge { display: inline-block; padding: 2px 8px; border-radius: 4px; font-weight: 600; font-size: 0.8rem; color: #fff; }
+  .status-2xx { background: #198754; } .status-3xx { background: #0dcaf0; color: #000; } .status-4xx { background: #fd7e14; } .status-5xx { background: #dc3545; }
+  .back-link { display: inline-block; margin-bottom: 16px; font-size: 0.85rem; }
+</style></head><body>
+<a href="index.html" class="back-link">&larr; Back to index</a>
+<h1><span class="method method-GET">GET</span> <span class="path">/users</span></h1>
+<div class="card"><div class="card-header">Overview</div><div class="card-body"><dl class="meta-grid"><dt>Summary</dt><dd>List users</dd><dt>Description</dt><dd>List users with pagination and optional role filter</dd><dt>Operation ID</dt><dd><code>listUsers</code></dd><dt>Tags</dt><dd><span class="tag">Users</span></dd></dl></div></div>
+<div class="card"><div class="card-header">Security</div><div class="card-body"><p>bearerAuth <span class="tag">http</span></p></div></div>
+<div class="card"><div class="card-header">Query Parameters</div><div class="card-body"><dl class="meta-grid"><dt>page</dt><dd><code>Int</code></dd><dt>limit</dt><dd><code>Int</code></dd><dt>role</dt><dd><code>Role</code> <span class="tag">admin | guest | member</span></dd></dl></div></div>
+<div class="card"><div class="card-header"><span class="status-badge status-2xx">200</span> Response</div><div class="card-body"><p>First page of users</p><h4>Response headers</h4><dl class="meta-grid"><dt>X-Rate-Limit-Remaining <span class="required">*</span></dt><dd><code>Int</code> = <code>59</code></dd></dl><h4>Response body</h4><pre>{
+  "users" : [
+    {
+      "id" : "00000000-0000-0000-0000-000000000001",
+      "email" : "alice@example.com",
+      "name" : "Alice",
+      "role" : "admin"
+    },
+    {
+      "id" : "00000000-0000-0000-0000-000000000002",
+      "email" : "bob@example.com",
+      "name" : "Bob",
+      "role" : "member"
+    }
+  ],
+  "total" : 2,
+  "page" : 1,
+  "limit" : 20
+}</pre><details><summary>Response schema</summary><pre>{
+  "$schema" : "http://json-schema.org/draft-07/schema#",
+  "title" : "PaginatedUsers",
+  "type" : "object",
+  "properties" : {
+    "users" : {
+      "type" : "array",
+      "required" : [
+      ],
+      "items" : {
+        "title" : "User",
+        "type" : "object",
+        "properties" : {
+          "id" : {
+            "type" : "string",
+            "format" : "uuid",
+            "required" : [
+            ]
+          },
+          "email" : {
+            "type" : "string",
+            "required" : [
+            ]
+          },
+          "name" : {
+            "type" : "string",
+            "required" : [
+            ]
+          },
+          "role" : {
+            "type" : "string",
+            "description" : "User role within the system",
+            "enum" : [
+              "admin",
+              "member",
+              "guest"
+            ],
+            "required" : [
+            ]
+          }
+        },
+        "required" : [
+          "email",
+          "id",
+          "name",
+          "role"
+        ],
+        "additionalProperties" : false
+      }
+    },
+    "total" : {
+      "type" : "integer",
+      "format" : "int32",
+      "required" : [
+      ]
+    },
+    "page" : {
+      "type" : "integer",
+      "format" : "int32",
+      "required" : [
+      ]
+    },
+    "limit" : {
+      "type" : "integer",
+      "format" : "int32",
+      "required" : [
+      ]
+    }
+  },
+  "required" : [
+    "limit",
+    "page",
+    "total",
+    "users"
+  ],
+  "additionalProperties" : false
+}</pre></details></div></div>
+</body></html>

--- a/openapi/src/test/resources/gold/simple/GET__users___userId__-baf46b48.html
+++ b/openapi/src/test/resources/gold/simple/GET__users___userId__-baf46b48.html
@@ -43,19 +43,13 @@
   "properties" : {
     "id" : {
       "type" : "string",
-      "format" : "uuid",
-      "required" : [
-      ]
+      "format" : "uuid"
     },
     "email" : {
-      "type" : "string",
-      "required" : [
-      ]
+      "type" : "string"
     },
     "name" : {
-      "type" : "string",
-      "required" : [
-      ]
+      "type" : "string"
     },
     "role" : {
       "type" : "string",
@@ -64,8 +58,6 @@
         "admin",
         "member",
         "guest"
-      ],
-      "required" : [
       ]
     }
   },
@@ -87,23 +79,15 @@
   "type" : "object",
   "properties" : {
     "code" : {
-      "type" : "string",
-      "required" : [
-      ]
+      "type" : "string"
     },
     "message" : {
-      "type" : "string",
-      "required" : [
-      ]
+      "type" : "string"
     },
     "details" : {
       "type" : "array",
-      "required" : [
-      ],
       "items" : {
-        "type" : "string",
-        "required" : [
-        ]
+        "type" : "string"
       }
     }
   },

--- a/openapi/src/test/resources/gold/simple/GET__users___userId__-baf46b48.html
+++ b/openapi/src/test/resources/gold/simple/GET__users___userId__-baf46b48.html
@@ -1,0 +1,116 @@
+<!DOCTYPE html><html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1"><title>GET /users/{userId}</title><style>
+  *, *::before, *::after { box-sizing: border-box; }
+  body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif; margin: 0; padding: 20px 40px; background: #f8f9fa; color: #1a1a2e; line-height: 1.5; }
+  h1 { font-size: 1.6rem; font-weight: 600; margin: 0 0 20px; color: #16213e; }
+  a { color: #0d6efd; text-decoration: none; }
+  a:hover { text-decoration: underline; }
+  .endpoint-list { list-style: none; padding: 0; margin: 0; }
+  .endpoint-list li { background: #fff; border: 1px solid #dee2e6; border-radius: 6px; margin-bottom: 8px; padding: 10px 16px; display: flex; align-items: center; gap: 12px; }
+  .endpoint-list li:hover { border-color: #0d6efd; }
+  .method { display: inline-block; font-size: 0.75rem; font-weight: 700; padding: 2px 8px; border-radius: 4px; min-width: 56px; text-align: center; color: #fff; }
+  .method-GET { background: #198754; } .method-POST { background: #0d6efd; } .method-PUT { background: #fd7e14; }
+  .method-PATCH { background: #6f42c1; } .method-DELETE { background: #dc3545; } .method-HEAD { background: #6c757d; }
+  .method-OPTIONS { background: #20c997; } .method-TRACE { background: #6c757d; } .method-CONNECT { background: #6c757d; }
+  .path { font-family: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace; font-size: 0.9rem; }
+  .card { background: #fff; border: 1px solid #dee2e6; border-radius: 8px; margin-bottom: 16px; overflow: hidden; }
+  .card-header { padding: 12px 16px; font-weight: 600; font-size: 0.85rem; color: #495057; background: #f1f3f5; border-bottom: 1px solid #dee2e6; text-transform: uppercase; letter-spacing: 0.05em; }
+  .card-body { padding: 16px; }
+  .card-body p { margin: 0 0 8px; }
+  .meta-grid { display: grid; grid-template-columns: 140px 1fr; gap: 0; }
+  .meta-grid dt { padding: 8px 12px; font-weight: 600; font-size: 0.8rem; color: #495057; background: #f8f9fa; border-bottom: 1px solid #eee; }
+  .meta-grid dd { padding: 8px 12px; margin: 0; border-bottom: 1px solid #eee; font-size: 0.9rem; }
+  .tag { display: inline-block; background: #e9ecef; color: #495057; padding: 1px 8px; border-radius: 4px; font-size: 0.8rem; margin-right: 4px; }
+  .required { color: #dc3545; font-weight: 700; }
+  pre { background: #212529; color: #e9ecef; padding: 14px; border-radius: 6px; overflow-x: auto; font-size: 0.82rem; line-height: 1.5; margin: 0; }
+  .status-badge { display: inline-block; padding: 2px 8px; border-radius: 4px; font-weight: 600; font-size: 0.8rem; color: #fff; }
+  .status-2xx { background: #198754; } .status-3xx { background: #0dcaf0; color: #000; } .status-4xx { background: #fd7e14; } .status-5xx { background: #dc3545; }
+  .back-link { display: inline-block; margin-bottom: 16px; font-size: 0.85rem; }
+</style></head><body>
+<a href="index.html" class="back-link">&larr; Back to index</a>
+<h1><span class="method method-GET">GET</span> <span class="path">/users/{userId}</span></h1>
+<div class="card"><div class="card-header">Overview</div><div class="card-body"><dl class="meta-grid"><dt>Summary</dt><dd>Get user</dd><dt>Description</dt><dd>Fetch a single user by UUID</dd><dt>Operation ID</dt><dd><code>getUser</code></dd><dt>Tags</dt><dd><span class="tag">Users</span></dd></dl></div></div>
+<div class="card"><div class="card-header">Security</div><div class="card-body"><p>bearerAuth <span class="tag">http</span></p></div></div>
+<div class="card"><div class="card-header">Path Parameters</div><div class="card-body"><dl class="meta-grid"><dt>userId <span class="required">*</span></dt><dd><code>UUID</code></dd></dl></div></div>
+<div class="card"><div class="card-header"><span class="status-badge status-2xx">200</span> Response</div><div class="card-body"><p>User found</p><h4>Response body</h4><pre>{
+  "id" : "00000000-0000-0000-0000-000000000001",
+  "email" : "alice@example.com",
+  "name" : "Alice",
+  "role" : "admin"
+}</pre><details><summary>Response schema</summary><pre>{
+  "$schema" : "http://json-schema.org/draft-07/schema#",
+  "title" : "User",
+  "type" : "object",
+  "properties" : {
+    "id" : {
+      "type" : "string",
+      "format" : "uuid",
+      "required" : [
+      ]
+    },
+    "email" : {
+      "type" : "string",
+      "required" : [
+      ]
+    },
+    "name" : {
+      "type" : "string",
+      "required" : [
+      ]
+    },
+    "role" : {
+      "type" : "string",
+      "description" : "User role within the system",
+      "enum" : [
+        "admin",
+        "member",
+        "guest"
+      ],
+      "required" : [
+      ]
+    }
+  },
+  "required" : [
+    "email",
+    "id",
+    "name",
+    "role"
+  ],
+  "additionalProperties" : false
+}</pre></details></div></div>
+<div class="card"><div class="card-header"><span class="status-badge status-4xx">404</span> Response</div><div class="card-body"><p>User not found</p><h4>Response body</h4><pre>{
+  "code" : "not_found",
+  "message" : "No such user",
+  "details" : null
+}</pre><details><summary>Response schema</summary><pre>{
+  "$schema" : "http://json-schema.org/draft-07/schema#",
+  "title" : "ErrorResponse",
+  "type" : "object",
+  "properties" : {
+    "code" : {
+      "type" : "string",
+      "required" : [
+      ]
+    },
+    "message" : {
+      "type" : "string",
+      "required" : [
+      ]
+    },
+    "details" : {
+      "type" : "array",
+      "required" : [
+      ],
+      "items" : {
+        "type" : "string",
+        "required" : [
+        ]
+      }
+    }
+  },
+  "required" : [
+    "code",
+    "message"
+  ],
+  "additionalProperties" : false
+}</pre></details></div></div>
+</body></html>

--- a/openapi/src/test/resources/gold/simple/PATCH__projects___projectId__-fc9e4246.html
+++ b/openapi/src/test/resources/gold/simple/PATCH__projects___projectId__-fc9e4246.html
@@ -1,0 +1,129 @@
+<!DOCTYPE html><html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1"><title>PATCH /projects/{projectId}</title><style>
+  *, *::before, *::after { box-sizing: border-box; }
+  body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif; margin: 0; padding: 20px 40px; background: #f8f9fa; color: #1a1a2e; line-height: 1.5; }
+  h1 { font-size: 1.6rem; font-weight: 600; margin: 0 0 20px; color: #16213e; }
+  a { color: #0d6efd; text-decoration: none; }
+  a:hover { text-decoration: underline; }
+  .endpoint-list { list-style: none; padding: 0; margin: 0; }
+  .endpoint-list li { background: #fff; border: 1px solid #dee2e6; border-radius: 6px; margin-bottom: 8px; padding: 10px 16px; display: flex; align-items: center; gap: 12px; }
+  .endpoint-list li:hover { border-color: #0d6efd; }
+  .method { display: inline-block; font-size: 0.75rem; font-weight: 700; padding: 2px 8px; border-radius: 4px; min-width: 56px; text-align: center; color: #fff; }
+  .method-GET { background: #198754; } .method-POST { background: #0d6efd; } .method-PUT { background: #fd7e14; }
+  .method-PATCH { background: #6f42c1; } .method-DELETE { background: #dc3545; } .method-HEAD { background: #6c757d; }
+  .method-OPTIONS { background: #20c997; } .method-TRACE { background: #6c757d; } .method-CONNECT { background: #6c757d; }
+  .path { font-family: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace; font-size: 0.9rem; }
+  .card { background: #fff; border: 1px solid #dee2e6; border-radius: 8px; margin-bottom: 16px; overflow: hidden; }
+  .card-header { padding: 12px 16px; font-weight: 600; font-size: 0.85rem; color: #495057; background: #f1f3f5; border-bottom: 1px solid #dee2e6; text-transform: uppercase; letter-spacing: 0.05em; }
+  .card-body { padding: 16px; }
+  .card-body p { margin: 0 0 8px; }
+  .meta-grid { display: grid; grid-template-columns: 140px 1fr; gap: 0; }
+  .meta-grid dt { padding: 8px 12px; font-weight: 600; font-size: 0.8rem; color: #495057; background: #f8f9fa; border-bottom: 1px solid #eee; }
+  .meta-grid dd { padding: 8px 12px; margin: 0; border-bottom: 1px solid #eee; font-size: 0.9rem; }
+  .tag { display: inline-block; background: #e9ecef; color: #495057; padding: 1px 8px; border-radius: 4px; font-size: 0.8rem; margin-right: 4px; }
+  .required { color: #dc3545; font-weight: 700; }
+  pre { background: #212529; color: #e9ecef; padding: 14px; border-radius: 6px; overflow-x: auto; font-size: 0.82rem; line-height: 1.5; margin: 0; }
+  .status-badge { display: inline-block; padding: 2px 8px; border-radius: 4px; font-weight: 600; font-size: 0.8rem; color: #fff; }
+  .status-2xx { background: #198754; } .status-3xx { background: #0dcaf0; color: #000; } .status-4xx { background: #fd7e14; } .status-5xx { background: #dc3545; }
+  .back-link { display: inline-block; margin-bottom: 16px; font-size: 0.85rem; }
+</style></head><body>
+<a href="index.html" class="back-link">&larr; Back to index</a>
+<h1><span class="method method-PATCH">PATCH</span> <span class="path">/projects/{projectId}</span></h1>
+<div class="card"><div class="card-header">Overview</div><div class="card-body"><dl class="meta-grid"><dt>Summary</dt><dd>Patch project</dd><dt>Description</dt><dd>Partially update a project</dd><dt>Operation ID</dt><dd><code>patchProject</code></dd><dt>Tags</dt><dd><span class="tag">Projects</span></dd></dl></div></div>
+<div class="card"><div class="card-header">Security</div><div class="card-body"><p>oauth2 <span class="tag">oauth2</span></p></div></div>
+<div class="card"><div class="card-header">Path Parameters</div><div class="card-body"><dl class="meta-grid"><dt>projectId <span class="required">*</span></dt><dd><code>Long</code></dd></dl></div></div>
+<div class="card"><div class="card-header">Request body</div><div class="card-body"><details><summary>Request schema (JSON Schema v7)</summary><pre>{
+  "$schema" : "http://json-schema.org/draft-07/schema#",
+  "title" : "PatchProjectRequest",
+  "type" : "object",
+  "properties" : {
+    "name" : {
+      "type" : "string",
+      "required" : [
+      ]
+    },
+    "description" : {
+      "type" : "string",
+      "required" : [
+      ]
+    },
+    "status" : {
+      "type" : "string",
+      "description" : "Lifecycle state of a project",
+      "enum" : [
+        "active",
+        "archived",
+        "draft"
+      ],
+      "required" : [
+      ]
+    }
+  },
+  "required" : [
+  ],
+  "additionalProperties" : false
+}</pre></details></div></div>
+<div class="card"><div class="card-header"><span class="status-badge status-2xx">200</span> Response</div><div class="card-body"><p>Project updated</p><h4>Request body</h4><pre>{
+  "name" : null,
+  "description" : "Updated desc",
+  "status" : null
+}</pre><h4>Response body</h4><pre>{
+  "id" : 42,
+  "name" : "Apollo",
+  "description" : "Updated desc",
+  "status" : "active",
+  "ownerId" : "00000000-0000-0000-0000-000000000001",
+  "createdAt" : "2026-01-01T00:00:00Z"
+}</pre><details><summary>Response schema</summary><pre>{
+  "$schema" : "http://json-schema.org/draft-07/schema#",
+  "title" : "Project",
+  "type" : "object",
+  "properties" : {
+    "name" : {
+      "type" : "string",
+      "required" : [
+      ]
+    },
+    "description" : {
+      "type" : "string",
+      "required" : [
+      ]
+    },
+    "id" : {
+      "type" : "integer",
+      "format" : "int64",
+      "required" : [
+      ]
+    },
+    "status" : {
+      "type" : "string",
+      "description" : "Lifecycle state of a project",
+      "enum" : [
+        "active",
+        "archived",
+        "draft"
+      ],
+      "required" : [
+      ]
+    },
+    "createdAt" : {
+      "type" : "string",
+      "required" : [
+      ]
+    },
+    "ownerId" : {
+      "type" : "string",
+      "format" : "uuid",
+      "required" : [
+      ]
+    }
+  },
+  "required" : [
+    "createdAt",
+    "id",
+    "name",
+    "ownerId",
+    "status"
+  ],
+  "additionalProperties" : false
+}</pre></details></div></div>
+</body></html>

--- a/openapi/src/test/resources/gold/simple/PATCH__projects___projectId__-fc9e4246.html
+++ b/openapi/src/test/resources/gold/simple/PATCH__projects___projectId__-fc9e4246.html
@@ -37,14 +37,10 @@
   "type" : "object",
   "properties" : {
     "name" : {
-      "type" : "string",
-      "required" : [
-      ]
+      "type" : "string"
     },
     "description" : {
-      "type" : "string",
-      "required" : [
-      ]
+      "type" : "string"
     },
     "status" : {
       "type" : "string",
@@ -53,8 +49,6 @@
         "active",
         "archived",
         "draft"
-      ],
-      "required" : [
       ]
     }
   },
@@ -79,20 +73,14 @@
   "type" : "object",
   "properties" : {
     "name" : {
-      "type" : "string",
-      "required" : [
-      ]
+      "type" : "string"
     },
     "description" : {
-      "type" : "string",
-      "required" : [
-      ]
+      "type" : "string"
     },
     "id" : {
       "type" : "integer",
-      "format" : "int64",
-      "required" : [
-      ]
+      "format" : "int64"
     },
     "status" : {
       "type" : "string",
@@ -101,20 +89,14 @@
         "active",
         "archived",
         "draft"
-      ],
-      "required" : [
       ]
     },
     "createdAt" : {
-      "type" : "string",
-      "required" : [
-      ]
+      "type" : "string"
     },
     "ownerId" : {
       "type" : "string",
-      "format" : "uuid",
-      "required" : [
-      ]
+      "format" : "uuid"
     }
   },
   "required" : [

--- a/openapi/src/test/resources/gold/simple/POST__auth_login-3b67d231.html
+++ b/openapi/src/test/resources/gold/simple/POST__auth_login-3b67d231.html
@@ -36,14 +36,10 @@
   "type" : "object",
   "properties" : {
     "client_id" : {
-      "type" : "string",
-      "required" : [
-      ]
+      "type" : "string"
     },
     "grant_type" : {
-      "type" : "string",
-      "required" : [
-      ]
+      "type" : "string"
     }
   },
   "required" : [
@@ -66,9 +62,7 @@
   "type" : "object",
   "properties" : {
     "token" : {
-      "type" : "string",
-      "required" : [
-      ]
+      "type" : "string"
     },
     "user" : {
       "title" : "User",
@@ -76,19 +70,13 @@
       "properties" : {
         "id" : {
           "type" : "string",
-          "format" : "uuid",
-          "required" : [
-          ]
+          "format" : "uuid"
         },
         "email" : {
-          "type" : "string",
-          "required" : [
-          ]
+          "type" : "string"
         },
         "name" : {
-          "type" : "string",
-          "required" : [
-          ]
+          "type" : "string"
         },
         "role" : {
           "type" : "string",
@@ -97,8 +85,6 @@
             "admin",
             "member",
             "guest"
-          ],
-          "required" : [
           ]
         }
       },
@@ -127,23 +113,15 @@
   "type" : "object",
   "properties" : {
     "code" : {
-      "type" : "string",
-      "required" : [
-      ]
+      "type" : "string"
     },
     "message" : {
-      "type" : "string",
-      "required" : [
-      ]
+      "type" : "string"
     },
     "details" : {
       "type" : "array",
-      "required" : [
-      ],
       "items" : {
-        "type" : "string",
-        "required" : [
-        ]
+        "type" : "string"
       }
     }
   },

--- a/openapi/src/test/resources/gold/simple/POST__auth_login-3b67d231.html
+++ b/openapi/src/test/resources/gold/simple/POST__auth_login-3b67d231.html
@@ -1,0 +1,156 @@
+<!DOCTYPE html><html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1"><title>POST /auth/login</title><style>
+  *, *::before, *::after { box-sizing: border-box; }
+  body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif; margin: 0; padding: 20px 40px; background: #f8f9fa; color: #1a1a2e; line-height: 1.5; }
+  h1 { font-size: 1.6rem; font-weight: 600; margin: 0 0 20px; color: #16213e; }
+  a { color: #0d6efd; text-decoration: none; }
+  a:hover { text-decoration: underline; }
+  .endpoint-list { list-style: none; padding: 0; margin: 0; }
+  .endpoint-list li { background: #fff; border: 1px solid #dee2e6; border-radius: 6px; margin-bottom: 8px; padding: 10px 16px; display: flex; align-items: center; gap: 12px; }
+  .endpoint-list li:hover { border-color: #0d6efd; }
+  .method { display: inline-block; font-size: 0.75rem; font-weight: 700; padding: 2px 8px; border-radius: 4px; min-width: 56px; text-align: center; color: #fff; }
+  .method-GET { background: #198754; } .method-POST { background: #0d6efd; } .method-PUT { background: #fd7e14; }
+  .method-PATCH { background: #6f42c1; } .method-DELETE { background: #dc3545; } .method-HEAD { background: #6c757d; }
+  .method-OPTIONS { background: #20c997; } .method-TRACE { background: #6c757d; } .method-CONNECT { background: #6c757d; }
+  .path { font-family: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace; font-size: 0.9rem; }
+  .card { background: #fff; border: 1px solid #dee2e6; border-radius: 8px; margin-bottom: 16px; overflow: hidden; }
+  .card-header { padding: 12px 16px; font-weight: 600; font-size: 0.85rem; color: #495057; background: #f1f3f5; border-bottom: 1px solid #dee2e6; text-transform: uppercase; letter-spacing: 0.05em; }
+  .card-body { padding: 16px; }
+  .card-body p { margin: 0 0 8px; }
+  .meta-grid { display: grid; grid-template-columns: 140px 1fr; gap: 0; }
+  .meta-grid dt { padding: 8px 12px; font-weight: 600; font-size: 0.8rem; color: #495057; background: #f8f9fa; border-bottom: 1px solid #eee; }
+  .meta-grid dd { padding: 8px 12px; margin: 0; border-bottom: 1px solid #eee; font-size: 0.9rem; }
+  .tag { display: inline-block; background: #e9ecef; color: #495057; padding: 1px 8px; border-radius: 4px; font-size: 0.8rem; margin-right: 4px; }
+  .required { color: #dc3545; font-weight: 700; }
+  pre { background: #212529; color: #e9ecef; padding: 14px; border-radius: 6px; overflow-x: auto; font-size: 0.82rem; line-height: 1.5; margin: 0; }
+  .status-badge { display: inline-block; padding: 2px 8px; border-radius: 4px; font-weight: 600; font-size: 0.8rem; color: #fff; }
+  .status-2xx { background: #198754; } .status-3xx { background: #0dcaf0; color: #000; } .status-4xx { background: #fd7e14; } .status-5xx { background: #dc3545; }
+  .back-link { display: inline-block; margin-bottom: 16px; font-size: 0.85rem; }
+</style></head><body>
+<a href="index.html" class="back-link">&larr; Back to index</a>
+<h1><span class="method method-POST">POST</span> <span class="path">/auth/login</span></h1>
+<div class="card"><div class="card-header">Overview</div><div class="card-body"><dl class="meta-grid"><dt>Summary</dt><dd>Login</dd><dt>Description</dt><dd>Exchange HTTP Basic credentials for a JWT token</dd><dt>Operation ID</dt><dd><code>login</code></dd><dt>Tags</dt><dd><span class="tag">Auth</span></dd></dl></div></div>
+<div class="card"><div class="card-header">Security</div><div class="card-body"><p>basicAuth <span class="tag">http</span></p></div></div>
+<div class="card"><div class="card-header">Request body</div><div class="card-body"><details><summary>Request schema (JSON Schema v7)</summary><pre>{
+  "$schema" : "http://json-schema.org/draft-07/schema#",
+  "title" : "LoginForm",
+  "type" : "object",
+  "properties" : {
+    "client_id" : {
+      "type" : "string",
+      "required" : [
+      ]
+    },
+    "grant_type" : {
+      "type" : "string",
+      "required" : [
+      ]
+    }
+  },
+  "required" : [
+    "client_id",
+    "grant_type"
+  ],
+  "additionalProperties" : false
+}</pre></details></div></div>
+<div class="card"><div class="card-header"><span class="status-badge status-2xx">200</span> Response</div><div class="card-body"><p>Successful login</p><h4>Request body</h4><pre>client_id=web&amp;grant_type=password</pre><h4>Response body</h4><pre>{
+  "token" : "jwt.token.xyz",
+  "user" : {
+    "id" : "00000000-0000-0000-0000-000000000001",
+    "email" : "alice@example.com",
+    "name" : "Alice",
+    "role" : "admin"
+  }
+}</pre><details><summary>Response schema</summary><pre>{
+  "$schema" : "http://json-schema.org/draft-07/schema#",
+  "title" : "LoginResponse",
+  "type" : "object",
+  "properties" : {
+    "token" : {
+      "type" : "string",
+      "required" : [
+      ]
+    },
+    "user" : {
+      "title" : "User",
+      "type" : "object",
+      "properties" : {
+        "id" : {
+          "type" : "string",
+          "format" : "uuid",
+          "required" : [
+          ]
+        },
+        "email" : {
+          "type" : "string",
+          "required" : [
+          ]
+        },
+        "name" : {
+          "type" : "string",
+          "required" : [
+          ]
+        },
+        "role" : {
+          "type" : "string",
+          "description" : "User role within the system",
+          "enum" : [
+            "admin",
+            "member",
+            "guest"
+          ],
+          "required" : [
+          ]
+        }
+      },
+      "required" : [
+        "email",
+        "id",
+        "name",
+        "role"
+      ],
+      "additionalProperties" : false
+    }
+  },
+  "required" : [
+    "token",
+    "user"
+  ],
+  "additionalProperties" : false
+}</pre></details></div></div>
+<div class="card"><div class="card-header"><span class="status-badge status-4xx">401</span> Response</div><div class="card-body"><p>Invalid credentials</p><h4>Request body</h4><pre>client_id=web&amp;grant_type=password</pre><h4>Response body</h4><pre>{
+  "code" : "unauthorized",
+  "message" : "Bad credentials",
+  "details" : null
+}</pre><details><summary>Response schema</summary><pre>{
+  "$schema" : "http://json-schema.org/draft-07/schema#",
+  "title" : "ErrorResponse",
+  "type" : "object",
+  "properties" : {
+    "code" : {
+      "type" : "string",
+      "required" : [
+      ]
+    },
+    "message" : {
+      "type" : "string",
+      "required" : [
+      ]
+    },
+    "details" : {
+      "type" : "array",
+      "required" : [
+      ],
+      "items" : {
+        "type" : "string",
+        "required" : [
+        ]
+      }
+    }
+  },
+  "required" : [
+    "code",
+    "message"
+  ],
+  "additionalProperties" : false
+}</pre></details></div></div>
+</body></html>

--- a/openapi/src/test/resources/gold/simple/POST__projects-0f98e629.html
+++ b/openapi/src/test/resources/gold/simple/POST__projects-0f98e629.html
@@ -1,0 +1,172 @@
+<!DOCTYPE html><html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1"><title>POST /projects</title><style>
+  *, *::before, *::after { box-sizing: border-box; }
+  body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif; margin: 0; padding: 20px 40px; background: #f8f9fa; color: #1a1a2e; line-height: 1.5; }
+  h1 { font-size: 1.6rem; font-weight: 600; margin: 0 0 20px; color: #16213e; }
+  a { color: #0d6efd; text-decoration: none; }
+  a:hover { text-decoration: underline; }
+  .endpoint-list { list-style: none; padding: 0; margin: 0; }
+  .endpoint-list li { background: #fff; border: 1px solid #dee2e6; border-radius: 6px; margin-bottom: 8px; padding: 10px 16px; display: flex; align-items: center; gap: 12px; }
+  .endpoint-list li:hover { border-color: #0d6efd; }
+  .method { display: inline-block; font-size: 0.75rem; font-weight: 700; padding: 2px 8px; border-radius: 4px; min-width: 56px; text-align: center; color: #fff; }
+  .method-GET { background: #198754; } .method-POST { background: #0d6efd; } .method-PUT { background: #fd7e14; }
+  .method-PATCH { background: #6f42c1; } .method-DELETE { background: #dc3545; } .method-HEAD { background: #6c757d; }
+  .method-OPTIONS { background: #20c997; } .method-TRACE { background: #6c757d; } .method-CONNECT { background: #6c757d; }
+  .path { font-family: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace; font-size: 0.9rem; }
+  .card { background: #fff; border: 1px solid #dee2e6; border-radius: 8px; margin-bottom: 16px; overflow: hidden; }
+  .card-header { padding: 12px 16px; font-weight: 600; font-size: 0.85rem; color: #495057; background: #f1f3f5; border-bottom: 1px solid #dee2e6; text-transform: uppercase; letter-spacing: 0.05em; }
+  .card-body { padding: 16px; }
+  .card-body p { margin: 0 0 8px; }
+  .meta-grid { display: grid; grid-template-columns: 140px 1fr; gap: 0; }
+  .meta-grid dt { padding: 8px 12px; font-weight: 600; font-size: 0.8rem; color: #495057; background: #f8f9fa; border-bottom: 1px solid #eee; }
+  .meta-grid dd { padding: 8px 12px; margin: 0; border-bottom: 1px solid #eee; font-size: 0.9rem; }
+  .tag { display: inline-block; background: #e9ecef; color: #495057; padding: 1px 8px; border-radius: 4px; font-size: 0.8rem; margin-right: 4px; }
+  .required { color: #dc3545; font-weight: 700; }
+  pre { background: #212529; color: #e9ecef; padding: 14px; border-radius: 6px; overflow-x: auto; font-size: 0.82rem; line-height: 1.5; margin: 0; }
+  .status-badge { display: inline-block; padding: 2px 8px; border-radius: 4px; font-weight: 600; font-size: 0.8rem; color: #fff; }
+  .status-2xx { background: #198754; } .status-3xx { background: #0dcaf0; color: #000; } .status-4xx { background: #fd7e14; } .status-5xx { background: #dc3545; }
+  .back-link { display: inline-block; margin-bottom: 16px; font-size: 0.85rem; }
+</style></head><body>
+<a href="index.html" class="back-link">&larr; Back to index</a>
+<h1><span class="method method-POST">POST</span> <span class="path">/projects</span></h1>
+<div class="card"><div class="card-header">Overview</div><div class="card-body"><dl class="meta-grid"><dt>Summary</dt><dd>Create project</dd><dt>Description</dt><dd>Create a new project</dd><dt>Operation ID</dt><dd><code>createProject</code></dd><dt>Tags</dt><dd><span class="tag">Projects</span></dd></dl></div></div>
+<div class="card"><div class="card-header">Security</div><div class="card-body"><p>oauth2 <span class="tag">oauth2</span></p></div></div>
+<div class="card"><div class="card-header">Request body</div><div class="card-body"><details><summary>Request schema (JSON Schema v7)</summary><pre>{
+  "$schema" : "http://json-schema.org/draft-07/schema#",
+  "title" : "CreateProjectRequest",
+  "type" : "object",
+  "properties" : {
+    "name" : {
+      "type" : "string",
+      "required" : [
+      ]
+    },
+    "description" : {
+      "type" : "string",
+      "required" : [
+      ]
+    },
+    "status" : {
+      "type" : "string",
+      "description" : "Lifecycle state of a project",
+      "enum" : [
+        "active",
+        "archived",
+        "draft"
+      ],
+      "required" : [
+      ]
+    }
+  },
+  "required" : [
+    "name",
+    "status"
+  ],
+  "additionalProperties" : false
+}</pre></details></div></div>
+<div class="card"><div class="card-header"><span class="status-badge status-2xx">201</span> Response</div><div class="card-body"><p>Project created</p><h4>Request body</h4><pre>{
+  "name" : "Apollo",
+  "description" : "Mission control",
+  "status" : "active"
+}</pre><h4>Response body</h4><pre>{
+  "id" : 42,
+  "name" : "Apollo",
+  "description" : "Mission control",
+  "status" : "active",
+  "ownerId" : "00000000-0000-0000-0000-000000000001",
+  "createdAt" : "2026-01-01T00:00:00Z"
+}</pre><details><summary>Response schema</summary><pre>{
+  "$schema" : "http://json-schema.org/draft-07/schema#",
+  "title" : "Project",
+  "type" : "object",
+  "properties" : {
+    "name" : {
+      "type" : "string",
+      "required" : [
+      ]
+    },
+    "description" : {
+      "type" : "string",
+      "required" : [
+      ]
+    },
+    "id" : {
+      "type" : "integer",
+      "format" : "int64",
+      "required" : [
+      ]
+    },
+    "status" : {
+      "type" : "string",
+      "description" : "Lifecycle state of a project",
+      "enum" : [
+        "active",
+        "archived",
+        "draft"
+      ],
+      "required" : [
+      ]
+    },
+    "createdAt" : {
+      "type" : "string",
+      "required" : [
+      ]
+    },
+    "ownerId" : {
+      "type" : "string",
+      "format" : "uuid",
+      "required" : [
+      ]
+    }
+  },
+  "required" : [
+    "createdAt",
+    "id",
+    "name",
+    "ownerId",
+    "status"
+  ],
+  "additionalProperties" : false
+}</pre></details></div></div>
+<div class="card"><div class="card-header"><span class="status-badge status-4xx">400</span> Response</div><div class="card-body"><p>Validation failed</p><h4>Request body</h4><pre>{
+  "name" : "",
+  "description" : null,
+  "status" : "draft"
+}</pre><h4>Response body</h4><pre>{
+  "code" : "validation",
+  "message" : "One or more fields are invalid",
+  "details" : [
+    "name: must not be blank"
+  ]
+}</pre><details><summary>Response schema</summary><pre>{
+  "$schema" : "http://json-schema.org/draft-07/schema#",
+  "title" : "ErrorResponse",
+  "type" : "object",
+  "properties" : {
+    "code" : {
+      "type" : "string",
+      "required" : [
+      ]
+    },
+    "message" : {
+      "type" : "string",
+      "required" : [
+      ]
+    },
+    "details" : {
+      "type" : "array",
+      "required" : [
+      ],
+      "items" : {
+        "type" : "string",
+        "required" : [
+        ]
+      }
+    }
+  },
+  "required" : [
+    "code",
+    "message"
+  ],
+  "additionalProperties" : false
+}</pre></details></div></div>
+</body></html>

--- a/openapi/src/test/resources/gold/simple/POST__projects-0f98e629.html
+++ b/openapi/src/test/resources/gold/simple/POST__projects-0f98e629.html
@@ -36,14 +36,10 @@
   "type" : "object",
   "properties" : {
     "name" : {
-      "type" : "string",
-      "required" : [
-      ]
+      "type" : "string"
     },
     "description" : {
-      "type" : "string",
-      "required" : [
-      ]
+      "type" : "string"
     },
     "status" : {
       "type" : "string",
@@ -52,8 +48,6 @@
         "active",
         "archived",
         "draft"
-      ],
-      "required" : [
       ]
     }
   },
@@ -80,20 +74,14 @@
   "type" : "object",
   "properties" : {
     "name" : {
-      "type" : "string",
-      "required" : [
-      ]
+      "type" : "string"
     },
     "description" : {
-      "type" : "string",
-      "required" : [
-      ]
+      "type" : "string"
     },
     "id" : {
       "type" : "integer",
-      "format" : "int64",
-      "required" : [
-      ]
+      "format" : "int64"
     },
     "status" : {
       "type" : "string",
@@ -102,20 +90,14 @@
         "active",
         "archived",
         "draft"
-      ],
-      "required" : [
       ]
     },
     "createdAt" : {
-      "type" : "string",
-      "required" : [
-      ]
+      "type" : "string"
     },
     "ownerId" : {
       "type" : "string",
-      "format" : "uuid",
-      "required" : [
-      ]
+      "format" : "uuid"
     }
   },
   "required" : [
@@ -143,23 +125,15 @@
   "type" : "object",
   "properties" : {
     "code" : {
-      "type" : "string",
-      "required" : [
-      ]
+      "type" : "string"
     },
     "message" : {
-      "type" : "string",
-      "required" : [
-      ]
+      "type" : "string"
     },
     "details" : {
       "type" : "array",
-      "required" : [
-      ],
       "items" : {
-        "type" : "string",
-        "required" : [
-        ]
+        "type" : "string"
       }
     }
   },

--- a/openapi/src/test/resources/gold/simple/POST__projects___projectId___tasks-f083bafd.html
+++ b/openapi/src/test/resources/gold/simple/POST__projects___projectId___tasks-f083bafd.html
@@ -37,14 +37,10 @@
   "type" : "object",
   "properties" : {
     "title" : {
-      "type" : "string",
-      "required" : [
-      ]
+      "type" : "string"
     },
     "description" : {
-      "type" : "string",
-      "required" : [
-      ]
+      "type" : "string"
     },
     "priority" : {
       "type" : "string",
@@ -53,8 +49,6 @@
         "low",
         "medium",
         "high"
-      ],
-      "required" : [
       ]
     }
   },
@@ -86,30 +80,20 @@
         "low",
         "medium",
         "high"
-      ],
-      "required" : [
       ]
     },
     "description" : {
-      "type" : "string",
-      "required" : [
-      ]
+      "type" : "string"
     },
     "id" : {
       "type" : "integer",
-      "format" : "int64",
-      "required" : [
-      ]
+      "format" : "int64"
     },
     "done" : {
-      "type" : "boolean",
-      "required" : [
-      ]
+      "type" : "boolean"
     },
     "title" : {
-      "type" : "string",
-      "required" : [
-      ]
+      "type" : "string"
     }
   },
   "required" : [

--- a/openapi/src/test/resources/gold/simple/POST__projects___projectId___tasks-f083bafd.html
+++ b/openapi/src/test/resources/gold/simple/POST__projects___projectId___tasks-f083bafd.html
@@ -1,0 +1,123 @@
+<!DOCTYPE html><html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1"><title>POST /projects/{projectId}/tasks</title><style>
+  *, *::before, *::after { box-sizing: border-box; }
+  body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif; margin: 0; padding: 20px 40px; background: #f8f9fa; color: #1a1a2e; line-height: 1.5; }
+  h1 { font-size: 1.6rem; font-weight: 600; margin: 0 0 20px; color: #16213e; }
+  a { color: #0d6efd; text-decoration: none; }
+  a:hover { text-decoration: underline; }
+  .endpoint-list { list-style: none; padding: 0; margin: 0; }
+  .endpoint-list li { background: #fff; border: 1px solid #dee2e6; border-radius: 6px; margin-bottom: 8px; padding: 10px 16px; display: flex; align-items: center; gap: 12px; }
+  .endpoint-list li:hover { border-color: #0d6efd; }
+  .method { display: inline-block; font-size: 0.75rem; font-weight: 700; padding: 2px 8px; border-radius: 4px; min-width: 56px; text-align: center; color: #fff; }
+  .method-GET { background: #198754; } .method-POST { background: #0d6efd; } .method-PUT { background: #fd7e14; }
+  .method-PATCH { background: #6f42c1; } .method-DELETE { background: #dc3545; } .method-HEAD { background: #6c757d; }
+  .method-OPTIONS { background: #20c997; } .method-TRACE { background: #6c757d; } .method-CONNECT { background: #6c757d; }
+  .path { font-family: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace; font-size: 0.9rem; }
+  .card { background: #fff; border: 1px solid #dee2e6; border-radius: 8px; margin-bottom: 16px; overflow: hidden; }
+  .card-header { padding: 12px 16px; font-weight: 600; font-size: 0.85rem; color: #495057; background: #f1f3f5; border-bottom: 1px solid #dee2e6; text-transform: uppercase; letter-spacing: 0.05em; }
+  .card-body { padding: 16px; }
+  .card-body p { margin: 0 0 8px; }
+  .meta-grid { display: grid; grid-template-columns: 140px 1fr; gap: 0; }
+  .meta-grid dt { padding: 8px 12px; font-weight: 600; font-size: 0.8rem; color: #495057; background: #f8f9fa; border-bottom: 1px solid #eee; }
+  .meta-grid dd { padding: 8px 12px; margin: 0; border-bottom: 1px solid #eee; font-size: 0.9rem; }
+  .tag { display: inline-block; background: #e9ecef; color: #495057; padding: 1px 8px; border-radius: 4px; font-size: 0.8rem; margin-right: 4px; }
+  .required { color: #dc3545; font-weight: 700; }
+  pre { background: #212529; color: #e9ecef; padding: 14px; border-radius: 6px; overflow-x: auto; font-size: 0.82rem; line-height: 1.5; margin: 0; }
+  .status-badge { display: inline-block; padding: 2px 8px; border-radius: 4px; font-weight: 600; font-size: 0.8rem; color: #fff; }
+  .status-2xx { background: #198754; } .status-3xx { background: #0dcaf0; color: #000; } .status-4xx { background: #fd7e14; } .status-5xx { background: #dc3545; }
+  .back-link { display: inline-block; margin-bottom: 16px; font-size: 0.85rem; }
+</style></head><body>
+<a href="index.html" class="back-link">&larr; Back to index</a>
+<h1><span class="method method-POST">POST</span> <span class="path">/projects/{projectId}/tasks</span></h1>
+<div class="card"><div class="card-header">Overview</div><div class="card-body"><dl class="meta-grid"><dt>Summary</dt><dd>Create task</dd><dt>Description</dt><dd>Create a task in a project</dd><dt>Operation ID</dt><dd><code>createTask</code></dd><dt>Tags</dt><dd><span class="tag">Tasks</span></dd></dl></div></div>
+<div class="card"><div class="card-header">Security</div><div class="card-body"><p>oauth2 <span class="tag">oauth2</span></p></div></div>
+<div class="card"><div class="card-header">Path Parameters</div><div class="card-body"><dl class="meta-grid"><dt>projectId <span class="required">*</span></dt><dd><code>Long</code></dd></dl></div></div>
+<div class="card"><div class="card-header">Request body</div><div class="card-body"><details><summary>Request schema (JSON Schema v7)</summary><pre>{
+  "$schema" : "http://json-schema.org/draft-07/schema#",
+  "title" : "CreateTaskRequest",
+  "type" : "object",
+  "properties" : {
+    "title" : {
+      "type" : "string",
+      "required" : [
+      ]
+    },
+    "description" : {
+      "type" : "string",
+      "required" : [
+      ]
+    },
+    "priority" : {
+      "type" : "string",
+      "description" : "Task priority level",
+      "enum" : [
+        "low",
+        "medium",
+        "high"
+      ],
+      "required" : [
+      ]
+    }
+  },
+  "required" : [
+    "priority",
+    "title"
+  ],
+  "additionalProperties" : false
+}</pre></details></div></div>
+<div class="card"><div class="card-header"><span class="status-badge status-2xx">201</span> Response</div><div class="card-body"><p>Task created</p><h4>Response headers</h4><dl class="meta-grid"><dt>Location <span class="required">*</span></dt><dd><code>String</code> = <code>/projects/42/tasks/101</code></dd></dl><h4>Request body</h4><pre>{
+  "title" : "New task",
+  "description" : null,
+  "priority" : "medium"
+}</pre><h4>Response body</h4><pre>{
+  "id" : 101,
+  "title" : "Wire up telemetry",
+  "description" : "Prometheus + Grafana",
+  "done" : false,
+  "priority" : "high"
+}</pre><details><summary>Response schema</summary><pre>{
+  "$schema" : "http://json-schema.org/draft-07/schema#",
+  "title" : "Task",
+  "type" : "object",
+  "properties" : {
+    "priority" : {
+      "type" : "string",
+      "description" : "Task priority level",
+      "enum" : [
+        "low",
+        "medium",
+        "high"
+      ],
+      "required" : [
+      ]
+    },
+    "description" : {
+      "type" : "string",
+      "required" : [
+      ]
+    },
+    "id" : {
+      "type" : "integer",
+      "format" : "int64",
+      "required" : [
+      ]
+    },
+    "done" : {
+      "type" : "boolean",
+      "required" : [
+      ]
+    },
+    "title" : {
+      "type" : "string",
+      "required" : [
+      ]
+    }
+  },
+  "required" : [
+    "done",
+    "id",
+    "priority",
+    "title"
+  ],
+  "additionalProperties" : false
+}</pre></details></div></div>
+</body></html>

--- a/openapi/src/test/resources/gold/simple/POST__webhooks-20c9a68b.html
+++ b/openapi/src/test/resources/gold/simple/POST__webhooks-20c9a68b.html
@@ -1,0 +1,85 @@
+<!DOCTYPE html><html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1"><title>POST /webhooks</title><style>
+  *, *::before, *::after { box-sizing: border-box; }
+  body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif; margin: 0; padding: 20px 40px; background: #f8f9fa; color: #1a1a2e; line-height: 1.5; }
+  h1 { font-size: 1.6rem; font-weight: 600; margin: 0 0 20px; color: #16213e; }
+  a { color: #0d6efd; text-decoration: none; }
+  a:hover { text-decoration: underline; }
+  .endpoint-list { list-style: none; padding: 0; margin: 0; }
+  .endpoint-list li { background: #fff; border: 1px solid #dee2e6; border-radius: 6px; margin-bottom: 8px; padding: 10px 16px; display: flex; align-items: center; gap: 12px; }
+  .endpoint-list li:hover { border-color: #0d6efd; }
+  .method { display: inline-block; font-size: 0.75rem; font-weight: 700; padding: 2px 8px; border-radius: 4px; min-width: 56px; text-align: center; color: #fff; }
+  .method-GET { background: #198754; } .method-POST { background: #0d6efd; } .method-PUT { background: #fd7e14; }
+  .method-PATCH { background: #6f42c1; } .method-DELETE { background: #dc3545; } .method-HEAD { background: #6c757d; }
+  .method-OPTIONS { background: #20c997; } .method-TRACE { background: #6c757d; } .method-CONNECT { background: #6c757d; }
+  .path { font-family: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace; font-size: 0.9rem; }
+  .card { background: #fff; border: 1px solid #dee2e6; border-radius: 8px; margin-bottom: 16px; overflow: hidden; }
+  .card-header { padding: 12px 16px; font-weight: 600; font-size: 0.85rem; color: #495057; background: #f1f3f5; border-bottom: 1px solid #dee2e6; text-transform: uppercase; letter-spacing: 0.05em; }
+  .card-body { padding: 16px; }
+  .card-body p { margin: 0 0 8px; }
+  .meta-grid { display: grid; grid-template-columns: 140px 1fr; gap: 0; }
+  .meta-grid dt { padding: 8px 12px; font-weight: 600; font-size: 0.8rem; color: #495057; background: #f8f9fa; border-bottom: 1px solid #eee; }
+  .meta-grid dd { padding: 8px 12px; margin: 0; border-bottom: 1px solid #eee; font-size: 0.9rem; }
+  .tag { display: inline-block; background: #e9ecef; color: #495057; padding: 1px 8px; border-radius: 4px; font-size: 0.8rem; margin-right: 4px; }
+  .required { color: #dc3545; font-weight: 700; }
+  pre { background: #212529; color: #e9ecef; padding: 14px; border-radius: 6px; overflow-x: auto; font-size: 0.82rem; line-height: 1.5; margin: 0; }
+  .status-badge { display: inline-block; padding: 2px 8px; border-radius: 4px; font-weight: 600; font-size: 0.8rem; color: #fff; }
+  .status-2xx { background: #198754; } .status-3xx { background: #0dcaf0; color: #000; } .status-4xx { background: #fd7e14; } .status-5xx { background: #dc3545; }
+  .back-link { display: inline-block; margin-bottom: 16px; font-size: 0.85rem; }
+</style></head><body>
+<a href="index.html" class="back-link">&larr; Back to index</a>
+<h1><span class="method method-POST">POST</span> <span class="path">/webhooks</span></h1>
+<div class="card"><div class="card-header">Overview</div><div class="card-body"><dl class="meta-grid"><dt>Summary</dt><dd>Deliver webhook</dd><dt>Description</dt><dd>Accept a webhook payload</dd><dt>Operation ID</dt><dd><code>deliverWebhook</code></dd><dt>Tags</dt><dd><span class="tag">Webhooks</span></dd></dl></div></div>
+<div class="card"><div class="card-header">Security</div><div class="card-body"><p>apiKey <span class="tag">apiKey</span></p></div></div>
+<div class="card"><div class="card-header">Request body</div><div class="card-body"><details><summary>Request schema (JSON Schema v7)</summary><pre>{
+  "$schema" : "http://json-schema.org/draft-07/schema#",
+  "title" : "WebhookPayload",
+  "type" : "object",
+  "properties" : {
+    "event" : {
+      "type" : "string",
+      "required" : [
+      ]
+    },
+    "data" : {
+      "type" : "string",
+      "required" : [
+      ]
+    }
+  },
+  "required" : [
+    "data",
+    "event"
+  ],
+  "additionalProperties" : false
+}</pre></details></div></div>
+<div class="card"><div class="card-header"><span class="status-badge status-2xx">202</span> Response</div><div class="card-body"><p>Legacy plain-text ack</p><h4>Request body</h4><pre>{
+  "event" : "order.created",
+  "data" : "{\"id\":1}"
+}</pre><h4>Response body</h4><pre>ACK</pre><details><summary>Response schema</summary><pre>{
+  "$schema" : "http://json-schema.org/draft-07/schema#",
+  "type" : "string",
+  "required" : [
+  ]
+}</pre></details></div></div>
+<div class="card"><div class="card-header"><span class="status-badge status-2xx">202</span> Response</div><div class="card-body"><p>Webhook accepted</p><h4>Request body</h4><pre>{
+  "event" : "order.created",
+  "data" : "{\"id\":1}"
+}</pre><h4>Response body</h4><pre>{
+  "received" : true
+}</pre><details><summary>Response schema</summary><pre>{
+  "$schema" : "http://json-schema.org/draft-07/schema#",
+  "title" : "WebhookAck",
+  "type" : "object",
+  "properties" : {
+    "received" : {
+      "type" : "boolean",
+      "required" : [
+      ]
+    }
+  },
+  "required" : [
+    "received"
+  ],
+  "additionalProperties" : false
+}</pre></details></div></div>
+</body></html>

--- a/openapi/src/test/resources/gold/simple/POST__webhooks-20c9a68b.html
+++ b/openapi/src/test/resources/gold/simple/POST__webhooks-20c9a68b.html
@@ -36,14 +36,10 @@
   "type" : "object",
   "properties" : {
     "event" : {
-      "type" : "string",
-      "required" : [
-      ]
+      "type" : "string"
     },
     "data" : {
-      "type" : "string",
-      "required" : [
-      ]
+      "type" : "string"
     }
   },
   "required" : [
@@ -57,9 +53,7 @@
   "data" : "{\"id\":1}"
 }</pre><h4>Response body</h4><pre>ACK</pre><details><summary>Response schema</summary><pre>{
   "$schema" : "http://json-schema.org/draft-07/schema#",
-  "type" : "string",
-  "required" : [
-  ]
+  "type" : "string"
 }</pre></details></div></div>
 <div class="card"><div class="card-header"><span class="status-badge status-2xx">202</span> Response</div><div class="card-body"><p>Webhook accepted</p><h4>Request body</h4><pre>{
   "event" : "order.created",
@@ -72,9 +66,7 @@
   "type" : "object",
   "properties" : {
     "received" : {
-      "type" : "boolean",
-      "required" : [
-      ]
+      "type" : "boolean"
     }
   },
   "required" : [

--- a/openapi/src/test/resources/gold/simple/PUT__users___userId__-3f0ffd01.html
+++ b/openapi/src/test/resources/gold/simple/PUT__users___userId__-3f0ffd01.html
@@ -1,0 +1,111 @@
+<!DOCTYPE html><html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1"><title>PUT /users/{userId}</title><style>
+  *, *::before, *::after { box-sizing: border-box; }
+  body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif; margin: 0; padding: 20px 40px; background: #f8f9fa; color: #1a1a2e; line-height: 1.5; }
+  h1 { font-size: 1.6rem; font-weight: 600; margin: 0 0 20px; color: #16213e; }
+  a { color: #0d6efd; text-decoration: none; }
+  a:hover { text-decoration: underline; }
+  .endpoint-list { list-style: none; padding: 0; margin: 0; }
+  .endpoint-list li { background: #fff; border: 1px solid #dee2e6; border-radius: 6px; margin-bottom: 8px; padding: 10px 16px; display: flex; align-items: center; gap: 12px; }
+  .endpoint-list li:hover { border-color: #0d6efd; }
+  .method { display: inline-block; font-size: 0.75rem; font-weight: 700; padding: 2px 8px; border-radius: 4px; min-width: 56px; text-align: center; color: #fff; }
+  .method-GET { background: #198754; } .method-POST { background: #0d6efd; } .method-PUT { background: #fd7e14; }
+  .method-PATCH { background: #6f42c1; } .method-DELETE { background: #dc3545; } .method-HEAD { background: #6c757d; }
+  .method-OPTIONS { background: #20c997; } .method-TRACE { background: #6c757d; } .method-CONNECT { background: #6c757d; }
+  .path { font-family: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace; font-size: 0.9rem; }
+  .card { background: #fff; border: 1px solid #dee2e6; border-radius: 8px; margin-bottom: 16px; overflow: hidden; }
+  .card-header { padding: 12px 16px; font-weight: 600; font-size: 0.85rem; color: #495057; background: #f1f3f5; border-bottom: 1px solid #dee2e6; text-transform: uppercase; letter-spacing: 0.05em; }
+  .card-body { padding: 16px; }
+  .card-body p { margin: 0 0 8px; }
+  .meta-grid { display: grid; grid-template-columns: 140px 1fr; gap: 0; }
+  .meta-grid dt { padding: 8px 12px; font-weight: 600; font-size: 0.8rem; color: #495057; background: #f8f9fa; border-bottom: 1px solid #eee; }
+  .meta-grid dd { padding: 8px 12px; margin: 0; border-bottom: 1px solid #eee; font-size: 0.9rem; }
+  .tag { display: inline-block; background: #e9ecef; color: #495057; padding: 1px 8px; border-radius: 4px; font-size: 0.8rem; margin-right: 4px; }
+  .required { color: #dc3545; font-weight: 700; }
+  pre { background: #212529; color: #e9ecef; padding: 14px; border-radius: 6px; overflow-x: auto; font-size: 0.82rem; line-height: 1.5; margin: 0; }
+  .status-badge { display: inline-block; padding: 2px 8px; border-radius: 4px; font-weight: 600; font-size: 0.8rem; color: #fff; }
+  .status-2xx { background: #198754; } .status-3xx { background: #0dcaf0; color: #000; } .status-4xx { background: #fd7e14; } .status-5xx { background: #dc3545; }
+  .back-link { display: inline-block; margin-bottom: 16px; font-size: 0.85rem; }
+</style></head><body>
+<a href="index.html" class="back-link">&larr; Back to index</a>
+<h1><span class="method method-PUT">PUT</span> <span class="path">/users/{userId}</span></h1>
+<div class="card"><div class="card-header">Overview</div><div class="card-body"><dl class="meta-grid"><dt>Summary</dt><dd>Update user</dd><dt>Description</dt><dd>Replace a user's profile (admin only)</dd><dt>Operation ID</dt><dd><code>updateUser</code></dd><dt>Tags</dt><dd><span class="tag">Users</span></dd></dl></div></div>
+<div class="card"><div class="card-header">Security</div><div class="card-body"><p>bearerAuth <span class="tag">http</span></p></div></div>
+<div class="card"><div class="card-header">Path Parameters</div><div class="card-body"><dl class="meta-grid"><dt>userId <span class="required">*</span></dt><dd><code>UUID</code></dd></dl></div></div>
+<div class="card"><div class="card-header">Request body</div><div class="card-body"><details><summary>Request schema (JSON Schema v7)</summary><pre>{
+  "$schema" : "http://json-schema.org/draft-07/schema#",
+  "title" : "UpdateUserRequest",
+  "type" : "object",
+  "properties" : {
+    "name" : {
+      "type" : "string",
+      "required" : [
+      ]
+    },
+    "role" : {
+      "type" : "string",
+      "description" : "User role within the system",
+      "enum" : [
+        "admin",
+        "member",
+        "guest"
+      ],
+      "required" : [
+      ]
+    }
+  },
+  "required" : [
+    "name",
+    "role"
+  ],
+  "additionalProperties" : false
+}</pre></details></div></div>
+<div class="card"><div class="card-header"><span class="status-badge status-2xx">200</span> Response</div><div class="card-body"><p>User updated</p><h4>Request body</h4><pre>{
+  "name" : "Alice Updated",
+  "role" : "admin"
+}</pre><h4>Response body</h4><pre>{
+  "id" : "00000000-0000-0000-0000-000000000001",
+  "email" : "alice@example.com",
+  "name" : "Alice Updated",
+  "role" : "admin"
+}</pre><details><summary>Response schema</summary><pre>{
+  "$schema" : "http://json-schema.org/draft-07/schema#",
+  "title" : "User",
+  "type" : "object",
+  "properties" : {
+    "id" : {
+      "type" : "string",
+      "format" : "uuid",
+      "required" : [
+      ]
+    },
+    "email" : {
+      "type" : "string",
+      "required" : [
+      ]
+    },
+    "name" : {
+      "type" : "string",
+      "required" : [
+      ]
+    },
+    "role" : {
+      "type" : "string",
+      "description" : "User role within the system",
+      "enum" : [
+        "admin",
+        "member",
+        "guest"
+      ],
+      "required" : [
+      ]
+    }
+  },
+  "required" : [
+    "email",
+    "id",
+    "name",
+    "role"
+  ],
+  "additionalProperties" : false
+}</pre></details></div></div>
+</body></html>

--- a/openapi/src/test/resources/gold/simple/PUT__users___userId__-3f0ffd01.html
+++ b/openapi/src/test/resources/gold/simple/PUT__users___userId__-3f0ffd01.html
@@ -37,9 +37,7 @@
   "type" : "object",
   "properties" : {
     "name" : {
-      "type" : "string",
-      "required" : [
-      ]
+      "type" : "string"
     },
     "role" : {
       "type" : "string",
@@ -48,8 +46,6 @@
         "admin",
         "member",
         "guest"
-      ],
-      "required" : [
       ]
     }
   },
@@ -74,19 +70,13 @@
   "properties" : {
     "id" : {
       "type" : "string",
-      "format" : "uuid",
-      "required" : [
-      ]
+      "format" : "uuid"
     },
     "email" : {
-      "type" : "string",
-      "required" : [
-      ]
+      "type" : "string"
     },
     "name" : {
-      "type" : "string",
-      "required" : [
-      ]
+      "type" : "string"
     },
     "role" : {
       "type" : "string",
@@ -95,8 +85,6 @@
         "admin",
         "member",
         "guest"
-      ],
-      "required" : [
       ]
     }
   },

--- a/openapi/src/test/resources/gold/simple/index.html
+++ b/openapi/src/test/resources/gold/simple/index.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html><html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1"><title>API Documentation</title><style>
+  *, *::before, *::after { box-sizing: border-box; }
+  body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif; margin: 0; padding: 20px 40px; background: #f8f9fa; color: #1a1a2e; line-height: 1.5; }
+  h1 { font-size: 1.6rem; font-weight: 600; margin: 0 0 20px; color: #16213e; }
+  a { color: #0d6efd; text-decoration: none; }
+  a:hover { text-decoration: underline; }
+  .endpoint-list { list-style: none; padding: 0; margin: 0; }
+  .endpoint-list li { background: #fff; border: 1px solid #dee2e6; border-radius: 6px; margin-bottom: 8px; padding: 10px 16px; display: flex; align-items: center; gap: 12px; }
+  .endpoint-list li:hover { border-color: #0d6efd; }
+  .method { display: inline-block; font-size: 0.75rem; font-weight: 700; padding: 2px 8px; border-radius: 4px; min-width: 56px; text-align: center; color: #fff; }
+  .method-GET { background: #198754; } .method-POST { background: #0d6efd; } .method-PUT { background: #fd7e14; }
+  .method-PATCH { background: #6f42c1; } .method-DELETE { background: #dc3545; } .method-HEAD { background: #6c757d; }
+  .method-OPTIONS { background: #20c997; } .method-TRACE { background: #6c757d; } .method-CONNECT { background: #6c757d; }
+  .path { font-family: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace; font-size: 0.9rem; }
+  .card { background: #fff; border: 1px solid #dee2e6; border-radius: 8px; margin-bottom: 16px; overflow: hidden; }
+  .card-header { padding: 12px 16px; font-weight: 600; font-size: 0.85rem; color: #495057; background: #f1f3f5; border-bottom: 1px solid #dee2e6; text-transform: uppercase; letter-spacing: 0.05em; }
+  .card-body { padding: 16px; }
+  .card-body p { margin: 0 0 8px; }
+  .meta-grid { display: grid; grid-template-columns: 140px 1fr; gap: 0; }
+  .meta-grid dt { padding: 8px 12px; font-weight: 600; font-size: 0.8rem; color: #495057; background: #f8f9fa; border-bottom: 1px solid #eee; }
+  .meta-grid dd { padding: 8px 12px; margin: 0; border-bottom: 1px solid #eee; font-size: 0.9rem; }
+  .tag { display: inline-block; background: #e9ecef; color: #495057; padding: 1px 8px; border-radius: 4px; font-size: 0.8rem; margin-right: 4px; }
+  .required { color: #dc3545; font-weight: 700; }
+  pre { background: #212529; color: #e9ecef; padding: 14px; border-radius: 6px; overflow-x: auto; font-size: 0.82rem; line-height: 1.5; margin: 0; }
+  .status-badge { display: inline-block; padding: 2px 8px; border-radius: 4px; font-weight: 600; font-size: 0.8rem; color: #fff; }
+  .status-2xx { background: #198754; } .status-3xx { background: #0dcaf0; color: #000; } .status-4xx { background: #fd7e14; } .status-5xx { background: #dc3545; }
+  .back-link { display: inline-block; margin-bottom: 16px; font-size: 0.85rem; }
+</style></head><body>
+<h1>API Documentation</h1>
+<ul class="endpoint-list">
+<li><a href="POST__auth_login-3b67d231.html"><span class="method method-POST">POST</span> <span class="path">/auth/login</span></a></li>
+<li><a href="GET__health-334cfc61.html"><span class="method method-GET">GET</span> <span class="path">/health</span></a></li>
+<li><a href="GET__me-2647d21d.html"><span class="method method-GET">GET</span> <span class="path">/me</span></a></li>
+<li><a href="GET__projects-9a7aa53f.html"><span class="method method-GET">GET</span> <span class="path">/projects</span></a></li>
+<li><a href="POST__projects-0f98e629.html"><span class="method method-POST">POST</span> <span class="path">/projects</span></a></li>
+<li><a href="PATCH__projects___projectId__-fc9e4246.html"><span class="method method-PATCH">PATCH</span> <span class="path">/projects/{projectId}</span></a></li>
+<li><a href="GET__projects___projectId___tasks-b0b82093.html"><span class="method method-GET">GET</span> <span class="path">/projects/{projectId}/tasks</span></a></li>
+<li><a href="POST__projects___projectId___tasks-f083bafd.html"><span class="method method-POST">POST</span> <span class="path">/projects/{projectId}/tasks</span></a></li>
+<li><a href="GET__users-c054bf63.html"><span class="method method-GET">GET</span> <span class="path">/users</span></a></li>
+<li><a href="DELETE__users___userId__-cf0347bd.html"><span class="method method-DELETE">DELETE</span> <span class="path">/users/{userId}</span></a></li>
+<li><a href="GET__users___userId__-baf46b48.html"><span class="method method-GET">GET</span> <span class="path">/users/{userId}</span></a></li>
+<li><a href="PUT__users___userId__-3f0ffd01.html"><span class="method method-PUT">PUT</span> <span class="path">/users/{userId}</span></a></li>
+<li><a href="POST__webhooks-20c9a68b.html"><span class="method method-POST">POST</span> <span class="path">/webhooks</span></a></li>
+</ul>
+</body></html>

--- a/openapi/src/test/resources/gold/tsrest/package-contracts.json
+++ b/openapi/src/test/resources/gold/tsrest/package-contracts.json
@@ -1,0 +1,6 @@
+{
+  "name": "baklava-gold-contracts",
+  "version": "0.0.0-test",
+  "main": "index.js",
+  "types": "index.d.ts"
+}

--- a/openapi/src/test/resources/gold/tsrest/package.json
+++ b/openapi/src/test/resources/gold/tsrest/package.json
@@ -1,0 +1,32 @@
+
+{
+  "name": "my-contracts",
+  "version": "1.0.0",
+  "description": "ts-rest contract package",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build:js": "esbuild src/contracts.ts --bundle --platform=node --target=es2022 --format=esm --tree-shaking=true --outfile=dist/index.js",
+    "build:dts": "dts-bundle-generator -o dist/index.d.ts src/contracts.ts",
+    "build:package": "cp package-contracts.json dist/package.json && sed -i \"s/VERSION/${VERSION}/g\" dist/package.json",
+    "build": "pnpm run build:js && pnpm run build:dts && pnpm run build:package"
+  },
+  "peerDependencies": {
+    "@ts-rest/core": "^3.52.1",
+    "zod": "^3.25.32"
+  },
+  "devDependencies": {
+    "esbuild": "^0.25.2",
+    "dts-bundle-generator": "^9.5.1",
+    "typescript": "^5.8.3"
+  }
+}

--- a/openapi/src/test/resources/gold/tsrest/src/auth-login.contract.ts
+++ b/openapi/src/test/resources/gold/tsrest/src/auth-login.contract.ts
@@ -1,0 +1,27 @@
+import { z } from "zod";
+import { initContract } from "@ts-rest/core";
+
+export const authLoginContract = initContract().router({
+  post: {
+    summary: 'Login',
+    description: 'Exchange HTTP Basic credentials for a JWT token',
+    method: 'POST',
+    path: '/auth/login',
+    body: z.object({
+        "client_id": z.string(),
+        "grant_type": z.string()}),
+    responses: {
+      200: z.object({
+        "token": z.string(),
+        "user": z.object({
+        "email": z.string(),
+        "id": z.string().uuid(),
+        "name": z.string(),
+        "role": z.enum(["admin","guest","member"]).describe("User role within the system")})}),
+      401: z.object({
+        "code": z.string(),
+        "details": z.array(z.string()).nullish(),
+        "message": z.string()})
+    }
+  }
+});

--- a/openapi/src/test/resources/gold/tsrest/src/contracts.ts
+++ b/openapi/src/test/resources/gold/tsrest/src/contracts.ts
@@ -1,0 +1,32 @@
+import { authLoginContract } from "./auth-login.contract";
+import { healthContract } from "./health.contract";
+import { meContract } from "./me.contract";
+import { projectsContract } from "./projects.contract";
+import { projectsProjectIdContract } from "./projects---projectId.contract";
+import { projectsProjectIdTasksContract } from "./projects---projectId-tasks.contract";
+import { usersContract } from "./users.contract";
+import { usersUserIdContract } from "./users---userId.contract";
+import { webhooksContract } from "./webhooks.contract";
+
+export const contracts: {
+  "auth-login": typeof authLoginContract;
+  "health": typeof healthContract;
+  "me": typeof meContract;
+  "projects": typeof projectsContract;
+  "projects---projectId": typeof projectsProjectIdContract;
+  "projects---projectId-tasks": typeof projectsProjectIdTasksContract;
+  "users": typeof usersContract;
+  "users---userId": typeof usersUserIdContract;
+  "webhooks": typeof webhooksContract
+} = {
+  "auth-login": authLoginContract,
+  "health": healthContract,
+  "me": meContract,
+  "projects": projectsContract,
+  "projects---projectId": projectsProjectIdContract,
+  "projects---projectId-tasks": projectsProjectIdTasksContract,
+  "users": usersContract,
+  "users---userId": usersUserIdContract,
+  "webhooks": webhooksContract
+};
+

--- a/openapi/src/test/resources/gold/tsrest/src/health.contract.ts
+++ b/openapi/src/test/resources/gold/tsrest/src/health.contract.ts
@@ -1,0 +1,16 @@
+import { z } from "zod";
+import { initContract } from "@ts-rest/core";
+
+export const healthContract = initContract().router({
+  get: {
+    summary: 'Liveness probe',
+    description: 'Return service liveness — no authentication required',
+    method: 'GET',
+    path: '/health',
+    responses: {
+      200: z.object({
+        "status": z.string(),
+        "uptimeSeconds": z.number().int()})
+    }
+  }
+});

--- a/openapi/src/test/resources/gold/tsrest/src/me.contract.ts
+++ b/openapi/src/test/resources/gold/tsrest/src/me.contract.ts
@@ -1,0 +1,18 @@
+import { z } from "zod";
+import { initContract } from "@ts-rest/core";
+
+export const meContract = initContract().router({
+  get: {
+    summary: 'Who am I',
+    description: 'Return the profile of the currently authenticated user',
+    method: 'GET',
+    path: '/me',
+    responses: {
+      200: z.object({
+        "email": z.string(),
+        "id": z.string().uuid(),
+        "name": z.string(),
+        "role": z.enum(["admin","guest","member"]).describe("User role within the system")})
+    }
+  }
+});

--- a/openapi/src/test/resources/gold/tsrest/src/projects---projectId-tasks.contract.ts
+++ b/openapi/src/test/resources/gold/tsrest/src/projects---projectId-tasks.contract.ts
@@ -1,0 +1,39 @@
+import { z } from "zod";
+import { initContract } from "@ts-rest/core";
+
+export const projectsProjectIdTasksContract = initContract().router({
+  get: {
+    summary: 'List tasks',
+    description: 'List all tasks in a project',
+    method: 'GET',
+    path: '/projects/:projectId/tasks',
+    pathParams: z.object({projectId: z.number().int()}),
+    responses: {
+      200: z.array(z.object({
+        "description": z.string().nullish(),
+        "done": z.boolean(),
+        "id": z.number().int(),
+        "priority": z.enum(["high","low","medium"]).describe("Task priority level"),
+        "title": z.string()}))
+    }
+  },
+  post: {
+    summary: 'Create task',
+    description: 'Create a task in a project',
+    method: 'POST',
+    path: '/projects/:projectId/tasks',
+    pathParams: z.object({projectId: z.number().int()}),
+    body: z.object({
+        "description": z.string().nullish(),
+        "priority": z.enum(["high","low","medium"]).describe("Task priority level"),
+        "title": z.string()}),
+    responses: {
+      201: z.object({
+        "description": z.string().nullish(),
+        "done": z.boolean(),
+        "id": z.number().int(),
+        "priority": z.enum(["high","low","medium"]).describe("Task priority level"),
+        "title": z.string()})
+    }
+  }
+});

--- a/openapi/src/test/resources/gold/tsrest/src/projects---projectId.contract.ts
+++ b/openapi/src/test/resources/gold/tsrest/src/projects---projectId.contract.ts
@@ -1,0 +1,25 @@
+import { z } from "zod";
+import { initContract } from "@ts-rest/core";
+
+export const projectsProjectIdContract = initContract().router({
+  patch: {
+    summary: 'Patch project',
+    description: 'Partially update a project',
+    method: 'PATCH',
+    path: '/projects/:projectId',
+    pathParams: z.object({projectId: z.number().int()}),
+    body: z.object({
+        "description": z.string().nullish(),
+        "name": z.string().nullish(),
+        "status": z.enum(["active","archived","draft"]).describe("Lifecycle state of a project").nullish()}),
+    responses: {
+      200: z.object({
+        "createdAt": z.string(),
+        "description": z.string().nullish(),
+        "id": z.number().int(),
+        "name": z.string(),
+        "ownerId": z.string().uuid(),
+        "status": z.enum(["active","archived","draft"]).describe("Lifecycle state of a project")})
+    }
+  }
+});

--- a/openapi/src/test/resources/gold/tsrest/src/projects.contract.ts
+++ b/openapi/src/test/resources/gold/tsrest/src/projects.contract.ts
@@ -1,0 +1,44 @@
+import { z } from "zod";
+import { initContract } from "@ts-rest/core";
+
+export const projectsContract = initContract().router({
+  get: {
+    summary: 'List projects',
+    description: 'List projects, optionally filtered by status',
+    method: 'GET',
+    path: '/projects',
+    query: z.object({status: z.enum(["active","archived","draft"]).describe("Lifecycle state of a project").nullish()}),
+    responses: {
+      200: z.array(z.object({
+        "createdAt": z.string(),
+        "description": z.string().nullish(),
+        "id": z.number().int(),
+        "name": z.string(),
+        "ownerId": z.string().uuid(),
+        "status": z.enum(["active","archived","draft"]).describe("Lifecycle state of a project")}))
+    }
+  },
+  post: {
+    summary: 'Create project',
+    description: 'Create a new project',
+    method: 'POST',
+    path: '/projects',
+    body: z.object({
+        "description": z.string().nullish(),
+        "name": z.string(),
+        "status": z.enum(["active","archived","draft"]).describe("Lifecycle state of a project")}),
+    responses: {
+      201: z.object({
+        "createdAt": z.string(),
+        "description": z.string().nullish(),
+        "id": z.number().int(),
+        "name": z.string(),
+        "ownerId": z.string().uuid(),
+        "status": z.enum(["active","archived","draft"]).describe("Lifecycle state of a project")}),
+      400: z.object({
+        "code": z.string(),
+        "details": z.array(z.string()).nullish(),
+        "message": z.string()})
+    }
+  }
+});

--- a/openapi/src/test/resources/gold/tsrest/src/users---userId.contract.ts
+++ b/openapi/src/test/resources/gold/tsrest/src/users---userId.contract.ts
@@ -1,0 +1,51 @@
+import { z } from "zod";
+import { initContract } from "@ts-rest/core";
+
+export const usersUserIdContract = initContract().router({
+  delete: {
+    summary: 'Delete user',
+    description: 'Delete a user',
+    method: 'DELETE',
+    path: '/users/:userId',
+    pathParams: z.object({userId: z.string().uuid()}),
+    body: z.undefined(),
+    responses: {
+      204: z.undefined()
+    }
+  },
+  get: {
+    summary: 'Get user',
+    description: 'Fetch a single user by UUID',
+    method: 'GET',
+    path: '/users/:userId',
+    pathParams: z.object({userId: z.string().uuid()}),
+    responses: {
+      200: z.object({
+        "email": z.string(),
+        "id": z.string().uuid(),
+        "name": z.string(),
+        "role": z.enum(["admin","guest","member"]).describe("User role within the system")}),
+      404: z.object({
+        "code": z.string(),
+        "details": z.array(z.string()).nullish(),
+        "message": z.string()})
+    }
+  },
+  put: {
+    summary: 'Update user',
+    description: 'Replace a user\'s profile (admin only)',
+    method: 'PUT',
+    path: '/users/:userId',
+    pathParams: z.object({userId: z.string().uuid()}),
+    body: z.object({
+        "name": z.string(),
+        "role": z.enum(["admin","guest","member"]).describe("User role within the system")}),
+    responses: {
+      200: z.object({
+        "email": z.string(),
+        "id": z.string().uuid(),
+        "name": z.string(),
+        "role": z.enum(["admin","guest","member"]).describe("User role within the system")})
+    }
+  }
+});

--- a/openapi/src/test/resources/gold/tsrest/src/users.contract.ts
+++ b/openapi/src/test/resources/gold/tsrest/src/users.contract.ts
@@ -1,0 +1,23 @@
+import { z } from "zod";
+import { initContract } from "@ts-rest/core";
+
+export const usersContract = initContract().router({
+  get: {
+    summary: 'List users',
+    description: 'List users with pagination and optional role filter',
+    method: 'GET',
+    path: '/users',
+    query: z.object({page: z.number().int().nullish(), limit: z.number().int().nullish(), role: z.enum(["admin","guest","member"]).describe("User role within the system").nullish()}),
+    responses: {
+      200: z.object({
+        "limit": z.number().int(),
+        "page": z.number().int(),
+        "total": z.number().int(),
+        "users": z.array(z.object({
+        "email": z.string(),
+        "id": z.string().uuid(),
+        "name": z.string(),
+        "role": z.enum(["admin","guest","member"]).describe("User role within the system")}))})
+    }
+  }
+});

--- a/openapi/src/test/resources/gold/tsrest/src/webhooks.contract.ts
+++ b/openapi/src/test/resources/gold/tsrest/src/webhooks.contract.ts
@@ -1,0 +1,18 @@
+import { z } from "zod";
+import { initContract } from "@ts-rest/core";
+
+export const webhooksContract = initContract().router({
+  post: {
+    summary: 'Deliver webhook',
+    description: 'Accept a webhook payload',
+    method: 'POST',
+    path: '/webhooks',
+    body: z.object({
+        "data": z.string(),
+        "event": z.string()}),
+    responses: {
+      202: z.union([z.object({
+        "received": z.boolean()}), z.string()])
+    }
+  }
+});

--- a/openapi/src/test/resources/gold/tsrest/tsconfig.json
+++ b/openapi/src/test/resources/gold/tsrest/tsconfig.json
@@ -1,0 +1,16 @@
+
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ES2022",
+    "declaration": true,
+    "declarationMap": false,
+    "emitDeclarationOnly": true,
+    "strict": true,
+    "moduleResolution": "node",
+    "esModuleInterop": true,
+    "baseUrl": "./src",
+    "outDir": "dist"
+  },
+  "include": ["src/*.ts"]
+}

--- a/openapi/src/test/scala/pl/iterators/baklava/openapi/ComprehensiveGoldSpec.scala
+++ b/openapi/src/test/scala/pl/iterators/baklava/openapi/ComprehensiveGoldSpec.scala
@@ -4,8 +4,6 @@ import com.github.pjfanning.pekkohttpcirce.FailFastCirceSupport
 import enumeratum.EnumEntry.Lowercase
 import enumeratum.{Enum, EnumEntry}
 import io.circe.syntax.*
-import io.swagger.v3.core.util.Yaml
-import io.swagger.v3.oas.models.OpenAPI
 import org.apache.pekko.actor.ActorSystem
 import org.apache.pekko.http.scaladsl.marshalling.{PredefinedToEntityMarshallers, ToEntityMarshaller}
 import org.apache.pekko.http.scaladsl.model.HttpMethods.*
@@ -448,22 +446,31 @@ class ComprehensiveGoldSpec
   private val regen: Boolean = sys.env.get("BAKLAVA_REGEN_GOLD").exists(v => v == "1" || v.equalsIgnoreCase("true"))
 
   override def afterAll(): Unit = {
-    // 1. OpenAPI YAML
-    val openAPI = new OpenAPI()
-    BaklavaDslFormatterOpenAPIWorker.generateForCalls(openAPI, listCalls)
-    val openApiYaml = Yaml.pretty(openAPI)
-    assertGoldFile("openapi/openapi.yaml", openApiYaml)
+    // Route through the public formatter entry points the sbt plugin uses in production,
+    // with the same config keys (`openapi-info`, `ts-rest-package-contract-json`). That way the
+    // gold files reflect exactly what end users see, including the top-level `info:` block that
+    // comes from openapi-info.
+    val config = Map(
+      "openapi-info"                  -> openApiInfo,
+      "ts-rest-package-contract-json" -> tsRestPackageJson
+    )
 
-    // 2. Simple HTML — run the real generator, read back what it wrote.
+    // 1. OpenAPI YAML
+    val openapiDir = new File("target/baklava/openapi")
+    deleteRecursively(openapiDir)
+    new BaklavaDslFormatterOpenAPI().create(config, listCalls)
+    assertGoldDir("openapi", openapiDir)
+
+    // 2. Simple HTML
     val simpleDir = new File("target/baklava/simple")
     deleteRecursively(simpleDir)
-    new BaklavaDslFormatterSimple().create(Map.empty, listCalls)
+    new BaklavaDslFormatterSimple().create(config, listCalls)
     assertGoldDir("simple", simpleDir)
 
-    // 3. ts-rest — run the real generator, read back what it wrote.
+    // 3. ts-rest
     val tsrestDir = new File("target/baklava/tsrest")
     deleteRecursively(tsrestDir)
-    new BaklavaDslFormatterTsRest().create(Map.empty, listCalls)
+    new BaklavaDslFormatterTsRest().create(config, listCalls)
     assertGoldDir("tsrest", tsrestDir)
 
     if (regen) println(s"[gold] Regenerated gold files under ${goldRoot.getAbsolutePath}")
@@ -471,27 +478,30 @@ class ComprehensiveGoldSpec
     super.afterAll()
   }
 
+  private val openApiInfo =
+    """{
+      |  "openapi": "3.0.1",
+      |  "info": {
+      |    "title": "Baklava Comprehensive Gold Spec",
+      |    "description": "Fixture API used by the gold test to exercise all three generators.",
+      |    "version": "0.0.0-test"
+      |  }
+      |}
+      |""".stripMargin
+
+  private val tsRestPackageJson =
+    """{
+      |  "name": "baklava-gold-contracts",
+      |  "version": "0.0.0-test",
+      |  "main": "index.js",
+      |  "types": "index.d.ts"
+      |}
+      |""".stripMargin
+
   // Gold files live at openapi/src/test/resources/gold/<format>/… — stored under the module's
   // resources so they're on the test classpath and travel with the repo. sbt runs tests with the
   // repository root as CWD (not the subproject), so the regen write path is prefixed accordingly.
   private val goldRoot = new File("openapi/src/test/resources/gold")
-
-  private def assertGoldFile(relPath: String, actual: String): Unit = {
-    val goldFile = new File(goldRoot, relPath)
-    if (regen) {
-      goldFile.getParentFile.mkdirs()
-      val _ = Files.write(goldFile.toPath, actual.getBytes(StandardCharsets.UTF_8))
-    } else {
-      assert(goldFile.exists(), s"Gold file missing: ${goldFile.getAbsolutePath} — run with BAKLAVA_REGEN_GOLD=1 to create")
-      val expected = new String(Files.readAllBytes(goldFile.toPath), StandardCharsets.UTF_8)
-      if (expected != actual) {
-        fail(
-          s"Gold mismatch for $relPath (run with BAKLAVA_REGEN_GOLD=1 to update after reviewing the diff).\n" +
-            diffSummary(expected, actual)
-        )
-      }
-    }
-  }
 
   private def assertGoldDir(format: String, actualDir: File): Unit = {
     val actualFiles   = listRelativeFiles(actualDir).sorted

--- a/openapi/src/test/scala/pl/iterators/baklava/openapi/ComprehensiveGoldSpec.scala
+++ b/openapi/src/test/scala/pl/iterators/baklava/openapi/ComprehensiveGoldSpec.scala
@@ -1,0 +1,640 @@
+package pl.iterators.baklava.openapi
+
+import com.github.pjfanning.pekkohttpcirce.FailFastCirceSupport
+import enumeratum.EnumEntry.Lowercase
+import enumeratum.{Enum, EnumEntry}
+import io.circe.syntax.*
+import io.swagger.v3.core.util.Yaml
+import io.swagger.v3.oas.models.OpenAPI
+import org.apache.pekko.actor.ActorSystem
+import org.apache.pekko.http.scaladsl.marshalling.{PredefinedToEntityMarshallers, ToEntityMarshaller}
+import org.apache.pekko.http.scaladsl.model.HttpMethods.*
+import org.apache.pekko.http.scaladsl.model.StatusCodes.*
+import org.apache.pekko.http.scaladsl.model.headers.RawHeader
+import org.apache.pekko.http.scaladsl.model.{ContentTypes, HttpEntity, HttpHeader, HttpResponse}
+import org.apache.pekko.http.scaladsl.server.Directives.complete
+import org.apache.pekko.http.scaladsl.server.Route
+import org.apache.pekko.http.scaladsl.unmarshalling.{FromEntityUnmarshaller, Unmarshaller}
+import org.apache.pekko.stream.Materializer
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
+import pl.iterators.baklava.pekkohttp.BaklavaPekkoHttp
+import pl.iterators.baklava.scalatest.{BaklavaScalatest, ScalatestAsExecution}
+import pl.iterators.baklava.simple.BaklavaDslFormatterSimple
+import pl.iterators.baklava.tsrest.BaklavaDslFormatterTsRest
+import pl.iterators.baklava.{
+  ApiKeyInHeader,
+  BaklavaTestFrameworkDslDebug,
+  EmptyBody,
+  FormOf,
+  HttpBasic,
+  HttpBearer,
+  OAuth2InBearer,
+  OAuthAuthorizationCodeFlow,
+  OAuthFlows,
+  Schema,
+  SchemaType,
+  SecurityScheme,
+  ToQueryParam
+}
+import pl.iterators.kebs.circe.KebsCirce
+import pl.iterators.kebs.circe.enums.KebsCirceEnumsLowercase
+import pl.iterators.kebs.enumeratum.KebsEnumeratum
+
+import java.io.File
+import java.nio.charset.StandardCharsets
+import java.nio.file.{Files, Path}
+import java.util.UUID
+import scala.concurrent.ExecutionContext
+import scala.jdk.CollectionConverters.*
+
+/** Gold test for the three Baklava generators (OpenAPI, ts-rest, simple HTML).
+  *
+  * Builds a comprehensive but realistic API and drives it end-to-end through the Baklava DSL, then generates all three output formats from
+  * the captured calls and compares byte-for-byte against checked-in golden files under `openapi/src/test/resources/gold/`.
+  *
+  * Run with `BAKLAVA_REGEN_GOLD=1` to overwrite the golden files when the generator output legitimately changes (review the diff before
+  * committing). Gold files are cross-version — the test is expected to produce identical output on Scala 2.13 and Scala 3.
+  */
+class ComprehensiveGoldSpec
+    extends AnyFunSpec
+    with Matchers
+    with BaklavaPekkoHttp[Unit, Unit, ScalatestAsExecution]
+    with BaklavaScalatest[Route, ToEntityMarshaller, FromEntityUnmarshaller]
+    with BaklavaTestFrameworkDslDebug[Route, ToEntityMarshaller, FromEntityUnmarshaller, Unit, Unit, ScalatestAsExecution]
+    with FailFastCirceSupport
+    with KebsCirce
+    with KebsCirceEnumsLowercase
+    with KebsEnumeratum {
+
+  private implicit val system: ActorSystem        = ActorSystem("comprehensive-gold")
+  implicit val executionContext: ExecutionContext = system.dispatcher
+  implicit val materializer: Materializer         = Materializer(system)
+
+  val routes: Route                                                 = complete(OK)
+  override def strictHeaderCheckDefault: Boolean                    = false
+  implicit val stringUnmarshaller: FromEntityUnmarshaller[String]   = Unmarshaller.stringUnmarshaller
+  implicit val byteArrayMarshaller: ToEntityMarshaller[Array[Byte]] = PredefinedToEntityMarshallers.ByteArrayMarshaller
+
+  // Stub: the test doesn't care about real HTTP — canned responses per assertion.
+  private var nextResponse: HttpResponse                                         = HttpResponse(OK)
+  override def performRequest(routes: Route, request: HttpRequest): HttpResponse = nextResponse
+
+  private def jsonResponse(status: org.apache.pekko.http.scaladsl.model.StatusCode, json: String): HttpResponse =
+    HttpResponse(status, entity = HttpEntity(ContentTypes.`application/json`, json))
+  private def textResponse(status: org.apache.pekko.http.scaladsl.model.StatusCode, text: String): HttpResponse =
+    HttpResponse(status, entity = HttpEntity(ContentTypes.`text/plain(UTF-8)`, text))
+  private def emptyResponse(status: org.apache.pekko.http.scaladsl.model.StatusCode): HttpResponse = HttpResponse(status)
+  private def jsonResponseWithHeaders(
+      status: org.apache.pekko.http.scaladsl.model.StatusCode,
+      json: String,
+      headers: Seq[(String, String)]
+  ): HttpResponse = {
+    val hs: Seq[HttpHeader] = headers.map { case (n, v) => RawHeader(n, v) }
+    HttpResponse(status, entity = HttpEntity(ContentTypes.`application/json`, json)).withHeaders(hs)
+  }
+
+  // Domain model + enums are defined in the companion object (ComprehensiveGoldSpec) below.
+  // They must be top-level rather than nested in the test class so Scala 3's enumeratum
+  // `findValues` macro can discover them, and so kebs can derive JSON codecs without warning.
+  import ComprehensiveGoldSpec.*
+
+  // ---------------------------------------------------------------------------
+  // Security schemes
+  // ---------------------------------------------------------------------------
+
+  private val bearerAuth: HttpBearer = HttpBearer(bearerFormat = "JWT", description = "JWT token issued by /auth/login")
+  private val bearerScheme           = SecurityScheme("bearerAuth", bearerAuth)
+
+  private val basicAuth   = HttpBasic(description = "HTTP Basic for the login endpoint only")
+  private val basicScheme = SecurityScheme("basicAuth", basicAuth)
+
+  private val apiKey       = ApiKeyInHeader("X-API-Key", "API key for webhook delivery")
+  private val apiKeyScheme = SecurityScheme("apiKey", apiKey)
+
+  private val oauthAdmin = OAuth2InBearer(
+    OAuthFlows(
+      authorizationCodeFlow = Some(
+        OAuthAuthorizationCodeFlow(
+          authorizationUrl = "https://example.com/oauth/authorize",
+          tokenUrl = "https://example.com/oauth/token",
+          scopes = Map("projects:read" -> "Read projects", "projects:write" -> "Create/update projects")
+        )
+      )
+    )
+  )
+  private val oauthScheme = SecurityScheme("oauth2", oauthAdmin)
+
+  // ---------------------------------------------------------------------------
+  // Fixture values
+  // ---------------------------------------------------------------------------
+
+  private val userId          = UUID.fromString("00000000-0000-0000-0000-000000000001")
+  private val otherUser       = UUID.fromString("00000000-0000-0000-0000-000000000002")
+  private val alice           = User(userId, "alice@example.com", "Alice", Role.Admin)
+  private val bob             = User(otherUser, "bob@example.com", "Bob", Role.Member)
+  private val project42       = Project(42L, "Apollo", Some("Mission control"), ProjectStatus.Active, userId, "2026-01-01T00:00:00Z")
+  private val archivedProject =
+    Project(7L, "Gemini", None, ProjectStatus.Archived, userId, "2025-06-01T00:00:00Z")
+  private val task1 = Task(101L, "Wire up telemetry", Some("Prometheus + Grafana"), done = false, Priority.High)
+  private val task2 = Task(102L, "Write docs", None, done = true, Priority.Low)
+
+  // ---------------------------------------------------------------------------
+  // API surface
+  // ---------------------------------------------------------------------------
+
+  path("/auth/login", description = "Authenticate against the API", summary = "Authentication")(
+    supports(
+      POST,
+      securitySchemes = Seq(basicScheme),
+      description = "Exchange HTTP Basic credentials for a JWT token",
+      summary = "Login",
+      operationId = "login",
+      tags = Seq("Auth")
+    )(
+      onRequest(
+        body = FormOf[LoginForm]("client_id" -> "web", "grant_type" -> "password"),
+        security = basicAuth("alice@example.com", "s3cret")
+      ).respondsWith[LoginResponse](OK, description = "Successful login")
+        .assert { ctx =>
+          nextResponse = jsonResponse(OK, LoginResponse("jwt.token.xyz", alice).asJson.noSpaces)
+          ctx.performRequest(routes)
+        },
+      onRequest(
+        body = FormOf[LoginForm]("client_id" -> "web", "grant_type" -> "password"),
+        security = basicAuth("mallory", "wrong")
+      ).respondsWith[ErrorResponse](Unauthorized, description = "Invalid credentials")
+        .assert { ctx =>
+          nextResponse = jsonResponse(Unauthorized, ErrorResponse("unauthorized", "Bad credentials", None).asJson.noSpaces)
+          ctx.performRequest(routes)
+        }
+    )
+  )
+
+  path("/me", description = "The authenticated caller", summary = "Current user")(
+    supports(
+      GET,
+      securitySchemes = Seq(bearerScheme),
+      description = "Return the profile of the currently authenticated user",
+      summary = "Who am I",
+      operationId = "me",
+      tags = Seq("Auth")
+    )(
+      onRequest(security = bearerAuth("jwt.token.xyz"))
+        .respondsWith[User](OK, description = "Authenticated user profile")
+        .assert { ctx =>
+          nextResponse = jsonResponse(OK, alice.asJson.noSpaces)
+          ctx.performRequest(routes)
+        }
+    )
+  )
+
+  path("/users", description = "User collection", summary = "Users")(
+    supports(
+      GET,
+      queryParameters = (
+        q[Option[Int]]("page", "Page number (1-indexed)"),
+        q[Option[Int]]("limit", "Items per page (max 100)"),
+        q[Option[Role]]("role", "Filter by role")
+      ),
+      securitySchemes = Seq(bearerScheme),
+      description = "List users with pagination and optional role filter",
+      summary = "List users",
+      operationId = "listUsers",
+      tags = Seq("Users")
+    )(
+      onRequest(queryParameters = (Some(1), Some(20), Some(Role.Admin)), security = bearerAuth("jwt.token.xyz"))
+        .respondsWith[PaginatedUsers](
+          OK,
+          description = "First page of users",
+          headers = Seq(h[Int]("X-Rate-Limit-Remaining", "Calls remaining in the current window"))
+        )
+        .assert { ctx =>
+          nextResponse = jsonResponseWithHeaders(
+            OK,
+            PaginatedUsers(Seq(alice, bob), total = 2, page = 1, limit = 20).asJson.noSpaces,
+            Seq("X-Rate-Limit-Remaining" -> "59")
+          )
+          ctx.performRequest(routes)
+        }
+    )
+  )
+
+  path("/users/{userId}", description = "Single user operations", summary = "User by ID")(
+    supports(
+      GET,
+      pathParameters = p[UUID]("userId", "The user's UUID"),
+      securitySchemes = Seq(bearerScheme),
+      description = "Fetch a single user by UUID",
+      summary = "Get user",
+      operationId = "getUser",
+      tags = Seq("Users")
+    )(
+      onRequest(pathParameters = userId, security = bearerAuth("jwt.token.xyz"))
+        .respondsWith[User](OK, description = "User found")
+        .assert { ctx =>
+          nextResponse = jsonResponse(OK, alice.asJson.noSpaces)
+          ctx.performRequest(routes)
+        },
+      onRequest(pathParameters = UUID.fromString("00000000-0000-0000-0000-0000000000ff"), security = bearerAuth("jwt.token.xyz"))
+        .respondsWith[ErrorResponse](NotFound, description = "User not found")
+        .assert { ctx =>
+          nextResponse = jsonResponse(NotFound, ErrorResponse("not_found", "No such user", None).asJson.noSpaces)
+          ctx.performRequest(routes)
+        }
+    ),
+    supports(
+      PUT,
+      pathParameters = p[UUID]("userId", "The user's UUID"),
+      securitySchemes = Seq(bearerScheme),
+      description = "Replace a user's profile (admin only)",
+      summary = "Update user",
+      operationId = "updateUser",
+      tags = Seq("Users")
+    )(
+      onRequest(
+        pathParameters = userId,
+        body = UpdateUserRequest("Alice Updated", Role.Admin),
+        security = bearerAuth("jwt.token.xyz")
+      ).respondsWith[User](OK, description = "User updated")
+        .assert { ctx =>
+          nextResponse = jsonResponse(OK, alice.copy(name = "Alice Updated").asJson.noSpaces)
+          ctx.performRequest(routes)
+        }
+    ),
+    supports(
+      DELETE,
+      pathParameters = p[UUID]("userId", "The user's UUID"),
+      securitySchemes = Seq(bearerScheme),
+      description = "Delete a user",
+      summary = "Delete user",
+      operationId = "deleteUser",
+      tags = Seq("Users")
+    )(
+      onRequest(pathParameters = otherUser, security = bearerAuth("jwt.token.xyz"))
+        .respondsWith[EmptyBody](NoContent, description = "User deleted")
+        .assert { ctx =>
+          nextResponse = emptyResponse(NoContent)
+          ctx.performRequest(routes)
+        }
+    )
+  )
+
+  path("/projects", description = "Project collection", summary = "Projects")(
+    supports(
+      GET,
+      queryParameters = q[Option[ProjectStatus]]("status", "Filter by lifecycle state"),
+      securitySchemes = Seq(oauthScheme),
+      description = "List projects, optionally filtered by status",
+      summary = "List projects",
+      operationId = "listProjects",
+      tags = Seq("Projects")
+    )(
+      onRequest(queryParameters = Some(ProjectStatus.Active), security = oauthAdmin("oauth.access.token"))
+        .respondsWith[Seq[Project]](OK, description = "All active projects")
+        .assert { ctx =>
+          nextResponse = jsonResponse(OK, Seq(project42).asJson.noSpaces)
+          ctx.performRequest(routes)
+        },
+      onRequest(queryParameters = Some(ProjectStatus.Archived), security = oauthAdmin("oauth.access.token"))
+        .respondsWith[Seq[Project]](OK, description = "All archived projects")
+        .assert { ctx =>
+          nextResponse = jsonResponse(OK, Seq(archivedProject).asJson.noSpaces)
+          ctx.performRequest(routes)
+        }
+    ),
+    supports(
+      POST,
+      securitySchemes = Seq(oauthScheme),
+      description = "Create a new project",
+      summary = "Create project",
+      operationId = "createProject",
+      tags = Seq("Projects")
+    )(
+      onRequest(
+        body = CreateProjectRequest("Apollo", Some("Mission control"), ProjectStatus.Active),
+        security = oauthAdmin("oauth.access.token")
+      ).respondsWith[Project](Created, description = "Project created")
+        .assert { ctx =>
+          nextResponse = jsonResponse(Created, project42.asJson.noSpaces)
+          ctx.performRequest(routes)
+        },
+      onRequest(
+        body = CreateProjectRequest("", None, ProjectStatus.Draft),
+        security = oauthAdmin("oauth.access.token")
+      ).respondsWith[ErrorResponse](BadRequest, description = "Validation failed")
+        .assert { ctx =>
+          nextResponse = jsonResponse(
+            BadRequest,
+            ErrorResponse("validation", "One or more fields are invalid", Some(Seq("name: must not be blank"))).asJson.noSpaces
+          )
+          ctx.performRequest(routes)
+        }
+    )
+  )
+
+  path("/projects/{projectId}", description = "Project detail", summary = "Project by ID")(
+    supports(
+      PATCH,
+      pathParameters = p[Long]("projectId", "The project ID"),
+      securitySchemes = Seq(oauthScheme),
+      description = "Partially update a project",
+      summary = "Patch project",
+      operationId = "patchProject",
+      tags = Seq("Projects")
+    )(
+      onRequest(
+        pathParameters = 42L,
+        body = PatchProjectRequest(name = None, description = Some("Updated desc"), status = None),
+        security = oauthAdmin("oauth.access.token")
+      ).respondsWith[Project](OK, description = "Project updated")
+        .assert { ctx =>
+          nextResponse = jsonResponse(OK, project42.copy(description = Some("Updated desc")).asJson.noSpaces)
+          ctx.performRequest(routes)
+        }
+    )
+  )
+
+  path("/projects/{projectId}/tasks", description = "Tasks within a project", summary = "Project tasks")(
+    supports(
+      GET,
+      pathParameters = p[Long]("projectId", "The project ID"),
+      securitySchemes = Seq(oauthScheme),
+      description = "List all tasks in a project",
+      summary = "List tasks",
+      operationId = "listTasks",
+      tags = Seq("Tasks")
+    )(
+      onRequest(pathParameters = 42L, security = oauthAdmin("oauth.access.token"))
+        .respondsWith[Seq[Task]](OK, description = "All tasks in the project")
+        .assert { ctx =>
+          nextResponse = jsonResponse(OK, Seq(task1, task2).asJson.noSpaces)
+          ctx.performRequest(routes)
+        }
+    ),
+    supports(
+      POST,
+      pathParameters = p[Long]("projectId", "The project ID"),
+      securitySchemes = Seq(oauthScheme),
+      description = "Create a task in a project",
+      summary = "Create task",
+      operationId = "createTask",
+      tags = Seq("Tasks")
+    )(
+      onRequest(
+        pathParameters = 42L,
+        body = CreateTaskRequest("New task", None, Priority.Medium),
+        security = oauthAdmin("oauth.access.token")
+      ).respondsWith[Task](
+        Created,
+        description = "Task created",
+        headers = Seq(h[String]("Location", "URL of the newly created task"))
+      ).assert { ctx =>
+        nextResponse = jsonResponseWithHeaders(
+          Created,
+          task1.asJson.noSpaces,
+          Seq("Location" -> "/projects/42/tasks/101")
+        )
+        ctx.performRequest(routes)
+      }
+    )
+  )
+
+  path("/webhooks", description = "Inbound webhooks", summary = "Webhooks")(
+    supports(
+      POST,
+      securitySchemes = Seq(apiKeyScheme),
+      description = "Accept a webhook payload",
+      summary = "Deliver webhook",
+      operationId = "deliverWebhook",
+      tags = Seq("Webhooks")
+    )(
+      onRequest(body = WebhookPayload("order.created", """{"id":1}"""), security = apiKey("secret-key"))
+        .respondsWith[WebhookAck](Accepted, description = "Webhook accepted")
+        .assert { ctx =>
+          nextResponse = jsonResponse(Accepted, WebhookAck(received = true).asJson.noSpaces)
+          ctx.performRequest(routes)
+        },
+      onRequest(body = WebhookPayload("order.created", """{"id":1}"""), security = apiKey("secret-key"))
+        .respondsWith[String](Accepted, description = "Legacy plain-text ack")
+        .assert { ctx =>
+          nextResponse = textResponse(Accepted, "ACK")
+          ctx.performRequest(routes)
+        }
+    )
+  )
+
+  path("/health", description = "Liveness probe", summary = "Health")(
+    supports(
+      GET,
+      description = "Return service liveness — no authentication required",
+      summary = "Liveness probe",
+      operationId = "health",
+      tags = Seq("System")
+    )(
+      onRequest()
+        .respondsWith[HealthResponse](OK, description = "Service is alive")
+        .assert { ctx =>
+          nextResponse = jsonResponse(OK, HealthResponse("ok", 12345L).asJson.noSpaces)
+          ctx.performRequest(routes)
+        }
+    )
+  )
+
+  // ---------------------------------------------------------------------------
+  // Gold comparison
+  // ---------------------------------------------------------------------------
+
+  private val regen: Boolean = sys.env.get("BAKLAVA_REGEN_GOLD").exists(v => v == "1" || v.equalsIgnoreCase("true"))
+
+  override def afterAll(): Unit = {
+    // 1. OpenAPI YAML
+    val openAPI = new OpenAPI()
+    BaklavaDslFormatterOpenAPIWorker.generateForCalls(openAPI, listCalls)
+    val openApiYaml = Yaml.pretty(openAPI)
+    assertGoldFile("openapi/openapi.yaml", openApiYaml)
+
+    // 2. Simple HTML — run the real generator, read back what it wrote.
+    val simpleDir = new File("target/baklava/simple")
+    deleteRecursively(simpleDir)
+    new BaklavaDslFormatterSimple().create(Map.empty, listCalls)
+    assertGoldDir("simple", simpleDir)
+
+    // 3. ts-rest — run the real generator, read back what it wrote.
+    val tsrestDir = new File("target/baklava/tsrest")
+    deleteRecursively(tsrestDir)
+    new BaklavaDslFormatterTsRest().create(Map.empty, listCalls)
+    assertGoldDir("tsrest", tsrestDir)
+
+    if (regen) println(s"[gold] Regenerated gold files under ${goldRoot.getAbsolutePath}")
+    val _ = system.terminate()
+    super.afterAll()
+  }
+
+  // Gold files live at openapi/src/test/resources/gold/<format>/… — stored under the module's
+  // resources so they're on the test classpath and travel with the repo. sbt runs tests with the
+  // repository root as CWD (not the subproject), so the regen write path is prefixed accordingly.
+  private val goldRoot = new File("openapi/src/test/resources/gold")
+
+  private def assertGoldFile(relPath: String, actual: String): Unit = {
+    val goldFile = new File(goldRoot, relPath)
+    if (regen) {
+      goldFile.getParentFile.mkdirs()
+      val _ = Files.write(goldFile.toPath, actual.getBytes(StandardCharsets.UTF_8))
+    } else {
+      assert(goldFile.exists(), s"Gold file missing: ${goldFile.getAbsolutePath} — run with BAKLAVA_REGEN_GOLD=1 to create")
+      val expected = new String(Files.readAllBytes(goldFile.toPath), StandardCharsets.UTF_8)
+      if (expected != actual) {
+        fail(
+          s"Gold mismatch for $relPath (run with BAKLAVA_REGEN_GOLD=1 to update after reviewing the diff).\n" +
+            diffSummary(expected, actual)
+        )
+      }
+    }
+  }
+
+  private def assertGoldDir(format: String, actualDir: File): Unit = {
+    val actualFiles   = listRelativeFiles(actualDir).sorted
+    val goldFormatDir = new File(goldRoot, format)
+    if (regen) {
+      // Wipe this format's gold dir so deletions are reflected.
+      deleteRecursively(goldFormatDir)
+      goldFormatDir.mkdirs()
+      actualFiles.foreach { rel =>
+        val target = new File(goldFormatDir, rel)
+        target.getParentFile.mkdirs()
+        Files.copy(new File(actualDir, rel).toPath, target.toPath)
+      }
+    } else {
+      assert(goldFormatDir.exists(), s"Gold dir missing: ${goldFormatDir.getAbsolutePath} — run with BAKLAVA_REGEN_GOLD=1 to create")
+      val goldFiles  = listRelativeFiles(goldFormatDir).sorted
+      val onlyActual = actualFiles.diff(goldFiles)
+      val onlyGold   = goldFiles.diff(actualFiles)
+      assert(
+        onlyActual.isEmpty && onlyGold.isEmpty,
+        s"File-set mismatch in $format.\n" +
+          s"  in actual but not gold: ${onlyActual.mkString(", ")}\n" +
+          s"  in gold but not actual: ${onlyGold.mkString(", ")}\n" +
+          "  Run with BAKLAVA_REGEN_GOLD=1 to update."
+      )
+      actualFiles.foreach { rel =>
+        val actual   = new String(Files.readAllBytes(new File(actualDir, rel).toPath), StandardCharsets.UTF_8)
+        val expected = new String(Files.readAllBytes(new File(goldFormatDir, rel).toPath), StandardCharsets.UTF_8)
+        if (actual != expected) {
+          fail(
+            s"Gold mismatch for $format/$rel (run with BAKLAVA_REGEN_GOLD=1 to update after reviewing).\n" +
+              diffSummary(expected, actual)
+          )
+        }
+      }
+    }
+  }
+
+  private def listRelativeFiles(root: File): Seq[String] = {
+    if (!root.exists()) Seq.empty
+    else {
+      val rootPath: Path = root.toPath
+      Files.walk(rootPath).iterator().asScala.toSeq.filter(Files.isRegularFile(_)).map(p => rootPath.relativize(p).toString)
+    }
+  }
+
+  private def deleteRecursively(f: File): Unit = {
+    if (f.exists()) {
+      if (f.isDirectory) Option(f.listFiles()).toSeq.flatten.foreach(deleteRecursively)
+      val _ = f.delete()
+    }
+  }
+
+  // Minimal text diff for failure messages — first differing line window.
+  private def diffSummary(expected: String, actual: String): String = {
+    val e           = expected.split('\n').toIndexedSeq
+    val a           = actual.split('\n').toIndexedSeq
+    val i           = (0 until math.min(e.length, a.length)).find(idx => e(idx) != a(idx)).getOrElse(math.min(e.length, a.length))
+    val windowStart = math.max(0, i - 2)
+    val windowEnd   = math.min(math.max(e.length, a.length), i + 5)
+    val eWindow     = (windowStart until math.min(e.length, windowEnd)).map(idx => f"  gold   $idx%4d: ${e(idx)}").mkString("\n")
+    val aWindow     = (windowStart until math.min(a.length, windowEnd)).map(idx => f"  actual $idx%4d: ${a(idx)}").mkString("\n")
+    s"first diff at line $i (gold=${e.length} lines, actual=${a.length} lines)\n$eWindow\n---\n$aWindow"
+  }
+
+  // Force ScalaTest to see a no-op assertion at test-discovery time so the spec isn't reported
+  // as empty. (All actual work happens via `path(...)` call-site registration + `afterAll`.)
+  describe("comprehensive gold test") {
+    it("is a placeholder — the real work is done in afterAll against captured calls")(succeed)
+  }
+}
+
+object ComprehensiveGoldSpec {
+
+  sealed trait Role extends EnumEntry with Lowercase
+  object Role       extends Enum[Role] {
+    case object Admin  extends Role
+    case object Member extends Role
+    case object Guest  extends Role
+    val values: IndexedSeq[Role]                  = findValues
+    implicit val schema: Schema[Role]             = enumSchema[Role]("Role", "User role within the system", values.map(_.entryName))
+    implicit val toQueryParam: ToQueryParam[Role] = new ToQueryParam[Role] {
+      def apply(t: Role): Seq[String] = Seq(t.entryName)
+    }
+  }
+
+  sealed trait ProjectStatus extends EnumEntry with Lowercase
+  object ProjectStatus       extends Enum[ProjectStatus] {
+    case object Active   extends ProjectStatus
+    case object Archived extends ProjectStatus
+    case object Draft    extends ProjectStatus
+    val values: IndexedSeq[ProjectStatus]      = findValues
+    implicit val schema: Schema[ProjectStatus] =
+      enumSchema[ProjectStatus]("ProjectStatus", "Lifecycle state of a project", values.map(_.entryName))
+    implicit val toQueryParam: ToQueryParam[ProjectStatus] = new ToQueryParam[ProjectStatus] {
+      def apply(t: ProjectStatus): Seq[String] = Seq(t.entryName)
+    }
+  }
+
+  sealed trait Priority extends EnumEntry with Lowercase
+  object Priority       extends Enum[Priority] {
+    case object Low    extends Priority
+    case object Medium extends Priority
+    case object High   extends Priority
+    val values: IndexedSeq[Priority]      = findValues
+    implicit val schema: Schema[Priority] = enumSchema[Priority]("Priority", "Task priority level", values.map(_.entryName))
+  }
+
+  private def enumSchema[T](name: String, desc: String, values: Seq[String]): Schema[T] = new Schema[T] {
+    val `type`: SchemaType                 = SchemaType.StringType
+    val className: String                  = name
+    val format: Option[String]             = None
+    val properties: Map[String, Schema[?]] = Map.empty
+    val items: Option[Schema[?]]           = None
+    val `enum`: Option[Set[String]]        = Some(values.toSet)
+    val required: Boolean                  = true
+    val additionalProperties: Boolean      = false
+    val default: Option[T]                 = None
+    val description: Option[String]        = Some(desc)
+  }
+
+  case class User(id: UUID, email: String, name: String, role: Role)
+  case class PaginatedUsers(users: Seq[User], total: Int, page: Int, limit: Int)
+  case class UpdateUserRequest(name: String, role: Role)
+
+  case class Project(
+      id: Long,
+      name: String,
+      description: Option[String],
+      status: ProjectStatus,
+      ownerId: UUID,
+      createdAt: String
+  )
+  case class CreateProjectRequest(name: String, description: Option[String], status: ProjectStatus)
+  case class PatchProjectRequest(name: Option[String], description: Option[String], status: Option[ProjectStatus])
+
+  case class Task(id: Long, title: String, description: Option[String], done: Boolean, priority: Priority)
+  case class CreateTaskRequest(title: String, description: Option[String], priority: Priority)
+
+  case class LoginForm(client_id: String, grant_type: String)
+  case class LoginResponse(token: String, user: User)
+  case class ErrorResponse(code: String, message: String, details: Option[Seq[String]])
+  case class WebhookPayload(event: String, data: String)
+  case class WebhookAck(received: Boolean)
+  case class HealthResponse(status: String, uptimeSeconds: Long)
+}

--- a/simple/src/main/scala/pl/iterators/baklava/simple/BaklavaDslFormatterSimple.scala
+++ b/simple/src/main/scala/pl/iterators/baklava/simple/BaklavaDslFormatterSimple.scala
@@ -245,14 +245,16 @@ class BaklavaDslFormatterSimple extends BaklavaDslFormatter {
         "properties"  -> (if (baklavaSchema.`type` == SchemaType.ObjectType)
                            baklavaSchema.properties.view.mapValues(j => toJsonSchemaV7(j)).toMap.asJson
                          else Json.Null),
-        "required" -> Json.arr(
-          baklavaSchema.properties.toSeq
-            .collect {
-              case (name, prop) if prop.required => name
-            }
-            .sorted
-            .map(Json.fromString): _*
-        ),
+        "required" -> (if (baklavaSchema.`type` == SchemaType.ObjectType)
+                         Json.arr(
+                           baklavaSchema.properties.toSeq
+                             .collect {
+                               case (name, prop) if prop.required => name
+                             }
+                             .sorted
+                             .map(Json.fromString): _*
+                         )
+                       else Json.Null),
         "additionalProperties" -> (if (baklavaSchema.`type` == SchemaType.ObjectType) Json.fromBoolean(baklavaSchema.additionalProperties)
                                    else Json.Null),
         "items" -> baklavaSchema.items.map(j => toJsonSchemaV7(j)).getOrElse(Json.Null)

--- a/simple/src/test/scala/pl/iterators/baklava/simple/BaklavaDslFormatterSimpleSpec.scala
+++ b/simple/src/test/scala/pl/iterators/baklava/simple/BaklavaDslFormatterSimpleSpec.scala
@@ -40,6 +40,20 @@ class BaklavaDslFormatterSimpleSpec extends AnyFunSpec with Matchers {
       requiredArray(generator.jsonSchemaV7(schemaB)) shouldBe requiredA
     }
 
+    it("omits the `required` keyword on non-object schemas (valid JSON Schema)") {
+      val schema = objectSchema(Map("a" -> stringRequired, "b" -> stringRequired))
+      val json   = parser.parse(generator.jsonSchemaV7(schema)).toTry.get.hcursor
+
+      // Object schema itself gets a `required` list.
+      json.downField("required").as[List[String]].toTry.get shouldBe List("a", "b")
+
+      // Leaf (string) properties must NOT carry a `required` key — per JSON Schema, `required`
+      // is only meaningful on object schemas and lists property names, not an empty array on
+      // scalar leaves.
+      json.downField("properties").downField("a").downField("required").succeeded shouldBe false
+      json.downField("properties").downField("b").downField("required").succeeded shouldBe false
+    }
+
     it("renders declared response headers with their captured example values (regression for C7)") {
       val base     = jsonCall(status = 200, desc = "ok", requestBody = "", responseBody = "")
       val withHdrs = base.copy(


### PR DESCRIPTION
## Summary

Adds a comprehensive gold (snapshot) test that drives a realistic 13-path API through the Baklava DSL end-to-end and verifies the byte-for-byte output of all three generators (OpenAPI, ts-rest, simple HTML) against checked-in gold files.

## Coverage

- Path, query, header parameters — `UUID`, `Long`, `Int`, enum types
- Optional + required fields, nested objects, arrays
- Three enumeratum enums (`Role`, `ProjectStatus`, `Priority`) with kebs lowercase codecs
- Four security schemes: HTTP Bearer, HTTP Basic, ApiKey in header, OAuth2 with authorization-code flow
- Multiple response statuses per operation (200/201/202/204/400/401/404)
- Multiple content-types per status (JSON + `text/plain` for webhook ack)
- Response headers with captured example values (`X-Rate-Limit-Remaining`, `Location`)
- Form-urlencoded request bodies with typed fields
- Operation tags, summaries, descriptions, operationIds

## Gold file layout

```
openapi/src/test/resources/gold/
├── openapi/openapi.yaml               (~1000 lines)
├── simple/index.html + 13 endpoint .html
└── tsrest/package.json, tsconfig.json, src/{contracts.ts + 10 contract.ts}
```

## Regenerating after intentional output changes

```
BAKLAVA_REGEN_GOLD=1 sbt 'project openapi' 'testOnly pl.iterators.baklava.openapi.ComprehensiveGoldSpec'
```

Review the diff before committing — this is the knob for confirming that a generator change is intentional and correct.

## Test plan

- [x] `sbt 'project openapi' '++ 2.13' test` — 79/79 pass
- [x] `sbt 'project openapi' '++ 3' test` — 79/79 pass
- [x] `CI=true sbt 'project openapi' '++ 2.13' test` — pass with strict warnings
- [x] `CI=true sbt 'project openapi' '++ 3' test` — pass with strict warnings
- [x] Gold files produce identical bytes on Scala 2.13 and Scala 3