### PR TITLE
simple: tag-grouped index + per-call curl with copy button

### DIFF
--- a/openapi/src/test/resources/gold/simple/DELETE__users___userId__-cf0347bd.html
+++ b/openapi/src/test/resources/gold/simple/DELETE__users___userId__-cf0347bd.html
@@ -41,18 +41,37 @@
 <div class="card"><div class="card-header">Security</div><div class="card-body"><p>bearerAuth <span class="tag">http</span></p></div></div>
 <div class="card"><div class="card-header">Path Parameters</div><div class="card-body"><dl class="meta-grid"><dt>userId <span class="required">*</span></dt><dd><code>UUID</code> = <code>00000000-0000-0000-0000-000000000002</code></dd></dl></div></div>
 <div class="card"><div class="card-header"><span class="status-badge status-2xx">204</span> Response</div><div class="card-body"><p>User deleted</p><h4>Curl</h4><div class="curl-block"><pre>curl -X DELETE '$BASE_URL/users/00000000-0000-0000-0000-000000000002' \
-  -H 'Authorization: Bearer &lt;TOKEN&gt;'</pre><button class="copy-btn" type="button" data-clipboard="curl -X DELETE &#39;$BASE_URL/users/00000000-0000-0000-0000-000000000002&#39; \
-  -H &#39;Authorization: Bearer &lt;TOKEN&gt;&#39;">Copy</button></div></div></div>
+  -H 'Authorization: Bearer &lt;TOKEN&gt;'</pre><button class="copy-btn" type="button">Copy</button></div></div></div>
 <script>
 document.addEventListener('click', function (e) {
   var btn = e.target.closest('button.copy-btn');
   if (!btn) return;
-  var payload = btn.getAttribute('data-clipboard') || '';
-  navigator.clipboard.writeText(payload).then(function () {
-    var original = btn.textContent;
-    btn.textContent = 'Copied';
+  var pre = btn.previousElementSibling;
+  var payload = pre ? pre.textContent : '';
+  var flash = function (msg) {
+    var original = btn.dataset.origText || btn.textContent;
+    btn.dataset.origText = original;
+    btn.textContent = msg;
     setTimeout(function () { btn.textContent = original; }, 1200);
-  });
+  };
+  var fallback = function () {
+    try {
+      var ta = document.createElement('textarea');
+      ta.value = payload;
+      ta.style.position = 'fixed';
+      ta.style.opacity = '0';
+      document.body.appendChild(ta);
+      ta.select();
+      var ok = document.execCommand('copy');
+      document.body.removeChild(ta);
+      flash(ok ? 'Copied' : 'Failed');
+    } catch (_) { flash('Failed'); }
+  };
+  if (navigator.clipboard && navigator.clipboard.writeText) {
+    navigator.clipboard.writeText(payload).then(function () { flash('Copied'); }, fallback);
+  } else {
+    fallback();
+  }
 });
 </script>
 </body></html>

--- a/openapi/src/test/resources/gold/simple/DELETE__users___userId__-cf0347bd.html
+++ b/openapi/src/test/resources/gold/simple/DELETE__users___userId__-cf0347bd.html
@@ -27,11 +27,32 @@
   .back-link { display: inline-block; margin-bottom: 16px; font-size: 0.85rem; }
   ul.examples { list-style: none; padding: 0; margin: 4px 0 0; font-size: 0.85rem; }
   ul.examples li { padding: 2px 0; }
