### PR TITLE
website: pin webpack to 5.98.x for webpackbar compatibility

### DIFF
--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "website",
+  "name": "baklava",
   "version": "0.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "website",
+      "name": "baklava",
       "version": "0.0.0",
       "dependencies": {
         "@docusaurus/core": "3.8.1",
@@ -16915,14 +16915,13 @@
       }
     },
     "node_modules/webpack": {
-      "version": "5.99.9",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.99.9.tgz",
-      "integrity": "sha512-brOPwM3JnmOa+7kd3NsmOUOwbDAj8FT9xDsG3IW0MgbN9yZV7Oi/s/+MNQ/EcSMqw7qfoRyXPoeEWT8zLVdVGg==",
+      "version": "5.98.0",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.98.0.tgz",
+      "integrity": "sha512-UFynvx+gM44Gv9qFgj0acCQK2VE1CtdfwFdimkapco3hlPCJ/zeq73n2yVKimVbtm+TnApIugGhLJnkU6gjYXA==",
       "license": "MIT",
       "dependencies": {
         "@types/eslint-scope": "^3.7.7",
         "@types/estree": "^1.0.6",
-        "@types/json-schema": "^7.0.15",
         "@webassemblyjs/ast": "^1.14.1",
         "@webassemblyjs/wasm-edit": "^1.14.1",
         "@webassemblyjs/wasm-parser": "^1.14.1",
@@ -16939,7 +16938,7 @@
         "loader-runner": "^4.2.0",
         "mime-types": "^2.1.27",
         "neo-async": "^2.6.2",
-        "schema-utils": "^4.3.2",
+        "schema-utils": "^4.3.0",
         "tapable": "^2.1.1",
         "terser-webpack-plugin": "^5.3.11",
         "watchpack": "^2.4.1",

--- a/website/package.json
+++ b/website/package.json
@@ -44,5 +44,11 @@
   },
   "engines": {
     "node": ">=18.0"
+  },
+  "overrides": {
+    "webpack": "~5.98.0"
+  },
+  "resolutions": {
+    "webpack": "~5.98.0"
   }
 }


### PR DESCRIPTION
## Summary

The **Website** workflow on `main` has been failing for the last two commits because `npm install` resolves webpack `5.99.9`, whose `ProgressPlugin` schema rejects the `{name, color, reporters, reporter}` options that webpackbar 6.0.1 (Docusaurus 3.8.1's transitive dep) passes to it.

Error surfaced by `docusaurus build`:

\`\`\`
ValidationError: Invalid options object. Progress Plugin has been
initialized using an options object that does not match the API schema.
 * options has an unknown property 'name'.
 * options has an unknown property 'color'.
 ...
\`\`\`

Pin webpack to \`~5.98.0\` via both \`overrides\` (npm) and \`resolutions\` (yarn) so the regression stays fixed whichever tool the mdoc/sbt Docusaurus plugin chooses to call.

## Test plan

- [x] Local \`npx docusaurus build\` succeeds with the pinned version
- [x] \`package-lock.json\` diff is minimal — only the webpack entry changes (5.99.9 → 5.98.0) + stale lockfile \`name\` field updated