+  .tag-group { margin-bottom: 24px; }
+  .tag-heading { margin: 20px 0 10px; font-size: 1.1rem; font-weight: 600; color: #16213e; text-transform: uppercase; letter-spacing: 0.05em; border-bottom: 2px solid #dee2e6; padding-bottom: 6px; }
+  .curl-block { position: relative; margin: 0 0 8px; }
+  .curl-block pre { padding-right: 72px; }
+  .copy-btn { position: absolute; top: 8px; right: 8px; background: #495057; color: #fff; border: none; border-radius: 4px; padding: 4px 10px; font-size: 0.75rem; cursor: pointer; font-family: inherit; }
+  .copy-btn:hover { background: #0d6efd; }
+  .copy-btn:active { background: #0a58ca; }
 </style></head><body>
 <a href="index.html" class="back-link">&larr; Back to index</a>
 <h1><span class="method method-DELETE">DELETE</span> <span class="path">/users/{userId}</span></h1>
 <div class="card"><div class="card-header">Overview</div><div class="card-body"><dl class="meta-grid"><dt>Summary</dt><dd>Delete user</dd><dt>Description</dt><dd>Delete a user</dd><dt>Operation ID</dt><dd><code>deleteUser</code></dd><dt>Tags</dt><dd><span class="tag">Users</span></dd></dl></div></div>
 <div class="card"><div class="card-header">Security</div><div class="card-body"><p>bearerAuth <span class="tag">http</span></p></div></div>
 <div class="card"><div class="card-header">Path Parameters</div><div class="card-body"><dl class="meta-grid"><dt>userId <span class="required">*</span></dt><dd><code>UUID</code> = <code>00000000-0000-0000-0000-000000000002</code></dd></dl></div></div>
-<div class="card"><div class="card-header"><span class="status-badge status-2xx">204</span> Response</div><div class="card-body"><p>User deleted</p></div></div>
+<div class="card"><div class="card-header"><span class="status-badge status-2xx">204</span> Response</div><div class="card-body"><p>User deleted</p><h4>Curl</h4><div class="curl-block"><pre>curl -X DELETE '$BASE_URL/users/00000000-0000-0000-0000-000000000002' \
+  -H 'Authorization: Bearer &lt;TOKEN&gt;'</pre><button class="copy-btn" type="button" data-clipboard="curl -X DELETE &#39;$BASE_URL/users/00000000-0000-0000-0000-000000000002&#39; \
+  -H &#39;Authorization: Bearer &lt;TOKEN&gt;&#39;">Copy</button></div></div></div>
+<script>
+document.addEventListener('click', function (e) {
+  var btn = e.target.closest('button.copy-btn');
+  if (!btn) return;
+  var payload = btn.getAttribute('data-clipboard') || '';
+  navigator.clipboard.writeText(payload).then(function () {
+    var original = btn.textContent;
+    btn.textContent = 'Copied';
+    setTimeout(function () { btn.textContent = original; }, 1200);
+  });
+});
+</script>
 </body></html>

--- a/openapi/src/test/resources/gold/simple/GET__health-334cfc61.html
+++ b/openapi/src/test/resources/gold/simple/GET__health-334cfc61.html
@@ -39,7 +39,7 @@
 <h1><span class="method method-GET">GET</span> <span class="path">/health</span></h1>
 <div class="card"><div class="card-header">Overview</div><div class="card-body"><dl class="meta-grid"><dt>Summary</dt><dd>Liveness probe</dd><dt>Description</dt><dd>Return service liveness — no authentication required</dd><dt>Operation ID</dt><dd><code>health</code></dd><dt>Tags</dt><dd><span class="tag">System</span></dd></dl></div></div>
 
-<div class="card"><div class="card-header"><span class="status-badge status-2xx">200</span> Response</div><div class="card-body"><p>Service is alive</p><h4>Curl</h4><div class="curl-block"><pre>curl -X GET '$BASE_URL/health'</pre><button class="copy-btn" type="button" data-clipboard="curl -X GET &#39;$BASE_URL/health&#39;">Copy</button></div><h4>Response body</h4><pre>{
+<div class="card"><div class="card-header"><span class="status-badge status-2xx">200</span> Response</div><div class="card-body"><p>Service is alive</p><h4>Curl</h4><div class="curl-block"><pre>curl -X GET '$BASE_URL/health'</pre><button class="copy-btn" type="button">Copy</button></div><h4>Response body</h4><pre>{
   "status" : "ok",
   "uptimeSeconds" : 12345
 }</pre><details><summary>Response schema</summary><pre>{
@@ -65,12 +65,32 @@
 document.addEventListener('click', function (e) {
   var btn = e.target.closest('button.copy-btn');
   if (!btn) return;
-  var payload = btn.getAttribute('data-clipboard') || '';
-  navigator.clipboard.writeText(payload).then(function () {
-    var original = btn.textContent;
-    btn.textContent = 'Copied';
+  var pre = btn.previousElementSibling;
+  var payload = pre ? pre.textContent : '';
+  var flash = function (msg) {
+    var original = btn.dataset.origText || btn.textContent;
+    btn.dataset.origText = original;
+    btn.textContent = msg;
     setTimeout(function () { btn.textContent = original; }, 1200);
-  });
+  };
+  var fallback = function () {
+    try {
+      var ta = document.createElement('textarea');
+      ta.value = payload;
+      ta.style.position = 'fixed';
+      ta.style.opacity = '0';
+      document.body.appendChild(ta);
+      ta.select();
+      var ok = document.execCommand('copy');
+      document.body.removeChild(ta);
+      flash(ok ? 'Copied' : 'Failed');
+    } catch (_) { flash('Failed'); }
+  };
+  if (navigator.clipboard && navigator.clipboard.writeText) {
+    navigator.clipboard.writeText(payload).then(function () { flash('Copied'); }, fallback);
+  } else {
+    fallback();
+  }
 });
 </script>
 </body></html>

--- a/openapi/src/test/resources/gold/simple/GET__health-334cfc61.html
+++ b/openapi/src/test/resources/gold/simple/GET__health-334cfc61.html
@@ -27,12 +27,19 @@
   .back-link { display: inline-block; margin-bottom: 16px; font-size: 0.85rem; }
   ul.examples { list-style: none; padding: 0; margin: 4px 0 0; font-size: 0.85rem; }
   ul.examples li { padding: 2px 0; }
+  .tag-group { margin-bottom: 24px; }
+  .tag-heading { margin: 20px 0 10px; font-size: 1.1rem; font-weight: 600; color: #16213e; text-transform: uppercase; letter-spacing: 0.05em; border-bottom: 2px solid #dee2e6; padding-bottom: 6px; }
+  .curl-block { position: relative; margin: 0 0 8px; }
+  .curl-block pre { padding-right: 72px; }
+  .copy-btn { position: absolute; top: 8px; right: 8px; background: #495057; color: #fff; border: none; border-radius: 4px; padding: 4px 10px; font-size: 0.75rem; cursor: pointer; font-family: inherit; }
+  .copy-btn:hover { background: #0d6efd; }
+  .copy-btn:active { background: #0a58ca; }
 </style></head><body>
 <a href="index.html" class="back-link">&larr; Back to index</a>
 <h1><span class="method method-GET">GET</span> <span class="path">/health</span></h1>
 <div class="card"><div class="card-header">Overview</div><div class="card-body"><dl class="meta-grid"><dt>Summary</dt><dd>Liveness probe</dd><dt>Description</dt><dd>Return service liveness — no authentication required</dd><dt>Operation ID</dt><dd><code>health</code></dd><dt>Tags</dt><dd><span class="tag">System</span></dd></dl></div></div>
 
-<div class="card"><div class="card-header"><span class="status-badge status-2xx">200</span> Response</div><div class="card-body"><p>Service is alive</p><h4>Response body</h4><pre>{
+<div class="card"><div class="card-header"><span class="status-badge status-2xx">200</span> Response</div><div class="card-body"><p>Service is alive</p><h4>Curl</h4><div class="curl-block"><pre>curl -X GET '$BASE_URL/health'</pre><button class="copy-btn" type="button" data-clipboard="curl -X GET &#39;$BASE_URL/health&#39;">Copy</button></div><h4>Response body</h4><pre>{
   "status" : "ok",
   "uptimeSeconds" : 12345
 }</pre><details><summary>Response schema</summary><pre>{
@@ -54,4 +61,16 @@
   ],
   "additionalProperties" : false
 }</pre></details></div></div>
+<script>
+document.addEventListener('click', function (e) {
+  var btn = e.target.closest('button.copy-btn');
+  if (!btn) return;
+  var payload = btn.getAttribute('data-clipboard') || '';
+  navigator.clipboard.writeText(payload).then(function () {
+    var original = btn.textContent;
+    btn.textContent = 'Copied';
+    setTimeout(function () { btn.textContent = original; }, 1200);
+  });
+});
+</script>
 </body></html>

--- a/openapi/src/test/resources/gold/simple/GET__me-2647d21d.html
+++ b/openapi/src/test/resources/gold/simple/GET__me-2647d21d.html
@@ -27,12 +27,21 @@
   .back-link { display: inline-block; margin-bottom: 16px; font-size: 0.85rem; }
   ul.examples { list-style: none; padding: 0; margin: 4px 0 0; font-size: 0.85rem; }
   ul.examples li { padding: 2px 0; }
+  .tag-group { margin-bottom: 24px; }
+  .tag-heading { margin: 20px 0 10px; font-size: 1.1rem; font-weight: 600; color: #16213e; text-transform: uppercase; letter-spacing: 0.05em; border-bottom: 2px solid #dee2e6; padding-bottom: 6px; }
+  .curl-block { position: relative; margin: 0 0 8px; }
+  .curl-block pre { padding-right: 72px; }
+  .copy-btn { position: absolute; top: 8px; right: 8px; background: #495057; color: #fff; border: none; border-radius: 4px; padding: 4px 10px; font-size: 0.75rem; cursor: pointer; font-family: inherit; }
+  .copy-btn:hover { background: #0d6efd; }
+  .copy-btn:active { background: #0a58ca; }
 </style></head><body>
 <a href="index.html" class="back-link">&larr; Back to index</a>
 <h1><span class="method method-GET">GET</span> <span class="path">/me</span></h1>
 <div class="card"><div class="card-header">Overview</div><div class="card-body"><dl class="meta-grid"><dt>Summary</dt><dd>Who am I</dd><dt>Description</dt><dd>Return the profile of the currently authenticated user</dd><dt>Operation ID</dt><dd><code>me</code></dd><dt>Tags</dt><dd><span class="tag">Auth</span></dd></dl></div></div>
 <div class="card"><div class="card-header">Security</div><div class="card-body"><p>bearerAuth <span class="tag">http</span></p></div></div>
-<div class="card"><div class="card-header"><span class="status-badge status-2xx">200</span> Response</div><div class="card-body"><p>Authenticated user profile</p><h4>Response body</h4><pre>{
+<div class="card"><div class="card-header"><span class="status-badge status-2xx">200</span> Response</div><div class="card-body"><p>Authenticated user profile</p><h4>Curl</h4><div class="curl-block"><pre>curl -X GET '$BASE_URL/me' \
+  -H 'Authorization: Bearer &lt;TOKEN&gt;'</pre><button class="copy-btn" type="button" data-clipboard="curl -X GET &#39;$BASE_URL/me&#39; \
+  -H &#39;Authorization: Bearer &lt;TOKEN&gt;&#39;">Copy</button></div><h4>Response body</h4><pre>{
   "id" : "00000000-0000-0000-0000-000000000001",
   "email" : "alice@example.com",
   "name" : "Alice",
@@ -70,4 +79,16 @@
   ],
   "additionalProperties" : false
 }</pre></details></div></div>
+<script>
+document.addEventListener('click', function (e) {
+  var btn = e.target.closest('button.copy-btn');
+  if (!btn) return;
+  var payload = btn.getAttribute('data-clipboard') || '';
+  navigator.clipboard.writeText(payload).then(function () {
+    var original = btn.textContent;
+    btn.textContent = 'Copied';
+    setTimeout(function () { btn.textContent = original; }, 1200);
+  });
+});
+</script>
 </body></html>

--- a/openapi/src/test/resources/gold/simple/GET__me-2647d21d.html
+++ b/openapi/src/test/resources/gold/simple/GET__me-2647d21d.html
@@ -40,8 +40,7 @@
 <div class="card"><div class="card-header">Overview</div><div class="card-body"><dl class="meta-grid"><dt>Summary</dt><dd>Who am I</dd><dt>Description</dt><dd>Return the profile of the currently authenticated user</dd><dt>Operation ID</dt><dd><code>me</code></dd><dt>Tags</dt><dd><span class="tag">Auth</span></dd></dl></div></div>
 <div class="card"><div class="card-header">Security</div><div class="card-body"><p>bearerAuth <span class="tag">http</span></p></div></div>
 <div class="card"><div class="card-header"><span class="status-badge status-2xx">200</span> Response</div><div class="card-body"><p>Authenticated user profile</p><h4>Curl</h4><div class="curl-block"><pre>curl -X GET '$BASE_URL/me' \
-  -H 'Authorization: Bearer &lt;TOKEN&gt;'</pre><button class="copy-btn" type="button" data-clipboard="curl -X GET &#39;$BASE_URL/me&#39; \
-  -H &#39;Authorization: Bearer &lt;TOKEN&gt;&#39;">Copy</button></div><h4>Response body</h4><pre>{
+  -H 'Authorization: Bearer &lt;TOKEN&gt;'</pre><button class="copy-btn" type="button">Copy</button></div><h4>Response body</h4><pre>{
   "id" : "00000000-0000-0000-0000-000000000001",
   "email" : "alice@example.com",
   "name" : "Alice",
@@ -83,12 +82,32 @@
 document.addEventListener('click', function (e) {
   var btn = e.target.closest('button.copy-btn');
   if (!btn) return;
-  var payload = btn.getAttribute('data-clipboard') || '';
-  navigator.clipboard.writeText(payload).then(function () {
-    var original = btn.textContent;
-    btn.textContent = 'Copied';
+  var pre = btn.previousElementSibling;
+  var payload = pre ? pre.textContent : '';
+  var flash = function (msg) {
+    var original = btn.dataset.origText || btn.textContent;
+    btn.dataset.origText = original;
+    btn.textContent = msg;
     setTimeout(function () { btn.textContent = original; }, 1200);
-  });
+  };
+  var fallback = function () {
+    try {
+      var ta = document.createElement('textarea');
+      ta.value = payload;
+      ta.style.position = 'fixed';
+      ta.style.opacity = '0';
+      document.body.appendChild(ta);
+      ta.select();
+      var ok = document.execCommand('copy');
+      document.body.removeChild(ta);
+      flash(ok ? 'Copied' : 'Failed');
+    } catch (_) { flash('Failed'); }
+  };
+  if (navigator.clipboard && navigator.clipboard.writeText) {
+    navigator.clipboard.writeText(payload).then(function () { flash('Copied'); }, fallback);
+  } else {
+    fallback();
+  }
 });
 </script>
 </body></html>

--- a/openapi/src/test/resources/gold/simple/GET__projects-9a7aa53f.html
+++ b/openapi/src/test/resources/gold/simple/GET__projects-9a7aa53f.html
@@ -41,8 +41,7 @@
 <div class="card"><div class="card-header">Security</div><div class="card-body"><p>oauth2 <span class="tag">oauth2</span></p></div></div>
 <div class="card"><div class="card-header">Query Parameters</div><div class="card-body"><dl class="meta-grid"><dt>status</dt><dd><code>ProjectStatus</code> <span class="tag">active | archived | draft</span><ul class="examples"><li><em>All active projects:</em> <code>active</code></li><li><em>All archived projects:</em> <code>archived</code></li></ul></dd></dl></div></div>
 <div class="card"><div class="card-header"><span class="status-badge status-2xx">200</span> Response</div><div class="card-body"><p>All active projects</p><h4>Curl</h4><div class="curl-block"><pre>curl -X GET '$BASE_URL/projects?status=active' \
-  -H 'Authorization: Bearer &lt;OAUTH_TOKEN&gt;'</pre><button class="copy-btn" type="button" data-clipboard="curl -X GET &#39;$BASE_URL/projects?status=active&#39; \
-  -H &#39;Authorization: Bearer &lt;OAUTH_TOKEN&gt;&#39;">Copy</button></div><h4>Response body</h4><pre>[
+  -H 'Authorization: Bearer &lt;OAUTH_TOKEN&gt;'</pre><button class="copy-btn" type="button">Copy</button></div><h4>Response body</h4><pre>[
   {
     "id" : 42,
     "name" : "Apollo",
@@ -96,8 +95,7 @@
   }
 }</pre></details></div></div>
 <div class="card"><div class="card-header"><span class="status-badge status-2xx">200</span> Response</div><div class="card-body"><p>All archived projects</p><h4>Curl</h4><div class="curl-block"><pre>curl -X GET '$BASE_URL/projects?status=archived' \
-  -H 'Authorization: Bearer &lt;OAUTH_TOKEN&gt;'</pre><button class="copy-btn" type="button" data-clipboard="curl -X GET &#39;$BASE_URL/projects?status=archived&#39; \
-  -H &#39;Authorization: Bearer &lt;OAUTH_TOKEN&gt;&#39;">Copy</button></div><h4>Response body</h4><pre>[
+  -H 'Authorization: Bearer &lt;OAUTH_TOKEN&gt;'</pre><button class="copy-btn" type="button">Copy</button></div><h4>Response body</h4><pre>[
   {
     "id" : 7,
     "name" : "Gemini",
@@ -154,12 +152,32 @@
 document.addEventListener('click', function (e) {
   var btn = e.target.closest('button.copy-btn');
   if (!btn) return;
-  var payload = btn.getAttribute('data-clipboard') || '';
-  navigator.clipboard.writeText(payload).then(function () {
-    var original = btn.textContent;
-    btn.textContent = 'Copied';
+  var pre = btn.previousElementSibling;
+  var payload = pre ? pre.textContent : '';
+  var flash = function (msg) {
+    var original = btn.dataset.origText || btn.textContent;
+    btn.dataset.origText = original;
+    btn.textContent = msg;
     setTimeout(function () { btn.textContent = original; }, 1200);
-  });
+  };
+  var fallback = function () {
+    try {
+      var ta = document.createElement('textarea');
+      ta.value = payload;
+      ta.style.position = 'fixed';
+      ta.style.opacity = '0';
+      document.body.appendChild(ta);
+      ta.select();
+      var ok = document.execCommand('copy');
+      document.body.removeChild(ta);
+      flash(ok ? 'Copied' : 'Failed');
+    } catch (_) { flash('Failed'); }
+  };
+  if (navigator.clipboard && navigator.clipboard.writeText) {
+    navigator.clipboard.writeText(payload).then(function () { flash('Copied'); }, fallback);
+  } else {
+    fallback();
+  }
 });
 </script>
 </body></html>

--- a/openapi/src/test/resources/gold/simple/GET__projects-9a7aa53f.html
+++ b/openapi/src/test/resources/gold/simple/GET__projects-9a7aa53f.html
@@ -27,13 +27,22 @@
   .back-link { display: inline-block; margin-bottom: 16px; font-size: 0.85rem; }
   ul.examples { list-style: none; padding: 0; margin: 4px 0 0; font-size: 0.85rem; }
   ul.examples li { padding: 2px 0; }
+  .tag-group { margin-bottom: 24px; }
+  .tag-heading { margin: 20px 0 10px; font-size: 1.1rem; font-weight: 600; color: #16213e; text-transform: uppercase; letter-spacing: 0.05em; border-bottom: 2px solid #dee2e6; padding-bottom: 6px; }
+  .curl-block { position: relative; margin: 0 0 8px; }
+  .curl-block pre { padding-right: 72px; }
+  .copy-btn { position: absolute; top: 8px; right: 8px; background: #495057; color: #fff; border: none; border-radius: 4px; padding: 4px 10px; font-size: 0.75rem; cursor: pointer; font-family: inherit; }
+  .copy-btn:hover { background: #0d6efd; }
+  .copy-btn:active { background: #0a58ca; }
 </style></head><body>
 <a href="index.html" class="back-link">&larr; Back to index</a>
 <h1><span class="method method-GET">GET</span> <span class="path">/projects</span></h1>
 <div class="card"><div class="card-header">Overview</div><div class="card-body"><dl class="meta-grid"><dt>Summary</dt><dd>List projects</dd><dt>Description</dt><dd>List projects, optionally filtered by status</dd><dt>Operation ID</dt><dd><code>listProjects</code></dd><dt>Tags</dt><dd><span class="tag">Projects</span></dd></dl></div></div>
 <div class="card"><div class="card-header">Security</div><div class="card-body"><p>oauth2 <span class="tag">oauth2</span></p></div></div>
 <div class="card"><div class="card-header">Query Parameters</div><div class="card-body"><dl class="meta-grid"><dt>status</dt><dd><code>ProjectStatus</code> <span class="tag">active | archived | draft</span><ul class="examples"><li><em>All active projects:</em> <code>active</code></li><li><em>All archived projects:</em> <code>archived</code></li></ul></dd></dl></div></div>
-<div class="card"><div class="card-header"><span class="status-badge status-2xx">200</span> Response</div><div class="card-body"><p>All active projects</p><h4>Response body</h4><pre>[
+<div class="card"><div class="card-header"><span class="status-badge status-2xx">200</span> Response</div><div class="card-body"><p>All active projects</p><h4>Curl</h4><div class="curl-block"><pre>curl -X GET '$BASE_URL/projects?status=active' \
+  -H 'Authorization: Bearer &lt;OAUTH_TOKEN&gt;'</pre><button class="copy-btn" type="button" data-clipboard="curl -X GET &#39;$BASE_URL/projects?status=active&#39; \
+  -H &#39;Authorization: Bearer &lt;OAUTH_TOKEN&gt;&#39;">Copy</button></div><h4>Response body</h4><pre>[
   {
     "id" : 42,
     "name" : "Apollo",
@@ -86,7 +95,9 @@
     "additionalProperties" : false
   }
 }</pre></details></div></div>
-<div class="card"><div class="card-header"><span class="status-badge status-2xx">200</span> Response</div><div class="card-body"><p>All archived projects</p><h4>Response body</h4><pre>[
+<div class="card"><div class="card-header"><span class="status-badge status-2xx">200</span> Response</div><div class="card-body"><p>All archived projects</p><h4>Curl</h4><div class="curl-block"><pre>curl -X GET '$BASE_URL/projects?status=archived' \
+  -H 'Authorization: Bearer &lt;OAUTH_TOKEN&gt;'</pre><button class="copy-btn" type="button" data-clipboard="curl -X GET &#39;$BASE_URL/projects?status=archived&#39; \
+  -H &#39;Authorization: Bearer &lt;OAUTH_TOKEN&gt;&#39;">Copy</button></div><h4>Response body</h4><pre>[
   {
     "id" : 7,
     "name" : "Gemini",
@@ -139,4 +150,16 @@
     "additionalProperties" : false
   }
 }</pre></details></div></div>
+<script>
+document.addEventListener('click', function (e) {
+  var btn = e.target.closest('button.copy-btn');
+  if (!btn) return;
+  var payload = btn.getAttribute('data-clipboard') || '';
+  navigator.clipboard.writeText(payload).then(function () {
+    var original = btn.textContent;
+    btn.textContent = 'Copied';
+    setTimeout(function () { btn.textContent = original; }, 1200);
+  });
+});
+</script>
 </body></html>

--- a/openapi/src/test/resources/gold/simple/GET__projects___projectId___tasks-b0b82093.html
+++ b/openapi/src/test/resources/gold/simple/GET__projects___projectId___tasks-b0b82093.html
@@ -27,13 +27,22 @@
   .back-link { display: inline-block; margin-bottom: 16px; font-size: 0.85rem; }
   ul.examples { list-style: none; padding: 0; margin: 4px 0 0; font-size: 0.85rem; }
   ul.examples li { padding: 2px 0; }
+  .tag-group { margin-bottom: 24px; }
+  .tag-heading { margin: 20px 0 10px; font-size: 1.1rem; font-weight: 600; color: #16213e; text-transform: uppercase; letter-spacing: 0.05em; border-bottom: 2px solid #dee2e6; padding-bottom: 6px; }
+  .curl-block { position: relative; margin: 0 0 8px; }
+  .curl-block pre { padding-right: 72px; }
+  .copy-btn { position: absolute; top: 8px; right: 8px; background: #495057; color: #fff; border: none; border-radius: 4px; padding: 4px 10px; font-size: 0.75rem; cursor: pointer; font-family: inherit; }
+  .copy-btn:hover { background: #0d6efd; }
+  .copy-btn:active { background: #0a58ca; }
 </style></head><body>
 <a href="index.html" class="back-link">&larr; Back to index</a>
 <h1><span class="method method-GET">GET</span> <span class="path">/projects/{projectId}/tasks</span></h1>
 <div class="card"><div class="card-header">Overview</div><div class="card-body"><dl class="meta-grid"><dt>Summary</dt><dd>List tasks</dd><dt>Description</dt><dd>List all tasks in a project</dd><dt>Operation ID</dt><dd><code>listTasks</code></dd><dt>Tags</dt><dd><span class="tag">Tasks</span></dd></dl></div></div>
 <div class="card"><div class="card-header">Security</div><div class="card-body"><p>oauth2 <span class="tag">oauth2</span></p></div></div>
 <div class="card"><div class="card-header">Path Parameters</div><div class="card-body"><dl class="meta-grid"><dt>projectId <span class="required">*</span></dt><dd><code>Long</code> = <code>42</code></dd></dl></div></div>
-<div class="card"><div class="card-header"><span class="status-badge status-2xx">200</span> Response</div><div class="card-body"><p>All tasks in the project</p><h4>Response body</h4><pre>[
+<div class="card"><div class="card-header"><span class="status-badge status-2xx">200</span> Response</div><div class="card-body"><p>All tasks in the project</p><h4>Curl</h4><div class="curl-block"><pre>curl -X GET '$BASE_URL/projects/42/tasks' \
+  -H 'Authorization: Bearer &lt;OAUTH_TOKEN&gt;'</pre><button class="copy-btn" type="button" data-clipboard="curl -X GET &#39;$BASE_URL/projects/42/tasks&#39; \
+  -H &#39;Authorization: Bearer &lt;OAUTH_TOKEN&gt;&#39;">Copy</button></div><h4>Response body</h4><pre>[
   {
     "id" : 101,
     "title" : "Wire up telemetry",
@@ -87,4 +96,16 @@
     "additionalProperties" : false
   }
 }</pre></details></div></div>
+<script>
+document.addEventListener('click', function (e) {
+  var btn = e.target.closest('button.copy-btn');
+  if (!btn) return;
+  var payload = btn.getAttribute('data-clipboard') || '';
+  navigator.clipboard.writeText(payload).then(function () {
+    var original = btn.textContent;
+    btn.textContent = 'Copied';
+    setTimeout(function () { btn.textContent = original; }, 1200);
+  });
+});
+</script>
 </body></html>

--- a/openapi/src/test/resources/gold/simple/GET__projects___projectId___tasks-b0b82093.html
+++ b/openapi/src/test/resources/gold/simple/GET__projects___projectId___tasks-b0b82093.html
@@ -41,8 +41,7 @@
 <div class="card"><div class="card-header">Security</div><div class="card-body"><p>oauth2 <span class="tag">oauth2</span></p></div></div>
 <div class="card"><div class="card-header">Path Parameters</div><div class="card-body"><dl class="meta-grid"><dt>projectId <span class="required">*</span></dt><dd><code>Long</code> = <code>42</code></dd></dl></div></div>
 <div class="card"><div class="card-header"><span class="status-badge status-2xx">200</span> Response</div><div class="card-body"><p>All tasks in the project</p><h4>Curl</h4><div class="curl-block"><pre>curl -X GET '$BASE_URL/projects/42/tasks' \
-  -H 'Authorization: Bearer &lt;OAUTH_TOKEN&gt;'</pre><button class="copy-btn" type="button" data-clipboard="curl -X GET &#39;$BASE_URL/projects/42/tasks&#39; \
-  -H &#39;Authorization: Bearer &lt;OAUTH_TOKEN&gt;&#39;">Copy</button></div><h4>Response body</h4><pre>[
+  -H 'Authorization: Bearer &lt;OAUTH_TOKEN&gt;'</pre><button class="copy-btn" type="button">Copy</button></div><h4>Response body</h4><pre>[
   {
     "id" : 101,
     "title" : "Wire up telemetry",
@@ -100,12 +99,32 @@
 document.addEventListener('click', function (e) {
   var btn = e.target.closest('button.copy-btn');
   if (!btn) return;
-  var payload = btn.getAttribute('data-clipboard') || '';
-  navigator.clipboard.writeText(payload).then(function () {
-    var original = btn.textContent;
-    btn.textContent = 'Copied';
+  var pre = btn.previousElementSibling;
+  var payload = pre ? pre.textContent : '';
+  var flash = function (msg) {
+    var original = btn.dataset.origText || btn.textContent;
+    btn.dataset.origText = original;
+    btn.textContent = msg;
     setTimeout(function () { btn.textContent = original; }, 1200);
-  });
+  };
+  var fallback = function () {
+    try {
+      var ta = document.createElement('textarea');
+      ta.value = payload;
+      ta.style.position = 'fixed';
+      ta.style.opacity = '0';
+      document.body.appendChild(ta);
+      ta.select();
+      var ok = document.execCommand('copy');
+      document.body.removeChild(ta);
+      flash(ok ? 'Copied' : 'Failed');
+    } catch (_) { flash('Failed'); }
+  };
+  if (navigator.clipboard && navigator.clipboard.writeText) {
+    navigator.clipboard.writeText(payload).then(function () { flash('Copied'); }, fallback);
+  } else {
+    fallback();
+  }
 });
 </script>
 </body></html>

--- a/openapi/src/test/resources/gold/simple/GET__users-c054bf63.html
+++ b/openapi/src/test/resources/gold/simple/GET__users-c054bf63.html
@@ -27,13 +27,22 @@
   .back-link { display: inline-block; margin-bottom: 16px; font-size: 0.85rem; }
   ul.examples { list-style: none; padding: 0; margin: 4px 0 0; font-size: 0.85rem; }
   ul.examples li { padding: 2px 0; }
+  .tag-group { margin-bottom: 24px; }
+  .tag-heading { margin: 20px 0 10px; font-size: 1.1rem; font-weight: 600; color: #16213e; text-transform: uppercase; letter-spacing: 0.05em; border-bottom: 2px solid #dee2e6; padding-bottom: 6px; }
+  .curl-block { position: relative; margin: 0 0 8px; }
+  .curl-block pre { padding-right: 72px; }
+  .copy-btn { position: absolute; top: 8px; right: 8px; background: #495057; color: #fff; border: none; border-radius: 4px; padding: 4px 10px; font-size: 0.75rem; cursor: pointer; font-family: inherit; }
+  .copy-btn:hover { background: #0d6efd; }
+  .copy-btn:active { background: #0a58ca; }
 </style></head><body>
 <a href="index.html" class="back-link">&larr; Back to index</a>
 <h1><span class="method method-GET">GET</span> <span class="path">/users</span></h1>
 <div class="card"><div class="card-header">Overview</div><div class="card-body"><dl class="meta-grid"><dt>Summary</dt><dd>List users</dd><dt>Description</dt><dd>List users with pagination and optional role filter</dd><dt>Operation ID</dt><dd><code>listUsers</code></dd><dt>Tags</dt><dd><span class="tag">Users</span></dd></dl></div></div>
 <div class="card"><div class="card-header">Security</div><div class="card-body"><p>bearerAuth <span class="tag">http</span></p></div></div>
 <div class="card"><div class="card-header">Query Parameters</div><div class="card-body"><dl class="meta-grid"><dt>page</dt><dd><code>Int</code> = <code>1</code></dd><dt>limit</dt><dd><code>Int</code> = <code>20</code></dd><dt>role</dt><dd><code>Role</code> <span class="tag">admin | guest | member</span> = <code>admin</code></dd></dl></div></div>
-<div class="card"><div class="card-header"><span class="status-badge status-2xx">200</span> Response</div><div class="card-body"><p>First page of users</p><h4>Response headers</h4><dl class="meta-grid"><dt>X-Rate-Limit-Remaining <span class="required">*</span></dt><dd><code>Int</code> = <code>59</code></dd></dl><h4>Response body</h4><pre>{
+<div class="card"><div class="card-header"><span class="status-badge status-2xx">200</span> Response</div><div class="card-body"><p>First page of users</p><h4>Curl</h4><div class="curl-block"><pre>curl -X GET '$BASE_URL/users?page=1&amp;limit=20&amp;role=admin' \
+  -H 'Authorization: Bearer &lt;TOKEN&gt;'</pre><button class="copy-btn" type="button" data-clipboard="curl -X GET &#39;$BASE_URL/users?page=1&amp;limit=20&amp;role=admin&#39; \
+  -H &#39;Authorization: Bearer &lt;TOKEN&gt;&#39;">Copy</button></div><h4>Response headers</h4><dl class="meta-grid"><dt>X-Rate-Limit-Remaining <span class="required">*</span></dt><dd><code>Int</code> = <code>59</code></dd></dl><h4>Response body</h4><pre>{
   "users" : [
     {
       "id" : "00000000-0000-0000-0000-000000000001",
@@ -112,4 +121,16 @@
   ],
   "additionalProperties" : false
 }</pre></details></div></div>
+<script>
+document.addEventListener('click', function (e) {
+  var btn = e.target.closest('button.copy-btn');
+  if (!btn) return;
+  var payload = btn.getAttribute('data-clipboard') || '';
+  navigator.clipboard.writeText(payload).then(function () {
+    var original = btn.textContent;
+    btn.textContent = 'Copied';
+    setTimeout(function () { btn.textContent = original; }, 1200);
+  });
+});
+</script>
 </body></html>

--- a/openapi/src/test/resources/gold/simple/GET__users-c054bf63.html
+++ b/openapi/src/test/resources/gold/simple/GET__users-c054bf63.html
@@ -41,8 +41,7 @@
 <div class="card"><div class="card-header">Security</div><div class="card-body"><p>bearerAuth <span class="tag">http</span></p></div></div>
 <div class="card"><div class="card-header">Query Parameters</div><div class="card-body"><dl class="meta-grid"><dt>page</dt><dd><code>Int</code> = <code>1</code></dd><dt>limit</dt><dd><code>Int</code> = <code>20</code></dd><dt>role</dt><dd><code>Role</code> <span class="tag">admin | guest | member</span> = <code>admin</code></dd></dl></div></div>
 <div class="card"><div class="card-header"><span class="status-badge status-2xx">200</span> Response</div><div class="card-body"><p>First page of users</p><h4>Curl</h4><div class="curl-block"><pre>curl -X GET '$BASE_URL/users?page=1&amp;limit=20&amp;role=admin' \
-  -H 'Authorization: Bearer &lt;TOKEN&gt;'</pre><button class="copy-btn" type="button" data-clipboard="curl -X GET &#39;$BASE_URL/users?page=1&amp;limit=20&amp;role=admin&#39; \
-  -H &#39;Authorization: Bearer &lt;TOKEN&gt;&#39;">Copy</button></div><h4>Response headers</h4><dl class="meta-grid"><dt>X-Rate-Limit-Remaining <span class="required">*</span></dt><dd><code>Int</code> = <code>59</code></dd></dl><h4>Response body</h4><pre>{
+  -H 'Authorization: Bearer &lt;TOKEN&gt;'</pre><button class="copy-btn" type="button">Copy</button></div><h4>Response headers</h4><dl class="meta-grid"><dt>X-Rate-Limit-Remaining <span class="required">*</span></dt><dd><code>Int</code> = <code>59</code></dd></dl><h4>Response body</h4><pre>{
   "users" : [
     {
       "id" : "00000000-0000-0000-0000-000000000001",
@@ -125,12 +124,32 @@
 document.addEventListener('click', function (e) {
   var btn = e.target.closest('button.copy-btn');
   if (!btn) return;
-  var payload = btn.getAttribute('data-clipboard') || '';
-  navigator.clipboard.writeText(payload).then(function () {
-    var original = btn.textContent;
-    btn.textContent = 'Copied';
+  var pre = btn.previousElementSibling;
+  var payload = pre ? pre.textContent : '';
+  var flash = function (msg) {
+    var original = btn.dataset.origText || btn.textContent;
+    btn.dataset.origText = original;
+    btn.textContent = msg;
     setTimeout(function () { btn.textContent = original; }, 1200);
-  });
+  };
+  var fallback = function () {
+    try {
+      var ta = document.createElement('textarea');
+      ta.value = payload;
+      ta.style.position = 'fixed';
+      ta.style.opacity = '0';
+      document.body.appendChild(ta);
+      ta.select();
+      var ok = document.execCommand('copy');
+      document.body.removeChild(ta);
+      flash(ok ? 'Copied' : 'Failed');
+    } catch (_) { flash('Failed'); }
+  };
+  if (navigator.clipboard && navigator.clipboard.writeText) {
+    navigator.clipboard.writeText(payload).then(function () { flash('Copied'); }, fallback);
+  } else {
+    fallback();
+  }
 });
 </script>
 </body></html>

--- a/openapi/src/test/resources/gold/simple/GET__users___userId__-baf46b48.html
+++ b/openapi/src/test/resources/gold/simple/GET__users___userId__-baf46b48.html
@@ -27,13 +27,22 @@
   .back-link { display: inline-block; margin-bottom: 16px; font-size: 0.85rem; }
   ul.examples { list-style: none; padding: 0; margin: 4px 0 0; font-size: 0.85rem; }
   ul.examples li { padding: 2px 0; }
+  .tag-group { margin-bottom: 24px; }
+  .tag-heading { margin: 20px 0 10px; font-size: 1.1rem; font-weight: 600; color: #16213e; text-transform: uppercase; letter-spacing: 0.05em; border-bottom: 2px solid #dee2e6; padding-bottom: 6px; }
+  .curl-block { position: relative; margin: 0 0 8px; }
+  .curl-block pre { padding-right: 72px; }
+  .copy-btn { position: absolute; top: 8px; right: 8px; background: #495057; color: #fff; border: none; border-radius: 4px; padding: 4px 10px; font-size: 0.75rem; cursor: pointer; font-family: inherit; }
+  .copy-btn:hover { background: #0d6efd; }
+  .copy-btn:active { background: #0a58ca; }
 </style></head><body>
 <a href="index.html" class="back-link">&larr; Back to index</a>
 <h1><span class="method method-GET">GET</span> <span class="path">/users/{userId}</span></h1>
 <div class="card"><div class="card-header">Overview</div><div class="card-body"><dl class="meta-grid"><dt>Summary</dt><dd>Get user</dd><dt>Description</dt><dd>Fetch a single user by UUID</dd><dt>Operation ID</dt><dd><code>getUser</code></dd><dt>Tags</dt><dd><span class="tag">Users</span></dd></dl></div></div>
 <div class="card"><div class="card-header">Security</div><div class="card-body"><p>bearerAuth <span class="tag">http</span></p></div></div>
 <div class="card"><div class="card-header">Path Parameters</div><div class="card-body"><dl class="meta-grid"><dt>userId <span class="required">*</span></dt><dd><code>UUID</code><ul class="examples"><li><em>User found:</em> <code>00000000-0000-0000-0000-000000000001</code></li><li><em>User not found:</em> <code>00000000-0000-0000-0000-0000000000ff</code></li></ul></dd></dl></div></div>
-<div class="card"><div class="card-header"><span class="status-badge status-2xx">200</span> Response</div><div class="card-body"><p>User found</p><h4>Response body</h4><pre>{
+<div class="card"><div class="card-header"><span class="status-badge status-2xx">200</span> Response</div><div class="card-body"><p>User found</p><h4>Curl</h4><div class="curl-block"><pre>curl -X GET '$BASE_URL/users/00000000-0000-0000-0000-000000000001' \
+  -H 'Authorization: Bearer &lt;TOKEN&gt;'</pre><button class="copy-btn" type="button" data-clipboard="curl -X GET &#39;$BASE_URL/users/00000000-0000-0000-0000-000000000001&#39; \
+  -H &#39;Authorization: Bearer &lt;TOKEN&gt;&#39;">Copy</button></div><h4>Response body</h4><pre>{
   "id" : "00000000-0000-0000-0000-000000000001",
   "email" : "alice@example.com",
   "name" : "Alice",
@@ -71,7 +80,9 @@
   ],
   "additionalProperties" : false
 }</pre></details></div></div>
-<div class="card"><div class="card-header"><span class="status-badge status-4xx">404</span> Response</div><div class="card-body"><p>User not found</p><h4>Response body</h4><pre>{
+<div class="card"><div class="card-header"><span class="status-badge status-4xx">404</span> Response</div><div class="card-body"><p>User not found</p><h4>Curl</h4><div class="curl-block"><pre>curl -X GET '$BASE_URL/users/00000000-0000-0000-0000-0000000000ff' \
+  -H 'Authorization: Bearer &lt;TOKEN&gt;'</pre><button class="copy-btn" type="button" data-clipboard="curl -X GET &#39;$BASE_URL/users/00000000-0000-0000-0000-0000000000ff&#39; \
+  -H &#39;Authorization: Bearer &lt;TOKEN&gt;&#39;">Copy</button></div><h4>Response body</h4><pre>{
   "code" : "not_found",
   "message" : "No such user",
   "details" : null
@@ -99,4 +110,16 @@
   ],
   "additionalProperties" : false
 }</pre></details></div></div>
+<script>
+document.addEventListener('click', function (e) {
+  var btn = e.target.closest('button.copy-btn');
+  if (!btn) return;
+  var payload = btn.getAttribute('data-clipboard') || '';
+  navigator.clipboard.writeText(payload).then(function () {
+    var original = btn.textContent;
+    btn.textContent = 'Copied';
+    setTimeout(function () { btn.textContent = original; }, 1200);
+  });
+});
+</script>
 </body></html>

--- a/openapi/src/test/resources/gold/simple/GET__users___userId__-baf46b48.html
+++ b/openapi/src/test/resources/gold/simple/GET__users___userId__-baf46b48.html
@@ -41,8 +41,7 @@
 <div class="card"><div class="card-header">Security</div><div class="card-body"><p>bearerAuth <span class="tag">http</span></p></div></div>
 <div class="card"><div class="card-header">Path Parameters</div><div class="card-body"><dl class="meta-grid"><dt>userId <span class="required">*</span></dt><dd><code>UUID</code><ul class="examples"><li><em>User found:</em> <code>00000000-0000-0000-0000-000000000001</code></li><li><em>User not found:</em> <code>00000000-0000-0000-0000-0000000000ff</code></li></ul></dd></dl></div></div>
 <div class="card"><div class="card-header"><span class="status-badge status-2xx">200</span> Response</div><div class="card-body"><p>User found</p><h4>Curl</h4><div class="curl-block"><pre>curl -X GET '$BASE_URL/users/00000000-0000-0000-0000-000000000001' \
-  -H 'Authorization: Bearer &lt;TOKEN&gt;'</pre><button class="copy-btn" type="button" data-clipboard="curl -X GET &#39;$BASE_URL/users/00000000-0000-0000-0000-000000000001&#39; \
-  -H &#39;Authorization: Bearer &lt;TOKEN&gt;&#39;">Copy</button></div><h4>Response body</h4><pre>{
+  -H 'Authorization: Bearer &lt;TOKEN&gt;'</pre><button class="copy-btn" type="button">Copy</button></div><h4>Response body</h4><pre>{
   "id" : "00000000-0000-0000-0000-000000000001",
   "email" : "alice@example.com",
   "name" : "Alice",
@@ -81,8 +80,7 @@
   "additionalProperties" : false
 }</pre></details></div></div>
 <div class="card"><div class="card-header"><span class="status-badge status-4xx">404</span> Response</div><div class="card-body"><p>User not found</p><h4>Curl</h4><div class="curl-block"><pre>curl -X GET '$BASE_URL/users/00000000-0000-0000-0000-0000000000ff' \
-  -H 'Authorization: Bearer &lt;TOKEN&gt;'</pre><button class="copy-btn" type="button" data-clipboard="curl -X GET &#39;$BASE_URL/users/00000000-0000-0000-0000-0000000000ff&#39; \
-  -H &#39;Authorization: Bearer &lt;TOKEN&gt;&#39;">Copy</button></div><h4>Response body</h4><pre>{
+  -H 'Authorization: Bearer &lt;TOKEN&gt;'</pre><button class="copy-btn" type="button">Copy</button></div><h4>Response body</h4><pre>{
   "code" : "not_found",
   "message" : "No such user",
   "details" : null
@@ -114,12 +112,32 @@
 document.addEventListener('click', function (e) {
   var btn = e.target.closest('button.copy-btn');
   if (!btn) return;
-  var payload = btn.getAttribute('data-clipboard') || '';
-  navigator.clipboard.writeText(payload).then(function () {
-    var original = btn.textContent;
-    btn.textContent = 'Copied';
+  var pre = btn.previousElementSibling;
+  var payload = pre ? pre.textContent : '';
+  var flash = function (msg) {
+    var original = btn.dataset.origText || btn.textContent;
+    btn.dataset.origText = original;
+    btn.textContent = msg;
     setTimeout(function () { btn.textContent = original; }, 1200);
-  });
+  };
+  var fallback = function () {
+    try {
+      var ta = document.createElement('textarea');
+      ta.value = payload;
+      ta.style.position = 'fixed';
+      ta.style.opacity = '0';
+      document.body.appendChild(ta);
+      ta.select();
+      var ok = document.execCommand('copy');
+      document.body.removeChild(ta);
+      flash(ok ? 'Copied' : 'Failed');
+    } catch (_) { flash('Failed'); }
+  };
+  if (navigator.clipboard && navigator.clipboard.writeText) {
+    navigator.clipboard.writeText(payload).then(function () { flash('Copied'); }, fallback);
+  } else {
+    fallback();
+  }
 });
 </script>
 </body></html>

--- a/openapi/src/test/resources/gold/simple/PATCH__projects___projectId__-fc9e4246.html
+++ b/openapi/src/test/resources/gold/simple/PATCH__projects___projectId__-fc9e4246.html
@@ -68,10 +68,7 @@
 <div class="card"><div class="card-header"><span class="status-badge status-2xx">200</span> Response</div><div class="card-body"><p>Project updated</p><h4>Curl</h4><div class="curl-block"><pre>curl -X PATCH '$BASE_URL/projects/42' \
   -H 'Content-Type: application/json' \
   -H 'Authorization: Bearer &lt;OAUTH_TOKEN&gt;' \
-  --data-raw '{"name":null,"description":"Updated desc","status":null}'</pre><button class="copy-btn" type="button" data-clipboard="curl -X PATCH &#39;$BASE_URL/projects/42&#39; \
-  -H &#39;Content-Type: application/json&#39; \
-  -H &#39;Authorization: Bearer &lt;OAUTH_TOKEN&gt;&#39; \
-  --data-raw &#39;{&quot;name&quot;:null,&quot;description&quot;:&quot;Updated desc&quot;,&quot;status&quot;:null}&#39;">Copy</button></div><h4>Request body</h4><pre>{
+  --data-raw '{"name":null,"description":"Updated desc","status":null}'</pre><button class="copy-btn" type="button">Copy</button></div><h4>Request body</h4><pre>{
   "name" : null,
   "description" : "Updated desc",
   "status" : null
@@ -127,12 +124,32 @@
 document.addEventListener('click', function (e) {
   var btn = e.target.closest('button.copy-btn');
   if (!btn) return;
-  var payload = btn.getAttribute('data-clipboard') || '';
-  navigator.clipboard.writeText(payload).then(function () {
-    var original = btn.textContent;
-    btn.textContent = 'Copied';
+  var pre = btn.previousElementSibling;
+  var payload = pre ? pre.textContent : '';
+  var flash = function (msg) {
+    var original = btn.dataset.origText || btn.textContent;
+    btn.dataset.origText = original;
+    btn.textContent = msg;
     setTimeout(function () { btn.textContent = original; }, 1200);
-  });
+  };
+  var fallback = function () {
+    try {
+      var ta = document.createElement('textarea');
+      ta.value = payload;
+      ta.style.position = 'fixed';
+      ta.style.opacity = '0';
+      document.body.appendChild(ta);
+      ta.select();
+      var ok = document.execCommand('copy');
+      document.body.removeChild(ta);
+      flash(ok ? 'Copied' : 'Failed');
+    } catch (_) { flash('Failed'); }
+  };
+  if (navigator.clipboard && navigator.clipboard.writeText) {
+    navigator.clipboard.writeText(payload).then(function () { flash('Copied'); }, fallback);
+  } else {
+    fallback();
+  }
 });
 </script>
 </body></html>

--- a/openapi/src/test/resources/gold/simple/PATCH__projects___projectId__-fc9e4246.html
+++ b/openapi/src/test/resources/gold/simple/PATCH__projects___projectId__-fc9e4246.html
@@ -27,6 +27,13 @@
   .back-link { display: inline-block; margin-bottom: 16px; font-size: 0.85rem; }
   ul.examples { list-style: none; padding: 0; margin: 4px 0 0; font-size: 0.85rem; }
   ul.examples li { padding: 2px 0; }
+  .tag-group { margin-bottom: 24px; }
+  .tag-heading { margin: 20px 0 10px; font-size: 1.1rem; font-weight: 600; color: #16213e; text-transform: uppercase; letter-spacing: 0.05em; border-bottom: 2px solid #dee2e6; padding-bottom: 6px; }
+  .curl-block { position: relative; margin: 0 0 8px; }
+  .curl-block pre { padding-right: 72px; }
+  .copy-btn { position: absolute; top: 8px; right: 8px; background: #495057; color: #fff; border: none; border-radius: 4px; padding: 4px 10px; font-size: 0.75rem; cursor: pointer; font-family: inherit; }
+  .copy-btn:hover { background: #0d6efd; }
+  .copy-btn:active { background: #0a58ca; }
 </style></head><body>
 <a href="index.html" class="back-link">&larr; Back to index</a>
 <h1><span class="method method-PATCH">PATCH</span> <span class="path">/projects/{projectId}</span></h1>
@@ -58,7 +65,13 @@
   ],
   "additionalProperties" : false
 }</pre></details></div></div>
-<div class="card"><div class="card-header"><span class="status-badge status-2xx">200</span> Response</div><div class="card-body"><p>Project updated</p><h4>Request body</h4><pre>{
+<div class="card"><div class="card-header"><span class="status-badge status-2xx">200</span> Response</div><div class="card-body"><p>Project updated</p><h4>Curl</h4><div class="curl-block"><pre>curl -X PATCH '$BASE_URL/projects/42' \
+  -H 'Content-Type: application/json' \
+  -H 'Authorization: Bearer &lt;OAUTH_TOKEN&gt;' \
+  --data-raw '{"name":null,"description":"Updated desc","status":null}'</pre><button class="copy-btn" type="button" data-clipboard="curl -X PATCH &#39;$BASE_URL/projects/42&#39; \
+  -H &#39;Content-Type: application/json&#39; \
+  -H &#39;Authorization: Bearer &lt;OAUTH_TOKEN&gt;&#39; \
+  --data-raw &#39;{&quot;name&quot;:null,&quot;description&quot;:&quot;Updated desc&quot;,&quot;status&quot;:null}&#39;">Copy</button></div><h4>Request body</h4><pre>{
   "name" : null,
   "description" : "Updated desc",
   "status" : null
@@ -110,4 +123,16 @@
   ],
   "additionalProperties" : false
 }</pre></details></div></div>
+<script>
+document.addEventListener('click', function (e) {
+  var btn = e.target.closest('button.copy-btn');
+  if (!btn) return;
+  var payload = btn.getAttribute('data-clipboard') || '';
+  navigator.clipboard.writeText(payload).then(function () {
+    var original = btn.textContent;
+    btn.textContent = 'Copied';
+    setTimeout(function () { btn.textContent = original; }, 1200);
+  });
+});
+</script>
 </body></html>

--- a/openapi/src/test/resources/gold/simple/POST__auth_login-3b67d231.html
+++ b/openapi/src/test/resources/gold/simple/POST__auth_login-3b67d231.html
@@ -27,6 +27,13 @@
   .back-link { display: inline-block; margin-bottom: 16px; font-size: 0.85rem; }
   ul.examples { list-style: none; padding: 0; margin: 4px 0 0; font-size: 0.85rem; }
   ul.examples li { padding: 2px 0; }
+  .tag-group { margin-bottom: 24px; }
+  .tag-heading { margin: 20px 0 10px; font-size: 1.1rem; font-weight: 600; color: #16213e; text-transform: uppercase; letter-spacing: 0.05em; border-bottom: 2px solid #dee2e6; padding-bottom: 6px; }
+  .curl-block { position: relative; margin: 0 0 8px; }
+  .curl-block pre { padding-right: 72px; }
+  .copy-btn { position: absolute; top: 8px; right: 8px; background: #495057; color: #fff; border: none; border-radius: 4px; padding: 4px 10px; font-size: 0.75rem; cursor: pointer; font-family: inherit; }
+  .copy-btn:hover { background: #0d6efd; }
+  .copy-btn:active { background: #0a58ca; }
 </style></head><body>
 <a href="index.html" class="back-link">&larr; Back to index</a>
 <h1><span class="method method-POST">POST</span> <span class="path">/auth/login</span></h1>
@@ -50,7 +57,13 @@
   ],
   "additionalProperties" : false
 }</pre></details></div></div>
-<div class="card"><div class="card-header"><span class="status-badge status-2xx">200</span> Response</div><div class="card-body"><p>Successful login</p><h4>Request body</h4><pre>client_id=web&amp;grant_type=password</pre><h4>Response body</h4><pre>{
+<div class="card"><div class="card-header"><span class="status-badge status-2xx">200</span> Response</div><div class="card-body"><p>Successful login</p><h4>Curl</h4><div class="curl-block"><pre>curl -X POST '$BASE_URL/auth/login' \
+  -H 'Content-Type: application/x-www-form-urlencoded' \
+  -H 'Authorization: Basic &lt;BASE64(USER:PASSWORD)&gt;' \
+  --data-raw 'client_id=web&amp;grant_type=password'</pre><button class="copy-btn" type="button" data-clipboard="curl -X POST &#39;$BASE_URL/auth/login&#39; \
+  -H &#39;Content-Type: application/x-www-form-urlencoded&#39; \
+  -H &#39;Authorization: Basic &lt;BASE64(USER:PASSWORD)&gt;&#39; \
+  --data-raw &#39;client_id=web&amp;grant_type=password&#39;">Copy</button></div><h4>Request body</h4><pre>client_id=web&amp;grant_type=password</pre><h4>Response body</h4><pre>{
   "token" : "jwt.token.xyz",
   "user" : {
     "id" : "00000000-0000-0000-0000-000000000001",
@@ -105,7 +118,13 @@
   ],
   "additionalProperties" : false
 }</pre></details></div></div>
-<div class="card"><div class="card-header"><span class="status-badge status-4xx">401</span> Response</div><div class="card-body"><p>Invalid credentials</p><h4>Request body</h4><pre>client_id=web&amp;grant_type=password</pre><h4>Response body</h4><pre>{
+<div class="card"><div class="card-header"><span class="status-badge status-4xx">401</span> Response</div><div class="card-body"><p>Invalid credentials</p><h4>Curl</h4><div class="curl-block"><pre>curl -X POST '$BASE_URL/auth/login' \
+  -H 'Content-Type: application/x-www-form-urlencoded' \
+  -H 'Authorization: Basic &lt;BASE64(USER:PASSWORD)&gt;' \
+  --data-raw 'client_id=web&amp;grant_type=password'</pre><button class="copy-btn" type="button" data-clipboard="curl -X POST &#39;$BASE_URL/auth/login&#39; \
+  -H &#39;Content-Type: application/x-www-form-urlencoded&#39; \
+  -H &#39;Authorization: Basic &lt;BASE64(USER:PASSWORD)&gt;&#39; \
+  --data-raw &#39;client_id=web&amp;grant_type=password&#39;">Copy</button></div><h4>Request body</h4><pre>client_id=web&amp;grant_type=password</pre><h4>Response body</h4><pre>{
   "code" : "unauthorized",
   "message" : "Bad credentials",
   "details" : null
@@ -133,4 +152,16 @@
   ],
   "additionalProperties" : false
 }</pre></details></div></div>
+<script>
+document.addEventListener('click', function (e) {
+  var btn = e.target.closest('button.copy-btn');
+  if (!btn) return;
+  var payload = btn.getAttribute('data-clipboard') || '';
+  navigator.clipboard.writeText(payload).then(function () {
+    var original = btn.textContent;
+    btn.textContent = 'Copied';
+    setTimeout(function () { btn.textContent = original; }, 1200);
+  });
+});
+</script>
 </body></html>

--- a/openapi/src/test/resources/gold/simple/POST__auth_login-3b67d231.html
+++ b/openapi/src/test/resources/gold/simple/POST__auth_login-3b67d231.html
@@ -60,10 +60,7 @@
 <div class="card"><div class="card-header"><span class="status-badge status-2xx">200</span> Response</div><div class="card-body"><p>Successful login</p><h4>Curl</h4><div class="curl-block"><pre>curl -X POST '$BASE_URL/auth/login' \
   -H 'Content-Type: application/x-www-form-urlencoded' \
   -H 'Authorization: Basic &lt;BASE64(USER:PASSWORD)&gt;' \
-  --data-raw 'client_id=web&amp;grant_type=password'</pre><button class="copy-btn" type="button" data-clipboard="curl -X POST &#39;$BASE_URL/auth/login&#39; \
-  -H &#39;Content-Type: application/x-www-form-urlencoded&#39; \
-  -H &#39;Authorization: Basic &lt;BASE64(USER:PASSWORD)&gt;&#39; \
-  --data-raw &#39;client_id=web&amp;grant_type=password&#39;">Copy</button></div><h4>Request body</h4><pre>client_id=web&amp;grant_type=password</pre><h4>Response body</h4><pre>{
+  --data-raw 'client_id=web&amp;grant_type=password'</pre><button class="copy-btn" type="button">Copy</button></div><h4>Request body</h4><pre>client_id=web&amp;grant_type=password</pre><h4>Response body</h4><pre>{
   "token" : "jwt.token.xyz",
   "user" : {
     "id" : "00000000-0000-0000-0000-000000000001",
@@ -121,10 +118,7 @@
 <div class="card"><div class="card-header"><span class="status-badge status-4xx">401</span> Response</div><div class="card-body"><p>Invalid credentials</p><h4>Curl</h4><div class="curl-block"><pre>curl -X POST '$BASE_URL/auth/login' \
   -H 'Content-Type: application/x-www-form-urlencoded' \
   -H 'Authorization: Basic &lt;BASE64(USER:PASSWORD)&gt;' \
-  --data-raw 'client_id=web&amp;grant_type=password'</pre><button class="copy-btn" type="button" data-clipboard="curl -X POST &#39;$BASE_URL/auth/login&#39; \
-  -H &#39;Content-Type: application/x-www-form-urlencoded&#39; \
-  -H &#39;Authorization: Basic &lt;BASE64(USER:PASSWORD)&gt;&#39; \
-  --data-raw &#39;client_id=web&amp;grant_type=password&#39;">Copy</button></div><h4>Request body</h4><pre>client_id=web&amp;grant_type=password</pre><h4>Response body</h4><pre>{
+  --data-raw 'client_id=web&amp;grant_type=password'</pre><button class="copy-btn" type="button">Copy</button></div><h4>Request body</h4><pre>client_id=web&amp;grant_type=password</pre><h4>Response body</h4><pre>{
   "code" : "unauthorized",
   "message" : "Bad credentials",
   "details" : null
@@ -156,12 +150,32 @@
 document.addEventListener('click', function (e) {
   var btn = e.target.closest('button.copy-btn');
   if (!btn) return;
-  var payload = btn.getAttribute('data-clipboard') || '';
-  navigator.clipboard.writeText(payload).then(function () {
-    var original = btn.textContent;
-    btn.textContent = 'Copied';
+  var pre = btn.previousElementSibling;
+  var payload = pre ? pre.textContent : '';
+  var flash = function (msg) {
+    var original = btn.dataset.origText || btn.textContent;
+    btn.dataset.origText = original;
+    btn.textContent = msg;
     setTimeout(function () { btn.textContent = original; }, 1200);
-  });
+  };
+  var fallback = function () {
+    try {
+      var ta = document.createElement('textarea');
+      ta.value = payload;
+      ta.style.position = 'fixed';
+      ta.style.opacity = '0';
+      document.body.appendChild(ta);
+      ta.select();
+      var ok = document.execCommand('copy');
+      document.body.removeChild(ta);
+      flash(ok ? 'Copied' : 'Failed');
+    } catch (_) { flash('Failed'); }
+  };
+  if (navigator.clipboard && navigator.clipboard.writeText) {
+    navigator.clipboard.writeText(payload).then(function () { flash('Copied'); }, fallback);
+  } else {
+    fallback();
+  }
 });
 </script>
 </body></html>

--- a/openapi/src/test/resources/gold/simple/POST__projects-0f98e629.html
+++ b/openapi/src/test/resources/gold/simple/POST__projects-0f98e629.html
@@ -69,10 +69,7 @@
 <div class="card"><div class="card-header"><span class="status-badge status-2xx">201</span> Response</div><div class="card-body"><p>Project created</p><h4>Curl</h4><div class="curl-block"><pre>curl -X POST '$BASE_URL/projects' \
   -H 'Content-Type: application/json' \
   -H 'Authorization: Bearer &lt;OAUTH_TOKEN&gt;' \
-  --data-raw '{"name":"Apollo","description":"Mission control","status":"active"}'</pre><button class="copy-btn" type="button" data-clipboard="curl -X POST &#39;$BASE_URL/projects&#39; \
-  -H &#39;Content-Type: application/json&#39; \
-  -H &#39;Authorization: Bearer &lt;OAUTH_TOKEN&gt;&#39; \
-  --data-raw &#39;{&quot;name&quot;:&quot;Apollo&quot;,&quot;description&quot;:&quot;Mission control&quot;,&quot;status&quot;:&quot;active&quot;}&#39;">Copy</button></div><h4>Request body</h4><pre>{
+  --data-raw '{"name":"Apollo","description":"Mission control","status":"active"}'</pre><button class="copy-btn" type="button">Copy</button></div><h4>Request body</h4><pre>{
   "name" : "Apollo",
   "description" : "Mission control",
   "status" : "active"
@@ -127,10 +124,7 @@
 <div class="card"><div class="card-header"><span class="status-badge status-4xx">400</span> Response</div><div class="card-body"><p>Validation failed</p><h4>Curl</h4><div class="curl-block"><pre>curl -X POST '$BASE_URL/projects' \
   -H 'Content-Type: application/json' \
   -H 'Authorization: Bearer &lt;OAUTH_TOKEN&gt;' \
-  --data-raw '{"name":"","description":null,"status":"draft"}'</pre><button class="copy-btn" type="button" data-clipboard="curl -X POST &#39;$BASE_URL/projects&#39; \
-  -H &#39;Content-Type: application/json&#39; \
-  -H &#39;Authorization: Bearer &lt;OAUTH_TOKEN&gt;&#39; \
-  --data-raw &#39;{&quot;name&quot;:&quot;&quot;,&quot;description&quot;:null,&quot;status&quot;:&quot;draft&quot;}&#39;">Copy</button></div><h4>Request body</h4><pre>{
+  --data-raw '{"name":"","description":null,"status":"draft"}'</pre><button class="copy-btn" type="button">Copy</button></div><h4>Request body</h4><pre>{
   "name" : "",
   "description" : null,
   "status" : "draft"
@@ -168,12 +162,32 @@
 document.addEventListener('click', function (e) {
   var btn = e.target.closest('button.copy-btn');
   if (!btn) return;
-  var payload = btn.getAttribute('data-clipboard') || '';
-  navigator.clipboard.writeText(payload).then(function () {
-    var original = btn.textContent;
-    btn.textContent = 'Copied';
+  var pre = btn.previousElementSibling;
+  var payload = pre ? pre.textContent : '';
+  var flash = function (msg) {
+    var original = btn.dataset.origText || btn.textContent;
+    btn.dataset.origText = original;
+    btn.textContent = msg;
     setTimeout(function () { btn.textContent = original; }, 1200);
-  });
+  };
+  var fallback = function () {
+    try {
+      var ta = document.createElement('textarea');
+      ta.value = payload;
+      ta.style.position = 'fixed';
+      ta.style.opacity = '0';
+      document.body.appendChild(ta);
+      ta.select();
+      var ok = document.execCommand('copy');
+      document.body.removeChild(ta);
+      flash(ok ? 'Copied' : 'Failed');
+    } catch (_) { flash('Failed'); }
+  };
+  if (navigator.clipboard && navigator.clipboard.writeText) {
+    navigator.clipboard.writeText(payload).then(function () { flash('Copied'); }, fallback);
+  } else {
+    fallback();
+  }
 });
 </script>
 </body></html>

--- a/openapi/src/test/resources/gold/simple/POST__projects-0f98e629.html
+++ b/openapi/src/test/resources/gold/simple/POST__projects-0f98e629.html
@@ -27,6 +27,13 @@
   .back-link { display: inline-block; margin-bottom: 16px; font-size: 0.85rem; }
   ul.examples { list-style: none; padding: 0; margin: 4px 0 0; font-size: 0.85rem; }
   ul.examples li { padding: 2px 0; }
+  .tag-group { margin-bottom: 24px; }
+  .tag-heading { margin: 20px 0 10px; font-size: 1.1rem; font-weight: 600; color: #16213e; text-transform: uppercase; letter-spacing: 0.05em; border-bottom: 2px solid #dee2e6; padding-bottom: 6px; }
+  .curl-block { position: relative; margin: 0 0 8px; }
+  .curl-block pre { padding-right: 72px; }
+  .copy-btn { position: absolute; top: 8px; right: 8px; background: #495057; color: #fff; border: none; border-radius: 4px; padding: 4px 10px; font-size: 0.75rem; cursor: pointer; font-family: inherit; }
+  .copy-btn:hover { background: #0d6efd; }
+  .copy-btn:active { background: #0a58ca; }
 </style></head><body>
 <a href="index.html" class="back-link">&larr; Back to index</a>
 <h1><span class="method method-POST">POST</span> <span class="path">/projects</span></h1>
@@ -59,7 +66,13 @@
   ],
   "additionalProperties" : false
 }</pre></details></div></div>
-<div class="card"><div class="card-header"><span class="status-badge status-2xx">201</span> Response</div><div class="card-body"><p>Project created</p><h4>Request body</h4><pre>{
+<div class="card"><div class="card-header"><span class="status-badge status-2xx">201</span> Response</div><div class="card-body"><p>Project created</p><h4>Curl</h4><div class="curl-block"><pre>curl -X POST '$BASE_URL/projects' \
+  -H 'Content-Type: application/json' \
+  -H 'Authorization: Bearer &lt;OAUTH_TOKEN&gt;' \
+  --data-raw '{"name":"Apollo","description":"Mission control","status":"active"}'</pre><button class="copy-btn" type="button" data-clipboard="curl -X POST &#39;$BASE_URL/projects&#39; \
+  -H &#39;Content-Type: application/json&#39; \
+  -H &#39;Authorization: Bearer &lt;OAUTH_TOKEN&gt;&#39; \
+  --data-raw &#39;{&quot;name&quot;:&quot;Apollo&quot;,&quot;description&quot;:&quot;Mission control&quot;,&quot;status&quot;:&quot;active&quot;}&#39;">Copy</button></div><h4>Request body</h4><pre>{
   "name" : "Apollo",
   "description" : "Mission control",
   "status" : "active"
@@ -111,7 +124,13 @@
   ],
   "additionalProperties" : false
 }</pre></details></div></div>
-<div class="card"><div class="card-header"><span class="status-badge status-4xx">400</span> Response</div><div class="card-body"><p>Validation failed</p><h4>Request body</h4><pre>{
+<div class="card"><div class="card-header"><span class="status-badge status-4xx">400</span> Response</div><div class="card-body"><p>Validation failed</p><h4>Curl</h4><div class="curl-block"><pre>curl -X POST '$BASE_URL/projects' \
+  -H 'Content-Type: application/json' \
+  -H 'Authorization: Bearer &lt;OAUTH_TOKEN&gt;' \
+  --data-raw '{"name":"","description":null,"status":"draft"}'</pre><button class="copy-btn" type="button" data-clipboard="curl -X POST &#39;$BASE_URL/projects&#39; \
+  -H &#39;Content-Type: application/json&#39; \
+  -H &#39;Authorization: Bearer &lt;OAUTH_TOKEN&gt;&#39; \
+  --data-raw &#39;{&quot;name&quot;:&quot;&quot;,&quot;description&quot;:null,&quot;status&quot;:&quot;draft&quot;}&#39;">Copy</button></div><h4>Request body</h4><pre>{
   "name" : "",
   "description" : null,
   "status" : "draft"
@@ -145,4 +164,16 @@
   ],
   "additionalProperties" : false
 }</pre></details></div></div>
+<script>
+document.addEventListener('click', function (e) {
+  var btn = e.target.closest('button.copy-btn');
+  if (!btn) return;
+  var payload = btn.getAttribute('data-clipboard') || '';
+  navigator.clipboard.writeText(payload).then(function () {
+    var original = btn.textContent;
+    btn.textContent = 'Copied';
+    setTimeout(function () { btn.textContent = original; }, 1200);
+  });
+});
+</script>
 </body></html>

--- a/openapi/src/test/resources/gold/simple/POST__projects___projectId___tasks-f083bafd.html
+++ b/openapi/src/test/resources/gold/simple/POST__projects___projectId___tasks-f083bafd.html
@@ -27,6 +27,13 @@
   .back-link { display: inline-block; margin-bottom: 16px; font-size: 0.85rem; }
   ul.examples { list-style: none; padding: 0; margin: 4px 0 0; font-size: 0.85rem; }
   ul.examples li { padding: 2px 0; }
+  .tag-group { margin-bottom: 24px; }
+  .tag-heading { margin: 20px 0 10px; font-size: 1.1rem; font-weight: 600; color: #16213e; text-transform: uppercase; letter-spacing: 0.05em; border-bottom: 2px solid #dee2e6; padding-bottom: 6px; }
+  .curl-block { position: relative; margin: 0 0 8px; }
+  .curl-block pre { padding-right: 72px; }
+  .copy-btn { position: absolute; top: 8px; right: 8px; background: #495057; color: #fff; border: none; border-radius: 4px; padding: 4px 10px; font-size: 0.75rem; cursor: pointer; font-family: inherit; }
+  .copy-btn:hover { background: #0d6efd; }
+  .copy-btn:active { background: #0a58ca; }
 </style></head><body>
 <a href="index.html" class="back-link">&larr; Back to index</a>
 <h1><span class="method method-POST">POST</span> <span class="path">/projects/{projectId}/tasks</span></h1>
@@ -60,7 +67,13 @@
   ],
   "additionalProperties" : false
 }</pre></details></div></div>
-<div class="card"><div class="card-header"><span class="status-badge status-2xx">201</span> Response</div><div class="card-body"><p>Task created</p><h4>Response headers</h4><dl class="meta-grid"><dt>Location <span class="required">*</span></dt><dd><code>String</code> = <code>/projects/42/tasks/101</code></dd></dl><h4>Request body</h4><pre>{
+<div class="card"><div class="card-header"><span class="status-badge status-2xx">201</span> Response</div><div class="card-body"><p>Task created</p><h4>Curl</h4><div class="curl-block"><pre>curl -X POST '$BASE_URL/projects/42/tasks' \
+  -H 'Content-Type: application/json' \
+  -H 'Authorization: Bearer &lt;OAUTH_TOKEN&gt;' \
+  --data-raw '{"title":"New task","description":null,"priority":"medium"}'</pre><button class="copy-btn" type="button" data-clipboard="curl -X POST &#39;$BASE_URL/projects/42/tasks&#39; \
+  -H &#39;Content-Type: application/json&#39; \
+  -H &#39;Authorization: Bearer &lt;OAUTH_TOKEN&gt;&#39; \
+  --data-raw &#39;{&quot;title&quot;:&quot;New task&quot;,&quot;description&quot;:null,&quot;priority&quot;:&quot;medium&quot;}&#39;">Copy</button></div><h4>Response headers</h4><dl class="meta-grid"><dt>Location <span class="required">*</span></dt><dd><code>String</code> = <code>/projects/42/tasks/101</code></dd></dl><h4>Request body</h4><pre>{
   "title" : "New task",
   "description" : null,
   "priority" : "medium"
@@ -106,4 +119,16 @@
   ],
   "additionalProperties" : false
 }</pre></details></div></div>
+<script>
+document.addEventListener('click', function (e) {
+  var btn = e.target.closest('button.copy-btn');
+  if (!btn) return;
+  var payload = btn.getAttribute('data-clipboard') || '';
+  navigator.clipboard.writeText(payload).then(function () {
+    var original = btn.textContent;
+    btn.textContent = 'Copied';
+    setTimeout(function () { btn.textContent = original; }, 1200);
+  });
+});
+</script>
 </body></html>

--- a/openapi/src/test/resources/gold/simple/POST__projects___projectId___tasks-f083bafd.html
+++ b/openapi/src/test/resources/gold/simple/POST__projects___projectId___tasks-f083bafd.html
@@ -70,10 +70,7 @@
 <div class="card"><div class="card-header"><span class="status-badge status-2xx">201</span> Response</div><div class="card-body"><p>Task created</p><h4>Curl</h4><div class="curl-block"><pre>curl -X POST '$BASE_URL/projects/42/tasks' \
   -H 'Content-Type: application/json' \
   -H 'Authorization: Bearer &lt;OAUTH_TOKEN&gt;' \
-  --data-raw '{"title":"New task","description":null,"priority":"medium"}'</pre><button class="copy-btn" type="button" data-clipboard="curl -X POST &#39;$BASE_URL/projects/42/tasks&#39; \
-  -H &#39;Content-Type: application/json&#39; \
-  -H &#39;Authorization: Bearer &lt;OAUTH_TOKEN&gt;&#39; \
-  --data-raw &#39;{&quot;title&quot;:&quot;New task&quot;,&quot;description&quot;:null,&quot;priority&quot;:&quot;medium&quot;}&#39;">Copy</button></div><h4>Response headers</h4><dl class="meta-grid"><dt>Location <span class="required">*</span></dt><dd><code>String</code> = <code>/projects/42/tasks/101</code></dd></dl><h4>Request body</h4><pre>{
+  --data-raw '{"title":"New task","description":null,"priority":"medium"}'</pre><button class="copy-btn" type="button">Copy</button></div><h4>Response headers</h4><dl class="meta-grid"><dt>Location <span class="required">*</span></dt><dd><code>String</code> = <code>/projects/42/tasks/101</code></dd></dl><h4>Request body</h4><pre>{
   "title" : "New task",
   "description" : null,
   "priority" : "medium"
@@ -123,12 +120,32 @@
 document.addEventListener('click', function (e) {
   var btn = e.target.closest('button.copy-btn');
   if (!btn) return;
-  var payload = btn.getAttribute('data-clipboard') || '';
-  navigator.clipboard.writeText(payload).then(function () {
-    var original = btn.textContent;
-    btn.textContent = 'Copied';
+  var pre = btn.previousElementSibling;
+  var payload = pre ? pre.textContent : '';
+  var flash = function (msg) {
+    var original = btn.dataset.origText || btn.textContent;
+    btn.dataset.origText = original;
+    btn.textContent = msg;
     setTimeout(function () { btn.textContent = original; }, 1200);
-  });
+  };
+  var fallback = function () {
+    try {
+      var ta = document.createElement('textarea');
+      ta.value = payload;
+      ta.style.position = 'fixed';
+      ta.style.opacity = '0';
+      document.body.appendChild(ta);
+      ta.select();
+      var ok = document.execCommand('copy');
+      document.body.removeChild(ta);
+      flash(ok ? 'Copied' : 'Failed');
+    } catch (_) { flash('Failed'); }
+  };
+  if (navigator.clipboard && navigator.clipboard.writeText) {
+    navigator.clipboard.writeText(payload).then(function () { flash('Copied'); }, fallback);
+  } else {
+    fallback();
+  }
 });
 </script>
 </body></html>

--- a/openapi/src/test/resources/gold/simple/POST__webhooks-20c9a68b.html
+++ b/openapi/src/test/resources/gold/simple/POST__webhooks-20c9a68b.html
@@ -27,6 +27,13 @@
   .back-link { display: inline-block; margin-bottom: 16px; font-size: 0.85rem; }
   ul.examples { list-style: none; padding: 0; margin: 4px 0 0; font-size: 0.85rem; }
   ul.examples li { padding: 2px 0; }
+  .tag-group { margin-bottom: 24px; }
+  .tag-heading { margin: 20px 0 10px; font-size: 1.1rem; font-weight: 600; color: #16213e; text-transform: uppercase; letter-spacing: 0.05em; border-bottom: 2px solid #dee2e6; padding-bottom: 6px; }
+  .curl-block { position: relative; margin: 0 0 8px; }
+  .curl-block pre { padding-right: 72px; }
+  .copy-btn { position: absolute; top: 8px; right: 8px; background: #495057; color: #fff; border: none; border-radius: 4px; padding: 4px 10px; font-size: 0.75rem; cursor: pointer; font-family: inherit; }
+  .copy-btn:hover { background: #0d6efd; }
+  .copy-btn:active { background: #0a58ca; }
 </style></head><body>
 <a href="index.html" class="back-link">&larr; Back to index</a>
 <h1><span class="method method-POST">POST</span> <span class="path">/webhooks</span></h1>
@@ -50,14 +57,26 @@
   ],
   "additionalProperties" : false
 }</pre></details></div></div>
-<div class="card"><div class="card-header"><span class="status-badge status-2xx">202</span> Response</div><div class="card-body"><p>Legacy plain-text ack</p><h4>Request body</h4><pre>{
+<div class="card"><div class="card-header"><span class="status-badge status-2xx">202</span> Response</div><div class="card-body"><p>Legacy plain-text ack</p><h4>Curl</h4><div class="curl-block"><pre>curl -X POST '$BASE_URL/webhooks' \
+  -H 'Content-Type: application/json' \
+  -H 'X-API-Key: &lt;API_KEY&gt;' \
+  --data-raw '{"event":"order.created","data":"{\"id\":1}"}'</pre><button class="copy-btn" type="button" data-clipboard="curl -X POST &#39;$BASE_URL/webhooks&#39; \
+  -H &#39;Content-Type: application/json&#39; \
+  -H &#39;X-API-Key: &lt;API_KEY&gt;&#39; \
+  --data-raw &#39;{&quot;event&quot;:&quot;order.created&quot;,&quot;data&quot;:&quot;{\&quot;id\&quot;:1}&quot;}&#39;">Copy</button></div><h4>Request body</h4><pre>{
   "event" : "order.created",
   "data" : "{\"id\":1}"
 }</pre><h4>Response body</h4><pre>ACK</pre><details><summary>Response schema</summary><pre>{
   "$schema" : "http://json-schema.org/draft-07/schema#",
   "type" : "string"
 }</pre></details></div></div>
-<div class="card"><div class="card-header"><span class="status-badge status-2xx">202</span> Response</div><div class="card-body"><p>Webhook accepted</p><h4>Request body</h4><pre>{
+<div class="card"><div class="card-header"><span class="status-badge status-2xx">202</span> Response</div><div class="card-body"><p>Webhook accepted</p><h4>Curl</h4><div class="curl-block"><pre>curl -X POST '$BASE_URL/webhooks' \
+  -H 'Content-Type: application/json' \
+  -H 'X-API-Key: &lt;API_KEY&gt;' \
+  --data-raw '{"event":"order.created","data":"{\"id\":1}"}'</pre><button class="copy-btn" type="button" data-clipboard="curl -X POST &#39;$BASE_URL/webhooks&#39; \
+  -H &#39;Content-Type: application/json&#39; \
+  -H &#39;X-API-Key: &lt;API_KEY&gt;&#39; \
+  --data-raw &#39;{&quot;event&quot;:&quot;order.created&quot;,&quot;data&quot;:&quot;{\&quot;id\&quot;:1}&quot;}&#39;">Copy</button></div><h4>Request body</h4><pre>{
   "event" : "order.created",
   "data" : "{\"id\":1}"
 }</pre><h4>Response body</h4><pre>{
@@ -76,4 +95,16 @@
   ],
   "additionalProperties" : false
 }</pre></details></div></div>
+<script>
+document.addEventListener('click', function (e) {
+  var btn = e.target.closest('button.copy-btn');
+  if (!btn) return;
+  var payload = btn.getAttribute('data-clipboard') || '';
+  navigator.clipboard.writeText(payload).then(function () {
+    var original = btn.textContent;
+    btn.textContent = 'Copied';
+    setTimeout(function () { btn.textContent = original; }, 1200);
+  });
+});
+</script>
 </body></html>

--- a/openapi/src/test/resources/gold/simple/POST__webhooks-20c9a68b.html
+++ b/openapi/src/test/resources/gold/simple/POST__webhooks-20c9a68b.html
@@ -60,10 +60,7 @@
 <div class="card"><div class="card-header"><span class="status-badge status-2xx">202</span> Response</div><div class="card-body"><p>Legacy plain-text ack</p><h4>Curl</h4><div class="curl-block"><pre>curl -X POST '$BASE_URL/webhooks' \
   -H 'Content-Type: application/json' \
   -H 'X-API-Key: &lt;API_KEY&gt;' \
-  --data-raw '{"event":"order.created","data":"{\"id\":1}"}'</pre><button class="copy-btn" type="button" data-clipboard="curl -X POST &#39;$BASE_URL/webhooks&#39; \
-  -H &#39;Content-Type: application/json&#39; \
-  -H &#39;X-API-Key: &lt;API_KEY&gt;&#39; \
-  --data-raw &#39;{&quot;event&quot;:&quot;order.created&quot;,&quot;data&quot;:&quot;{\&quot;id\&quot;:1}&quot;}&#39;">Copy</button></div><h4>Request body</h4><pre>{
+  --data-raw '{"event":"order.created","data":"{\"id\":1}"}'</pre><button class="copy-btn" type="button">Copy</button></div><h4>Request body</h4><pre>{
   "event" : "order.created",
   "data" : "{\"id\":1}"
 }</pre><h4>Response body</h4><pre>ACK</pre><details><summary>Response schema</summary><pre>{
@@ -73,10 +70,7 @@
 <div class="card"><div class="card-header"><span class="status-badge status-2xx">202</span> Response</div><div class="card-body"><p>Webhook accepted</p><h4>Curl</h4><div class="curl-block"><pre>curl -X POST '$BASE_URL/webhooks' \
   -H 'Content-Type: application/json' \
   -H 'X-API-Key: &lt;API_KEY&gt;' \
-  --data-raw '{"event":"order.created","data":"{\"id\":1}"}'</pre><button class="copy-btn" type="button" data-clipboard="curl -X POST &#39;$BASE_URL/webhooks&#39; \
-  -H &#39;Content-Type: application/json&#39; \
-  -H &#39;X-API-Key: &lt;API_KEY&gt;&#39; \
-  --data-raw &#39;{&quot;event&quot;:&quot;order.created&quot;,&quot;data&quot;:&quot;{\&quot;id\&quot;:1}&quot;}&#39;">Copy</button></div><h4>Request body</h4><pre>{
+  --data-raw '{"event":"order.created","data":"{\"id\":1}"}'</pre><button class="copy-btn" type="button">Copy</button></div><h4>Request body</h4><pre>{
   "event" : "order.created",
   "data" : "{\"id\":1}"
 }</pre><h4>Response body</h4><pre>{
@@ -99,12 +93,32 @@
 document.addEventListener('click', function (e) {
   var btn = e.target.closest('button.copy-btn');
   if (!btn) return;
-  var payload = btn.getAttribute('data-clipboard') || '';
-  navigator.clipboard.writeText(payload).then(function () {
-    var original = btn.textContent;
-    btn.textContent = 'Copied';
+  var pre = btn.previousElementSibling;
+  var payload = pre ? pre.textContent : '';
+  var flash = function (msg) {
+    var original = btn.dataset.origText || btn.textContent;
+    btn.dataset.origText = original;
+    btn.textContent = msg;
     setTimeout(function () { btn.textContent = original; }, 1200);
-  });
+  };
+  var fallback = function () {
+    try {
+      var ta = document.createElement('textarea');
+      ta.value = payload;
+      ta.style.position = 'fixed';
+      ta.style.opacity = '0';
+      document.body.appendChild(ta);
+      ta.select();
+      var ok = document.execCommand('copy');
+      document.body.removeChild(ta);
+      flash(ok ? 'Copied' : 'Failed');
+    } catch (_) { flash('Failed'); }
+  };
+  if (navigator.clipboard && navigator.clipboard.writeText) {
+    navigator.clipboard.writeText(payload).then(function () { flash('Copied'); }, fallback);
+  } else {
+    fallback();
+  }
 });
 </script>
 </body></html>

--- a/openapi/src/test/resources/gold/simple/PUT__users___userId__-3f0ffd01.html
+++ b/openapi/src/test/resources/gold/simple/PUT__users___userId__-3f0ffd01.html
@@ -67,10 +67,7 @@
 <div class="card"><div class="card-header"><span class="status-badge status-2xx">200</span> Response</div><div class="card-body"><p>User updated</p><h4>Curl</h4><div class="curl-block"><pre>curl -X PUT '$BASE_URL/users/00000000-0000-0000-0000-000000000001' \
   -H 'Content-Type: application/json' \
   -H 'Authorization: Bearer &lt;TOKEN&gt;' \
-  --data-raw '{"name":"Alice Updated","role":"admin"}'</pre><button class="copy-btn" type="button" data-clipboard="curl -X PUT &#39;$BASE_URL/users/00000000-0000-0000-0000-000000000001&#39; \
-  -H &#39;Content-Type: application/json&#39; \
-  -H &#39;Authorization: Bearer &lt;TOKEN&gt;&#39; \
-  --data-raw &#39;{&quot;name&quot;:&quot;Alice Updated&quot;,&quot;role&quot;:&quot;admin&quot;}&#39;">Copy</button></div><h4>Request body</h4><pre>{
+  --data-raw '{"name":"Alice Updated","role":"admin"}'</pre><button class="copy-btn" type="button">Copy</button></div><h4>Request body</h4><pre>{
   "name" : "Alice Updated",
   "role" : "admin"
 }</pre><h4>Response body</h4><pre>{
@@ -115,12 +112,32 @@
 document.addEventListener('click', function (e) {
   var btn = e.target.closest('button.copy-btn');
   if (!btn) return;
-  var payload = btn.getAttribute('data-clipboard') || '';
-  navigator.clipboard.writeText(payload).then(function () {
-    var original = btn.textContent;
-    btn.textContent = 'Copied';
+  var pre = btn.previousElementSibling;
+  var payload = pre ? pre.textContent : '';
+  var flash = function (msg) {
+    var original = btn.dataset.origText || btn.textContent;
+    btn.dataset.origText = original;
+    btn.textContent = msg;
     setTimeout(function () { btn.textContent = original; }, 1200);
-  });
+  };
+  var fallback = function () {
+    try {
+      var ta = document.createElement('textarea');
+      ta.value = payload;
+      ta.style.position = 'fixed';
+      ta.style.opacity = '0';
+      document.body.appendChild(ta);
+      ta.select();
+      var ok = document.execCommand('copy');
+      document.body.removeChild(ta);
+      flash(ok ? 'Copied' : 'Failed');
+    } catch (_) { flash('Failed'); }
+  };
+  if (navigator.clipboard && navigator.clipboard.writeText) {
+    navigator.clipboard.writeText(payload).then(function () { flash('Copied'); }, fallback);
+  } else {
+    fallback();
+  }
 });
 </script>
 </body></html>

--- a/openapi/src/test/resources/gold/simple/PUT__users___userId__-3f0ffd01.html
+++ b/openapi/src/test/resources/gold/simple/PUT__users___userId__-3f0ffd01.html
@@ -27,6 +27,13 @@
   .back-link { display: inline-block; margin-bottom: 16px; font-size: 0.85rem; }
   ul.examples { list-style: none; padding: 0; margin: 4px 0 0; font-size: 0.85rem; }
   ul.examples li { padding: 2px 0; }
+  .tag-group { margin-bottom: 24px; }
+  .tag-heading { margin: 20px 0 10px; font-size: 1.1rem; font-weight: 600; color: #16213e; text-transform: uppercase; letter-spacing: 0.05em; border-bottom: 2px solid #dee2e6; padding-bottom: 6px; }
+  .curl-block { position: relative; margin: 0 0 8px; }
+  .curl-block pre { padding-right: 72px; }
+  .copy-btn { position: absolute; top: 8px; right: 8px; background: #495057; color: #fff; border: none; border-radius: 4px; padding: 4px 10px; font-size: 0.75rem; cursor: pointer; font-family: inherit; }
+  .copy-btn:hover { background: #0d6efd; }
+  .copy-btn:active { background: #0a58ca; }
 </style></head><body>
 <a href="index.html" class="back-link">&larr; Back to index</a>
 <h1><span class="method method-PUT">PUT</span> <span class="path">/users/{userId}</span></h1>
@@ -57,7 +64,13 @@
   ],
   "additionalProperties" : false
 }</pre></details></div></div>
-<div class="card"><div class="card-header"><span class="status-badge status-2xx">200</span> Response</div><div class="card-body"><p>User updated</p><h4>Request body</h4><pre>{
+<div class="card"><div class="card-header"><span class="status-badge status-2xx">200</span> Response</div><div class="card-body"><p>User updated</p><h4>Curl</h4><div class="curl-block"><pre>curl -X PUT '$BASE_URL/users/00000000-0000-0000-0000-000000000001' \
+  -H 'Content-Type: application/json' \
+  -H 'Authorization: Bearer &lt;TOKEN&gt;' \
+  --data-raw '{"name":"Alice Updated","role":"admin"}'</pre><button class="copy-btn" type="button" data-clipboard="curl -X PUT &#39;$BASE_URL/users/00000000-0000-0000-0000-000000000001&#39; \
+  -H &#39;Content-Type: application/json&#39; \
+  -H &#39;Authorization: Bearer &lt;TOKEN&gt;&#39; \
+  --data-raw &#39;{&quot;name&quot;:&quot;Alice Updated&quot;,&quot;role&quot;:&quot;admin&quot;}&#39;">Copy</button></div><h4>Request body</h4><pre>{
   "name" : "Alice Updated",
   "role" : "admin"
 }</pre><h4>Response body</h4><pre>{
@@ -98,4 +111,16 @@
   ],
   "additionalProperties" : false
 }</pre></details></div></div>
+<script>
+document.addEventListener('click', function (e) {
+  var btn = e.target.closest('button.copy-btn');
+  if (!btn) return;
+  var payload = btn.getAttribute('data-clipboard') || '';
+  navigator.clipboard.writeText(payload).then(function () {
+    var original = btn.textContent;
+    btn.textContent = 'Copied';
+    setTimeout(function () { btn.textContent = original; }, 1200);
+  });
+});
+</script>
 </body></html>

--- a/openapi/src/test/resources/gold/simple/index.html
+++ b/openapi/src/test/resources/gold/simple/index.html
@@ -27,21 +27,26 @@
   .back-link { display: inline-block; margin-bottom: 16px; font-size: 0.85rem; }
   ul.examples { list-style: none; padding: 0; margin: 4px 0 0; font-size: 0.85rem; }
   ul.examples li { padding: 2px 0; }
+  .tag-group { margin-bottom: 24px; }
+  .tag-heading { margin: 20px 0 10px; font-size: 1.1rem; font-weight: 600; color: #16213e; text-transform: uppercase; letter-spacing: 0.05em; border-bottom: 2px solid #dee2e6; padding-bottom: 6px; }
+  .curl-block { position: relative; margin: 0 0 8px; }
+  .curl-block pre { padding-right: 72px; }
+  .copy-btn { position: absolute; top: 8px; right: 8px; background: #495057; color: #fff; border: none; border-radius: 4px; padding: 4px 10px; font-size: 0.75rem; cursor: pointer; font-family: inherit; }
+  .copy-btn:hover { background: #0d6efd; }
+  .copy-btn:active { background: #0a58ca; }
 </style></head><body>
 <h1>API Documentation</h1>
-<ul class="endpoint-list">
-<li><a href="POST__auth_login-3b67d231.html"><span class="method method-POST">POST</span> <span class="path">/auth/login</span></a></li>
-<li><a href="GET__health-334cfc61.html"><span class="method method-GET">GET</span> <span class="path">/health</span></a></li>
-<li><a href="GET__me-2647d21d.html"><span class="method method-GET">GET</span> <span class="path">/me</span></a></li>
-<li><a href="GET__projects-9a7aa53f.html"><span class="method method-GET">GET</span> <span class="path">/projects</span></a></li>
+<section class="tag-group"><h2 class="tag-heading">Auth</h2><ul class="endpoint-list"><li><a href="POST__auth_login-3b67d231.html"><span class="method method-POST">POST</span> <span class="path">/auth/login</span></a></li>
+<li><a href="GET__me-2647d21d.html"><span class="method method-GET">GET</span> <span class="path">/me</span></a></li></ul></section>
+<section class="tag-group"><h2 class="tag-heading">Projects</h2><ul class="endpoint-list"><li><a href="GET__projects-9a7aa53f.html"><span class="method method-GET">GET</span> <span class="path">/projects</span></a></li>
 <li><a href="POST__projects-0f98e629.html"><span class="method method-POST">POST</span> <span class="path">/projects</span></a></li>
-<li><a href="PATCH__projects___projectId__-fc9e4246.html"><span class="method method-PATCH">PATCH</span> <span class="path">/projects/{projectId}</span></a></li>
-<li><a href="GET__projects___projectId___tasks-b0b82093.html"><span class="method method-GET">GET</span> <span class="path">/projects/{projectId}/tasks</span></a></li>
-<li><a href="POST__projects___projectId___tasks-f083bafd.html"><span class="method method-POST">POST</span> <span class="path">/projects/{projectId}/tasks</span></a></li>
-<li><a href="GET__users-c054bf63.html"><span class="method method-GET">GET</span> <span class="path">/users</span></a></li>
+<li><a href="PATCH__projects___projectId__-fc9e4246.html"><span class="method method-PATCH">PATCH</span> <span class="path">/projects/{projectId}</span></a></li></ul></section>
+<section class="tag-group"><h2 class="tag-heading">System</h2><ul class="endpoint-list"><li><a href="GET__health-334cfc61.html"><span class="method method-GET">GET</span> <span class="path">/health</span></a></li></ul></section>
+<section class="tag-group"><h2 class="tag-heading">Tasks</h2><ul class="endpoint-list"><li><a href="GET__projects___projectId___tasks-b0b82093.html"><span class="method method-GET">GET</span> <span class="path">/projects/{projectId}/tasks</span></a></li>
+<li><a href="POST__projects___projectId___tasks-f083bafd.html"><span class="method method-POST">POST</span> <span class="path">/projects/{projectId}/tasks</span></a></li></ul></section>
+<section class="tag-group"><h2 class="tag-heading">Users</h2><ul class="endpoint-list"><li><a href="GET__users-c054bf63.html"><span class="method method-GET">GET</span> <span class="path">/users</span></a></li>
 <li><a href="DELETE__users___userId__-cf0347bd.html"><span class="method method-DELETE">DELETE</span> <span class="path">/users/{userId}</span></a></li>
 <li><a href="GET__users___userId__-baf46b48.html"><span class="method method-GET">GET</span> <span class="path">/users/{userId}</span></a></li>
-<li><a href="PUT__users___userId__-3f0ffd01.html"><span class="method method-PUT">PUT</span> <span class="path">/users/{userId}</span></a></li>
-<li><a href="POST__webhooks-20c9a68b.html"><span class="method method-POST">POST</span> <span class="path">/webhooks</span></a></li>
-</ul>
+<li><a href="PUT__users___userId__-3f0ffd01.html"><span class="method method-PUT">PUT</span> <span class="path">/users/{userId}</span></a></li></ul></section>
+<section class="tag-group"><h2 class="tag-heading">Webhooks</h2><ul class="endpoint-list"><li><a href="POST__webhooks-20c9a68b.html"><span class="method method-POST">POST</span> <span class="path">/webhooks</span></a></li></ul></section>
 </body></html>

--- a/simple/src/main/scala/pl/iterators/baklava/simple/BaklavaDslFormatterSimple.scala
+++ b/simple/src/main/scala/pl/iterators/baklava/simple/BaklavaDslFormatterSimple.scala
@@ -234,19 +234,41 @@ class BaklavaDslFormatterSimple extends BaklavaDslFormatter {
   }
 
   // One inline script for the whole page. Binds a click handler to every `button.copy-btn`,
-  // reads the payload from `data-clipboard`, writes it to the clipboard, and briefly shows
-  // "Copied" so the user gets feedback. No external JS or CSS needed.
+  // reads the payload from the sibling `<pre>` (so line breaks survive — attribute values have
+  // their whitespace normalized by the HTML parser), tries `navigator.clipboard.writeText` first,
+  // and falls back to `document.execCommand('copy')` on insecure/file contexts where the Clipboard
+  // API is unavailable. Feedback is shown via the button text ("Copied" / "Failed").
   private val copyScript =
     """<script>
       |document.addEventListener('click', function (e) {
       |  var btn = e.target.closest('button.copy-btn');
       |  if (!btn) return;
-      |  var payload = btn.getAttribute('data-clipboard') || '';
-      |  navigator.clipboard.writeText(payload).then(function () {
-      |    var original = btn.textContent;
-      |    btn.textContent = 'Copied';
+      |  var pre = btn.previousElementSibling;
+      |  var payload = pre ? pre.textContent : '';
+      |  var flash = function (msg) {
+      |    var original = btn.dataset.origText || btn.textContent;
+      |    btn.dataset.origText = original;
+      |    btn.textContent = msg;
       |    setTimeout(function () { btn.textContent = original; }, 1200);
-      |  });
+      |  };
+      |  var fallback = function () {
+      |    try {
+      |      var ta = document.createElement('textarea');
+      |      ta.value = payload;
+      |      ta.style.position = 'fixed';
+      |      ta.style.opacity = '0';
+      |      document.body.appendChild(ta);
+      |      ta.select();
+      |      var ok = document.execCommand('copy');
+      |      document.body.removeChild(ta);
+      |      flash(ok ? 'Copied' : 'Failed');
+      |    } catch (_) { flash('Failed'); }
+      |  };
+      |  if (navigator.clipboard && navigator.clipboard.writeText) {
+      |    navigator.clipboard.writeText(payload).then(function () { flash('Copied'); }, fallback);
+      |  } else {
+      |    fallback();
+      |  }
       |});
       |</script>""".stripMargin
 
@@ -269,13 +291,26 @@ class BaklavaDslFormatterSimple extends BaklavaDslFormatter {
       s.oAuth2InBearer.map(_ => "Authorization" -> "Bearer <OAUTH_TOKEN>")
     }
 
+    // Never leak captured values into headers that the security-scheme placeholders cover. That
+    // means `Authorization`, `Cookie`, and any `<name>` declared via ApiKeyInHeader — if the user
+    // also declared one of these via `headers = h[String]("Authorization")` the captured value
+    // would otherwise end up in the generated curl verbatim.
+    val redactedNames: Set[String] = {
+      val base        = Set("authorization", "cookie")
+      val apiKeyNames = c.request.securitySchemes.flatMap(_.security.apiKeyInHeader.map(_.name.toLowerCase(java.util.Locale.ROOT)))
+      base ++ apiKeyNames
+    }
     val declaredHeaders: Seq[(String, String)] =
-      c.request.headersSeq.flatMap(h => h.example.map(v => h.name -> v))
+      c.request.headersSeq
+        .flatMap(h => h.example.map(v => h.name -> v))
+        .filterNot { case (name, _) => redactedNames.contains(name.toLowerCase(java.util.Locale.ROOT)) }
 
     val contentTypeHeader: Seq[(String, String)] =
       c.response.requestContentType.map("Content-Type" -> _).toSeq
 
-    val allHeaders = (contentTypeHeader ++ declaredHeaders ++ authHeaders).distinctBy(_._1.toLowerCase(java.util.Locale.ROOT))
+    // Auth placeholders come FIRST in the merge so `distinctBy` keeps them and discards any
+    // accidentally-declared duplicate of `Authorization` / `Cookie` / an API-key header.
+    val allHeaders = (contentTypeHeader ++ authHeaders ++ declaredHeaders).distinctBy(_._1.toLowerCase(java.util.Locale.ROOT))
 
     val headerLines = allHeaders.map { case (k, v) => s"  -H ${shellSingleQuote(s"$k: $v")} \\\n" }
 
@@ -289,11 +324,14 @@ class BaklavaDslFormatterSimple extends BaklavaDslFormatter {
     // Trim the trailing ` \` off the last continuation so the command pastes cleanly.
     val trimmed = cmd.stripSuffix(" \\\n").stripSuffix("\n")
 
+    // Copy the actual newlines from the adjacent <pre> rather than storing the payload in a
+    // `data-*` attribute. Attribute values have their whitespace normalized during HTML parsing,
+    // so the captured newlines/`\` continuations wouldn't survive round-trip through
+    // `.getAttribute(...)`. Reading `previousElementSibling.textContent` returns exactly what the
+    // user sees.
     s"""<h4>Curl</h4><div class="curl-block"><pre>${escHtml(
         trimmed
-      )}</pre><button class="copy-btn" type="button" data-clipboard="${escHtmlAttr(
-        trimmed
-      )}">Copy</button></div>"""
+      )}</pre><button class="copy-btn" type="button">Copy</button></div>"""
   }
 
   /** Wrap `s` in single quotes for safe shell consumption. Single quotes can't be escaped inside a single-quoted string, so any literal

--- a/simple/src/main/scala/pl/iterators/baklava/simple/BaklavaDslFormatterSimple.scala
+++ b/simple/src/main/scala/pl/iterators/baklava/simple/BaklavaDslFormatterSimple.scala
@@ -44,6 +44,13 @@ class BaklavaDslFormatterSimple extends BaklavaDslFormatter {
       |  .back-link { display: inline-block; margin-bottom: 16px; font-size: 0.85rem; }
       |  ul.examples { list-style: none; padding: 0; margin: 4px 0 0; font-size: 0.85rem; }
       |  ul.examples li { padding: 2px 0; }
+      |  .tag-group { margin-bottom: 24px; }
+      |  .tag-heading { margin: 20px 0 10px; font-size: 1.1rem; font-weight: 600; color: #16213e; text-transform: uppercase; letter-spacing: 0.05em; border-bottom: 2px solid #dee2e6; padding-bottom: 6px; }
+      |  .curl-block { position: relative; margin: 0 0 8px; }
+      |  .curl-block pre { padding-right: 72px; }
+      |  .copy-btn { position: absolute; top: 8px; right: 8px; background: #495057; color: #fff; border: none; border-radius: 4px; padding: 4px 10px; font-size: 0.75rem; cursor: pointer; font-family: inherit; }
+      |  .copy-btn:hover { background: #0d6efd; }
+      |  .copy-btn:active { background: #0a58ca; }
       |</style>""".stripMargin
 
   override def create(config: Map[String, String], calls: Seq[BaklavaSerializableCall]): Unit = {
@@ -54,26 +61,50 @@ class BaklavaDslFormatterSimple extends BaklavaDslFormatter {
       .toList
       .sortBy(s => (s._1._2, s._1._1.map(_.method).getOrElse("UNDEFINED")))
 
-    val indexRows = endpoints.map { case ((method, symbolicPath), endpointCalls) =>
+    // (method, symbolicPath, filename, tags) — write each endpoint page up-front and remember the
+    // tags so we can group them on the index like Swagger UI does.
+    val rendered = endpoints.map { case ((method, symbolicPath), endpointCalls) =>
       val methodName = method.map(_.method).getOrElse("UNDEFINED")
       val filename   = toFilename(s"$methodName $symbolicPath")
-
       writeFile(s"$dirName/$filename", generateEndpointPage(endpointCalls.sortBy(_.response.status.code)))
-
-      s"""<li><a href="${escHtmlAttr(filename)}"><span class="method method-${escHtmlAttr(methodName)}">${escHtml(
-          methodName
-        )}</span> <span class="path">${escHtml(symbolicPath)}</span></a></li>"""
+      val tags = endpointCalls.flatMap(_.request.operationTags).distinct
+      (methodName, symbolicPath, filename, tags)
     }
 
-    val indexHtml =
-      s"""<!DOCTYPE html><html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1"><title>API Documentation</title>$css</head><body>
-         |<h1>API Documentation</h1>
-         |<ul class="endpoint-list">
-         |${indexRows.mkString("\n")}
-         |</ul>
-         |</body></html>""".stripMargin
+    writeFile(s"$dirName/index.html", renderIndexHtml(rendered))
+  }
 
-    writeFile(s"$dirName/index.html", indexHtml)
+  /** Build the index HTML that groups every endpoint by its tag, Swagger-UI-style. Each operation appears under *every* tag it declares.
+    * Operations with no tags go under a `default` section. Tag sections are alphabetized; `default`, when present, is pushed to the end.
+    *
+    * `rendered` carries `(methodName, symbolicPath, filename, tags)` for every endpoint page.
+    */
+  private[simple] def renderIndexHtml(rendered: Seq[(String, String, String, Seq[String])]): String = {
+    val DefaultTag = "default"
+    val byTag      = rendered.flatMap { case e @ (_, _, _, tags) =>
+      val owners = if (tags.isEmpty) Seq(DefaultTag) else tags
+      owners.map(t => t -> e)
+    }
+    val tagSections = byTag
+      .groupMap(_._1)(_._2)
+      .toList
+      .sortBy { case (tag, _) => if (tag == DefaultTag) (1, tag) else (0, tag) }
+      .map { case (tag, entries) =>
+        val rows = entries
+          .sortBy { case (method, path, _, _) => (path, method) }
+          .map { case (method, path, filename, _) =>
+            s"""<li><a href="${escHtmlAttr(filename)}"><span class="method method-${escHtmlAttr(method)}">${escHtml(
+                method
+              )}</span> <span class="path">${escHtml(path)}</span></a></li>"""
+          }
+          .mkString("\n")
+        s"""<section class="tag-group"><h2 class="tag-heading">${escHtml(tag)}</h2><ul class="endpoint-list">$rows</ul></section>"""
+      }
+
+    s"""<!DOCTYPE html><html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1"><title>API Documentation</title>$css</head><body>
+       |<h1>API Documentation</h1>
+       |${tagSections.mkString("\n")}
+       |</body></html>""".stripMargin
   }
 
   private[simple] def generateEndpointPage(calls: Seq[BaklavaSerializableCall]): String = {
@@ -146,6 +177,12 @@ class BaklavaDslFormatterSimple extends BaklavaDslFormatter {
       val statusCss = if (status < 300) "2xx" else if (status < 400) "3xx" else if (status < 500) "4xx" else "5xx"
       val desc      = c.request.responseDescription.map(d => s"<p>${escHtml(d)}</p>").getOrElse("")
 
+      // Per-call curl command with a copy-to-clipboard button. The actual Authorization token /
+      // API key isn't in the serialized call (only the scheme type is), so the curl uses
+      // placeholders the caller must fill in — same compromise the OpenAPI `securitySchemes`
+      // render makes.
+      val curlBlock = renderCurl(c)
+
       // Per-call request body — previously only calls.head was rendered, so distinct inputs
       // across calls were silently dropped. Now each call's request body shows alongside its
       // response.
@@ -176,7 +213,7 @@ class BaklavaDslFormatterSimple extends BaklavaDslFormatter {
 
       card(
         s"""<span class="status-badge status-$statusCss">$status</span> Response""",
-        (List(Some(desc)) ++ List(responseHeadersSection, requestBodyPre, responseBodyPre, schemaPre)).flatten.mkString
+        (List(Some(desc), Some(curlBlock)) ++ List(responseHeadersSection, requestBodyPre, responseBodyPre, schemaPre)).flatten.mkString
       )
     }
 
@@ -192,8 +229,78 @@ class BaklavaDslFormatterSimple extends BaklavaDslFormatter {
        |${if (metaRows.nonEmpty) card("Overview", s"<dl class=\"meta-grid\">${metaRows.mkString}</dl>") else ""}
        |${List(securitySection, headersSection, pathParamsSection, queryParamsSection, requestBodySection).flatten.mkString("\n")}
        |${responseSections.mkString("\n")}
+       |$copyScript
        |</body></html>""".stripMargin
   }
+
+  // One inline script for the whole page. Binds a click handler to every `button.copy-btn`,
+  // reads the payload from `data-clipboard`, writes it to the clipboard, and briefly shows
+  // "Copied" so the user gets feedback. No external JS or CSS needed.
+  private val copyScript =
+    """<script>
+      |document.addEventListener('click', function (e) {
+      |  var btn = e.target.closest('button.copy-btn');
+      |  if (!btn) return;
+      |  var payload = btn.getAttribute('data-clipboard') || '';
+      |  navigator.clipboard.writeText(payload).then(function () {
+      |    var original = btn.textContent;
+      |    btn.textContent = 'Copied';
+      |    setTimeout(function () { btn.textContent = original; }, 1200);
+      |  });
+      |});
+      |</script>""".stripMargin
+
+  /** Render a per-call curl command + a copy-to-clipboard button.
+    *
+    * The captured call gives us: method, resolved path, request-body string, request content-type, declared security schemes (as types,
+    * without the live token) and declared headers (with the value the test sent, if any). For security we emit placeholder headers the
+    * reader fills in — the actual token/secret/key isn't serialized.
+    */
+  private[simple] def renderCurl(c: BaklavaSerializableCall): String = {
+    val method = c.request.method.map(_.method).getOrElse("GET")
+
+    val authHeaders: Seq[(String, String)] = c.request.securitySchemes.flatMap { scheme =>
+      val s = scheme.security
+      s.httpBearer.map(_ => "Authorization" -> "Bearer <TOKEN>") orElse
+      s.httpBasic.map(_ => "Authorization" -> "Basic <BASE64(USER:PASSWORD)>") orElse
+      s.apiKeyInHeader.map(k => k.name -> "<API_KEY>") orElse
+      s.apiKeyInCookie.map(k => "Cookie" -> s"${k.name}=<API_KEY>") orElse
+      s.openIdConnectInBearer.map(_ => "Authorization" -> "Bearer <OIDC_TOKEN>") orElse
+      s.oAuth2InBearer.map(_ => "Authorization" -> "Bearer <OAUTH_TOKEN>")
+    }
+
+    val declaredHeaders: Seq[(String, String)] =
+      c.request.headersSeq.flatMap(h => h.example.map(v => h.name -> v))
+
+    val contentTypeHeader: Seq[(String, String)] =
+      c.response.requestContentType.map("Content-Type" -> _).toSeq
+
+    val allHeaders = (contentTypeHeader ++ declaredHeaders ++ authHeaders).distinctBy(_._1.toLowerCase(java.util.Locale.ROOT))
+
+    val headerLines = allHeaders.map { case (k, v) => s"  -H ${shellSingleQuote(s"$k: $v")} \\\n" }
+
+    val bodyLine = if (c.response.requestBodyString.nonEmpty) s"  --data-raw ${shellSingleQuote(c.response.requestBodyString)}\n" else ""
+
+    val cmd =
+      s"curl -X $method ${shellSingleQuote(s"$$BASE_URL${c.request.path}")} \\\n" +
+        headerLines.mkString +
+        bodyLine
+
+    // Trim the trailing ` \` off the last continuation so the command pastes cleanly.
+    val trimmed = cmd.stripSuffix(" \\\n").stripSuffix("\n")
+
+    s"""<h4>Curl</h4><div class="curl-block"><pre>${escHtml(
+        trimmed
+      )}</pre><button class="copy-btn" type="button" data-clipboard="${escHtmlAttr(
+        trimmed
+      )}">Copy</button></div>"""
+  }
+
+  /** Wrap `s` in single quotes for safe shell consumption. Single quotes can't be escaped inside a single-quoted string, so any literal
+    * `'` is emitted as `'\''` (close quote, escaped quote, reopen quote). All other characters pass through unchanged.
+    */
+  private def shellSingleQuote(s: String): String =
+    "'" + s.replace("'", "'\\''") + "'"
 
   private def card(title: String, body: String): String =
     s"""<div class="card"><div class="card-header">$title</div><div class="card-body">$body</div></div>"""

--- a/simple/src/test/scala/pl/iterators/baklava/simple/BaklavaDslFormatterSimpleSpec.scala
+++ b/simple/src/test/scala/pl/iterators/baklava/simple/BaklavaDslFormatterSimpleSpec.scala
@@ -134,7 +134,42 @@ class BaklavaDslFormatterSimpleSpec extends AnyFunSpec with Matchers {
       out should include("'$BASE_URL/users'")
       out should include("-H 'Content-Type: application/json'")
       out should include("""--data-raw '{"name":"Alice"}'""")
-      out should include("""<button class="copy-btn" type="button" data-clipboard=""")
+      // Payload is copied from the adjacent <pre>'s textContent (not a data-* attribute), since
+      // attribute values have whitespace normalized and we'd lose line-continuation newlines.
+      out should include("""<button class="copy-btn" type="button">Copy</button>""")
+      out should not include "data-clipboard="
+    }
+
+    it("never leaks a declared Authorization/Cookie/API-key header value — only placeholders") {
+      val base = jsonCall(status = 200, desc = "ok", requestBody = "", responseBody = "{}")
+      val call = base.copy(
+        request = base.request.copy(
+          securitySchemes = Seq(
+            BaklavaSecuritySchemaSerializable(
+              "bearerAuth",
+              BaklavaSecuritySerializable(httpBearer = Some(HttpBearer(bearerFormat = "JWT")))
+            ),
+            BaklavaSecuritySchemaSerializable(
+              "apiKey",
+              BaklavaSecuritySerializable(apiKeyInHeader = Some(ApiKeyInHeader("X-API-Key")))
+            )
+          ),
+          // Headers a naive user might also declare alongside the security scheme — we must NOT
+          // leak these captured values (which would contain a real token / cookie / key).
+          headersSeq = Seq(
+            BaklavaHeaderSerializable("Authorization", None, stringRequired, Some("Bearer real-jwt-xyz")),
+            BaklavaHeaderSerializable("Cookie", None, stringRequired, Some("session=real-cookie")),
+            BaklavaHeaderSerializable("X-API-Key", None, stringRequired, Some("real-api-key"))
+          )
+        )
+      )
+      val out = generator.renderCurl(call)
+
+      out should not include "real-jwt-xyz"
+      out should not include "real-cookie"
+      out should not include "real-api-key"
+      out should include("-H 'Authorization: Bearer &lt;TOKEN&gt;'")
+      out should include("-H 'X-API-Key: &lt;API_KEY&gt;'")
     }
 
     it("emits security-scheme placeholder headers (bearer, api key)") {
@@ -162,9 +197,9 @@ class BaklavaDslFormatterSimpleSpec extends AnyFunSpec with Matchers {
     it("shell-escapes single quotes inside body and path") {
       val base = jsonCall(status = 200, desc = "ok", requestBody = """he said 'hi'""", responseBody = "")
       val out  = generator.renderCurl(base)
-      // The embedded apostrophes are closed, escaped, reopened: '\''. HTML-escaped for display
-      // (backslash passes through; apostrophe becomes &#39;).
-      out should include("""he said &#39;\&#39;&#39;hi&#39;\&#39;&#39;""")
+      // The embedded apostrophes are closed, escaped, reopened: '\''. `escHtml` doesn't touch
+      // apostrophes, so the shell-escape form appears verbatim inside the <pre>.
+      out should include("""'he said '\''hi'\'''""")
     }
   }
 

--- a/simple/src/test/scala/pl/iterators/baklava/simple/BaklavaDslFormatterSimpleSpec.scala
+++ b/simple/src/test/scala/pl/iterators/baklava/simple/BaklavaDslFormatterSimpleSpec.scala
@@ -120,6 +120,82 @@ class BaklavaDslFormatterSimpleSpec extends AnyFunSpec with Matchers {
     }
   }
 
+  describe("renderCurl") {
+    it("emits an explicit curl command with method, base-URL placeholder, content-type and body") {
+      val call = jsonCall(
+        status = 201,
+        desc = "ok",
+        requestBody = """{"name":"Alice"}""",
+        responseBody = """{"id":1}"""
+      )
+      val out = generator.renderCurl(call)
+
+      out should include("curl -X POST")
+      out should include("'$BASE_URL/users'")
+      out should include("-H 'Content-Type: application/json'")
+      out should include("""--data-raw '{"name":"Alice"}'""")
+      out should include("""<button class="copy-btn" type="button" data-clipboard=""")
+    }
+
+    it("emits security-scheme placeholder headers (bearer, api key)") {
+      val base = jsonCall(status = 200, desc = "ok", requestBody = "", responseBody = "{}")
+      val call = base.copy(
+        request = base.request.copy(
+          securitySchemes = Seq(
+            BaklavaSecuritySchemaSerializable(
+              "bearerAuth",
+              BaklavaSecuritySerializable(httpBearer = Some(HttpBearer(bearerFormat = "JWT")))
+            ),
+            BaklavaSecuritySchemaSerializable(
+              "apiKey",
+              BaklavaSecuritySerializable(apiKeyInHeader = Some(ApiKeyInHeader("X-API-Key")))
+            )
+          )
+        )
+      )
+      val out = generator.renderCurl(call)
+
+      out should include("-H 'Authorization: Bearer &lt;TOKEN&gt;'")
+      out should include("-H 'X-API-Key: &lt;API_KEY&gt;'")
+    }
+
+    it("shell-escapes single quotes inside body and path") {
+      val base = jsonCall(status = 200, desc = "ok", requestBody = """he said 'hi'""", responseBody = "")
+      val out  = generator.renderCurl(base)
+      // The embedded apostrophes are closed, escaped, reopened: '\''. HTML-escaped for display
+      // (backslash passes through; apostrophe becomes &#39;).
+      out should include("""he said &#39;\&#39;&#39;hi&#39;\&#39;&#39;""")
+    }
+  }
+
+  describe("renderIndexHtml") {
+    it("groups endpoints under each tag section, with untagged operations under 'default'") {
+      val rendered: Seq[(String, String, String, Seq[String])] = Seq(
+        ("GET", "/a", "GET__a.html", Seq("Users")),
+        ("GET", "/b", "GET__b.html", Seq("Users", "Admin")),
+        ("GET", "/c", "GET__c.html", Seq.empty)
+      )
+      val html = generator.renderIndexHtml(rendered)
+
+      val adminIdx   = html.indexOf(">Admin<")
+      val usersIdx   = html.indexOf(">Users<")
+      val defaultIdx = html.indexOf(">default<")
+      adminIdx should be > -1
+      usersIdx should be > adminIdx
+      defaultIdx should be > usersIdx
+
+      // Endpoint /b appears under BOTH Users and Admin sections.
+      val bMatches = html.split("""<span class="path">/b</span>""", -1).length - 1
+      bMatches shouldBe 2
+    }
+
+    it("HTML-escapes tag names so hostile tag strings can't break out") {
+      val html = generator.renderIndexHtml(Seq(("GET", "/x", "GET__x.html", Seq("<script>"))))
+      html should include("&lt;script&gt;")
+      html should not include "<script>"
+    }
+  }
+
   describe("toFilename") {
     it("produces distinct filenames for paths that differ only by `/` vs `_` (regression for C6)") {
       generator.toFilename("GET /a/b") should not be generator.toFilename("GET /a_b")


### PR DESCRIPTION
## Summary

Two UX enhancements to the simple HTML formatter.

### (a) Index grouped by tags, Swagger-UI style

- One \`<section>\` per tag, heading is the tag name
- Operations appear under **every** tag they declare (matching Swagger UI)
- Operations with no tags go under a \`default\` section
- Sections sorted alphabetically; \`default\` pushed to the end
- Within a section: sorted by \`(path, method)\`

### (b) Per-call curl example + copy-to-clipboard button

Each response card now includes a ready-to-run curl command reconstructed from the captured call:

- \`curl -X METHOD '\$BASE_URL/...'\` with backslash continuations for readability
- \`Content-Type\` from \`response.requestContentType\`
- Declared custom headers with the value captured in that scenario
- Placeholder \`Authorization\` / API-key header per security scheme (actual secrets are never serialized)
- \`--data-raw\` for any non-empty request body, shell-safe single-quoted
- \`<button class="copy-btn">Copy</button>\` wired up via one inline \`<script>\` at page-end (no external JS)

## Gold & tests

- Gold files regenerated; index now shows \`Auth / Projects / System / Tasks / Users / Webhooks\` sections, each endpoint page carries one curl block per response scenario.
- New unit tests:
  - \`renderCurl\`: method/base-URL/content-type/body, security placeholders (bearer, api key), shell-quote escaping
  - \`renderIndexHtml\`: alphabetical sections with \`default\` last, multi-tag endpoints appearing under each, HTML-escape of hostile tag strings
- OpenAPI YAML and ts-rest gold unchanged

## Test plan

- [x] \`sbt 'project simple' '++ 2.13' test\` — 14/14 pass
- [x] \`sbt 'project simple' '++ 3' test\` — 14/14 pass
- [x] \`CI=true sbt 'project openapi' '++ 2.13' test\` — 92/92 pass (gold stays green)
- [x] \`CI=true sbt 'project openapi' '++ 3' test\` — 92/92 pass