### PR TITLE
feat: http4s routes for serving OpenAPI + Swagger UI (#54)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,11 +75,11 @@ jobs:
 
       - name: Make target directories
         if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main')
-        run: mkdir -p scalatest/target http4s/target openapi/target pekkohttproutes/target simple/target sbtplugin/target munit/target core/target tsrest/target specs2/target pekkohttp/target project/target
+        run: mkdir -p scalatest/target http4sroutes/target http4s/target openapi/target pekkohttproutes/target simple/target sbtplugin/target munit/target core/target tsrest/target specs2/target pekkohttp/target project/target
 
       - name: Compress target directories
         if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main')
-        run: tar cf targets.tar scalatest/target http4s/target openapi/target pekkohttproutes/target simple/target sbtplugin/target munit/target core/target tsrest/target specs2/target pekkohttp/target project/target
+        run: tar cf targets.tar scalatest/target http4sroutes/target http4s/target openapi/target pekkohttproutes/target simple/target sbtplugin/target munit/target core/target tsrest/target specs2/target pekkohttp/target project/target
 
       - name: Upload target directories
         if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main')

--- a/build.sbt
+++ b/build.sbt
@@ -47,7 +47,7 @@ lazy val perScalaVersionTestSources = Test / unmanagedSourceDirectories ++= {
 }
 
 lazy val baklava =
-  tlCrossRootProject.aggregate(core, simple, openapi, tsrest, pekkohttp, pekkohttproutes, http4s, specs2, scalatest, munit, sbtplugin)
+  tlCrossRootProject.aggregate(core, simple, openapi, tsrest, pekkohttp, pekkohttproutes, http4s, http4sroutes, specs2, scalatest, munit, sbtplugin)
 
 val swaggerV       = "2.2.45"
 val swaggerParserV = "2.1.39"
@@ -173,6 +173,21 @@ lazy val http4s = project
     name := "baklava-http4s",
     libraryDependencies ++= Seq(
       "org.http4s" %% "http4s-dsl" % http4sV
+    )
+  )
+
+lazy val http4sroutes = project
+  .in(file("http4sroutes"))
+  .settings(
+    name := "baklava-http4s-routes",
+    libraryDependencies ++= Seq(
+      "org.http4s"           %% "http4s-dsl"     % http4sV,
+      "org.http4s"           %% "http4s-server"  % http4sV,
+      "com.typesafe"          % "config"         % typesafeConfigV,
+      "org.webjars"           % "webjars-locator" % webjarsLocatorV,
+      "io.swagger.core.v3"    % "swagger-core"   % swaggerV,
+      "io.swagger.parser.v3"  % "swagger-parser" % swaggerParserV,
+      "org.webjars"           % "swagger-ui"     % swaggerUiV
     )
   )
 

--- a/build.sbt
+++ b/build.sbt
@@ -47,7 +47,20 @@ lazy val perScalaVersionTestSources = Test / unmanagedSourceDirectories ++= {
 }
 
 lazy val baklava =
-  tlCrossRootProject.aggregate(core, simple, openapi, tsrest, pekkohttp, pekkohttproutes, http4s, http4sroutes, specs2, scalatest, munit, sbtplugin)
+  tlCrossRootProject.aggregate(
+    core,
+    simple,
+    openapi,
+    tsrest,
+    pekkohttp,
+    pekkohttproutes,
+    http4s,
+    http4sroutes,
+    specs2,
+    scalatest,
+    munit,
+    sbtplugin
+  )
 
 val swaggerV       = "2.2.45"
 val swaggerParserV = "2.1.39"
@@ -181,13 +194,13 @@ lazy val http4sroutes = project
   .settings(
     name := "baklava-http4s-routes",
     libraryDependencies ++= Seq(
-      "org.http4s"           %% "http4s-dsl"     % http4sV,
-      "org.http4s"           %% "http4s-server"  % http4sV,
-      "com.typesafe"          % "config"         % typesafeConfigV,
-      "org.webjars"           % "webjars-locator" % webjarsLocatorV,
-      "io.swagger.core.v3"    % "swagger-core"   % swaggerV,
-      "io.swagger.parser.v3"  % "swagger-parser" % swaggerParserV,
-      "org.webjars"           % "swagger-ui"     % swaggerUiV
+      "org.http4s"          %% "http4s-dsl"      % http4sV,
+      "org.http4s"          %% "http4s-server"   % http4sV,
+      "com.typesafe"         % "config"          % typesafeConfigV,
+      "org.webjars"          % "webjars-locator" % webjarsLocatorV,
+      "io.swagger.core.v3"   % "swagger-core"    % swaggerV,
+      "io.swagger.parser.v3" % "swagger-parser"  % swaggerParserV,
+      "org.webjars"          % "swagger-ui"      % swaggerUiV
     )
   )
 

--- a/docs/http4s.md
+++ b/docs/http4s.md
@@ -257,6 +257,6 @@ object Main extends IOApp.Simple {
 }
 ```
 
-For detailed configuration options check [installation.md#swaggerui-and-routes-configuration].
+For detailed configuration options check [the SwaggerUI and routes configuration section](installation.md#swaggerui-and-routes-configuration).
 
 The http4s and pekko-http variants expose the same endpoints (`GET /openapi`, `GET /swagger-ui/<version>/…`, `GET /swagger`) and share the same configuration keys under `baklava-routes`.

--- a/docs/http4s.md
+++ b/docs/http4s.md
@@ -222,3 +222,41 @@ class GetUsersUserIdRouteSpec extends BaseRouteSpec {
 
 }
 ```
+
+## Serving Open API and Swagger UI
+
+Adding `baklava-http4s-routes` dependency to your project you can easily serve Open API and Swagger UI:
+
+```scala
+import cats.effect.{IO, IOApp}
+import com.comcast.ip4s.*
+import com.typesafe.config.{Config, ConfigFactory}
+import org.http4s.ember.server.EmberServerBuilder
+import org.http4s.server.Router
+import org.http4s.HttpRoutes
+import pl.iterators.baklava.http4s.routes.BaklavaRoutes
+
+object Main extends IOApp.Simple {
+  def run: IO[Unit] = {
+    val apiRoutes: HttpRoutes[IO] = ??? // all your API routes
+    val config: Config            = ConfigFactory.load()
+
+    val appRoutes: HttpRoutes[IO] = Router(
+      "/"    -> BaklavaRoutes.routes(config),
+      "/v1"  -> apiRoutes
+    )
+
+    EmberServerBuilder
+      .default[IO]
+      .withHost(host"0.0.0.0")
+      .withPort(port"8080")
+      .withHttpApp(appRoutes.orNotFound)
+      .build
+      .useForever
+  }
+}
+```
+
+For detailed configuration options check [installation.md#swaggerui-and-routes-configuration].
+
+The http4s and pekko-http variants expose the same endpoints (`GET /openapi`, `GET /swagger-ui/<version>/…`, `GET /swagger`) and share the same configuration keys under `baklava-routes`.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -69,11 +69,14 @@ libraryDependencies += "pl.iterators" %% "baklava-tsrest" % "VERSION" % Test
 
 #### Optional: SwaggerUI Support
 
-**⚠️ SwaggerUI is only available with Pekko HTTP + OpenAPI format combination**
+SwaggerUI is available for both Pekko HTTP and http4s (combined with the OpenAPI output format). Add the matching routes module:
 
 ```scala
-// Only add this if you're using Pekko HTTP AND OpenAPI format
+// Pekko HTTP
 libraryDependencies += "pl.iterators" %% "baklava-pekko-http-routes" % "VERSION"
+
+// http4s
+libraryDependencies += "pl.iterators" %% "baklava-http4s-routes" % "VERSION"
 ```
 
 ## Configuration
@@ -220,6 +223,16 @@ inConfig(Test)(
 )
 ```
 
+To serve SwaggerUI from an http4s app, add `baklava-http4s-routes` and the OpenAPI format:
+
+```scala
+libraryDependencies ++= Seq(
+  "pl.iterators" %% "baklava-http4s" % "VERSION" % Test,
+  "pl.iterators" %% "baklava-openapi" % "VERSION" % Test,
+  "pl.iterators" %% "baklava-http4s-routes" % "VERSION"
+)
+```
+
 ### Example 3: Pekko HTTP + Specs2 + Multiple Formats
 
 ```scala
@@ -279,7 +292,7 @@ The documentation will be generated in `target/baklava/` directory after running
 
 ### SwaggerUI and Routes Configuration
 
-If you're using SwaggerUI (Pekko HTTP + OpenAPI), you can configure the routes behavior at runtime.
+If you're using SwaggerUI (Pekko HTTP or http4s + OpenAPI), you can configure the routes behavior at runtime. Both `baklava-pekko-http-routes` and `baklava-http4s-routes` modules read the same `baklava-routes { ... }` section, so the configuration below applies to either.
 
 #### Configuration via application.conf
 

--- a/docs/pekko-http.md
+++ b/docs/pekko-http.md
@@ -278,4 +278,4 @@ import scala.io.StdIn
   }
 ```
 
-For detailed configuration options check [installation.md#swaggerui-and-routes-configuration]
+For detailed configuration options check [the SwaggerUI and routes configuration section](installation.md#swaggerui-and-routes-configuration).

--- a/http4sroutes/src/main/resources/reference.conf
+++ b/http4sroutes/src/main/resources/reference.conf
@@ -1,0 +1,20 @@
+baklava-routes {
+  enabled = "true"
+  enabled = ${?BAKLAVA_ROUTES_ENABLED}
+
+  #Override this to set http basic auth for baklava routes
+  basic-auth-user = ${?BAKLAVA_ROUTES_BASIC_AUTH_USER}
+  basic-auth-password = ${?BAKLAVA_ROUTES_BASIC_AUTH_PASSWORD}
+
+  #Filesystem path where output of baklava is stored
+  filesystem-path = "./target/baklava"
+  filesystem-path = ${?BAKLAVA_ROUTES_FILESYSTEM_PATH}
+
+  #HTTP serve prefix of baklava resources
+  public-path-prefix = "/"
+  public-path-prefix = ${?BAKLAVA_ROUTES_PUBLIC_PATH_PREFIX}
+
+  #API prefix
+  api-public-path-prefix = "/v1"
+  api-public-path-prefix = ${?BAKLAVA_ROUTES_API_PUBLIC_PATH_PREFIX}
+}

--- a/http4sroutes/src/main/resources/reference.conf
+++ b/http4sroutes/src/main/resources/reference.conf
@@ -1,5 +1,5 @@
 baklava-routes {
-  enabled = "true"
+  enabled = true
   enabled = ${?BAKLAVA_ROUTES_ENABLED}
 
   #Override this to set http basic auth for baklava routes

--- a/http4sroutes/src/main/scala/pl/iterators/baklava/http4s/routes/BaklavaRoutes.scala
+++ b/http4sroutes/src/main/scala/pl/iterators/baklava/http4s/routes/BaklavaRoutes.scala
@@ -19,15 +19,33 @@ import scala.util.{Failure, Success, Try}
 
 object BaklavaRoutes {
 
-  /** The swagger-ui webjar version is the source of truth; we serve assets at `/swagger-ui/<version>/...` so the version has to match the
+  /** The swagger-ui webjar version is the source of truth; we serve assets at `/swagger-ui/<version>/...` so the version must match the
     * resources actually on the classpath. Read the webjar's own metadata rather than hard-coding it here — otherwise a webjar upgrade in
     * build.sbt silently breaks these routes with 404s.
     *
-    * Falls back to a safe constant only if the webjar is missing from the classpath (which would mean the user hasn't added the dependency
-    * properly), so runtime error messages are at least actionable.
+    * If the webjar is missing from the classpath (the user didn't add the dependency) we fail fast — letting the route respond with a
+    * confusing 404 at request time would be worse than a clear startup error.
     */
   private lazy val swaggerVersion: String =
-    Try(new WebJarAssetLocator().getWebJars.get("swagger-ui")).toOption.filter(_ != null).getOrElse("5.17.11")
+    Option(new WebJarAssetLocator().getWebJars.get("swagger-ui")).getOrElse(
+      throw new IllegalStateException(
+        "swagger-ui webjar not on the classpath — add `\"org.webjars\" % \"swagger-ui\" % \"...\"` to your project's dependencies " +
+          "or remove baklava-http4s-routes if you don't intend to serve SwaggerUI."
+      )
+    )
+
+  /** slf4j logger used for server-side logging of request-handling failures. The route responses stay generic (no `e.getMessage` in the
+    * client body) so internal details — filesystem paths, parser errors — never leak to unauthenticated clients when basic auth is
+    * disabled.
+    */
+  private val log: org.slf4j.Logger = org.slf4j.LoggerFactory.getLogger("pl.iterators.baklava.http4s.routes.BaklavaRoutes")
+
+  /** Ensure a public-path prefix ends with exactly one trailing slash. The configured prefix is concatenated with fixed sub-paths
+    * (`"swagger-ui/<v>/index.html"`, `"openapi"`); missing the separator silently produced `/api-docsswagger-ui/...` for
+    * `public-path-prefix = "/api-docs"`.
+    */
+  private def withTrailingSlash(prefix: String): String =
+    if (prefix.endsWith("/")) prefix else prefix + "/"
 
   def routes(config: com.typesafe.config.Config): HttpRoutes[IO] = {
     val internalConfig = Config(config)
@@ -45,12 +63,15 @@ object BaklavaRoutes {
     case GET -> Root / "openapi" =>
       // `openApiFileContent` does blocking file I/O + YAML parsing; wrap in IO.blocking so
       // exceptions land inside the effect (a missing or malformed file becomes a 404/500, not a
-      // crashed request handler).
+      // crashed request handler). Error bodies are generic; the real cause goes to the log only.
       IO.blocking(openApiFileContent(c))
         .flatMap(content => Ok(content).map(_.withContentType(`Content-Type`(MediaType.text.yaml))))
         .recoverWith {
-          case _: java.io.FileNotFoundException => NotFound("openapi.yml not found — run `sbt test` first to generate it")
-          case e: Throwable                     => InternalServerError(s"Failed to serve openapi: ${e.getMessage}")
+          case _: java.io.FileNotFoundException =>
+            NotFound("openapi document not available — run `sbt test` first to generate it")
+          case e: Throwable =>
+            IO(log.warn(s"Failed to serve openapi document from ${c.fileSystemPath}/openapi/openapi.yml", e)) *>
+            InternalServerError("Failed to serve openapi document")
         }
 
     case GET -> Root / "swagger-ui" / version / "swagger-initializer.js" if version == swaggerVersion =>
@@ -60,10 +81,12 @@ object BaklavaRoutes {
       serveSwaggerAsset(rest.segments.map(_.decoded()).mkString("/"))
 
     case GET -> Root / "swagger" =>
-      val swaggerUiUrl = s"${c.publicPathPrefix}swagger-ui/$swaggerVersion/index.html"
+      val swaggerUiUrl = s"${withTrailingSlash(c.publicPathPrefix)}swagger-ui/$swaggerVersion/index.html"
       Uri.fromString(swaggerUiUrl) match {
         case Right(uri) => SeeOther(Location(uri))
-        case Left(err)  => InternalServerError(s"Invalid swagger-ui URL '$swaggerUiUrl': ${err.message}")
+        case Left(_)    =>
+          IO(log.warn(s"Invalid swagger-ui URL constructed from publicPathPrefix='${c.publicPathPrefix}': $swaggerUiUrl")) *>
+          InternalServerError("Misconfigured swagger-ui URL")
       }
   }
 
@@ -103,7 +126,7 @@ object BaklavaRoutes {
   }
 
   private def swaggerInitializerContent(c: Config): String = {
-    val swaggerDocsUrl = s"${c.publicPathPrefix}openapi"
+    val swaggerDocsUrl = s"${withTrailingSlash(c.publicPathPrefix)}openapi"
     s"""
        |window.onload = function() {
        |  window.ui = SwaggerUIBundle({
@@ -124,21 +147,23 @@ object BaklavaRoutes {
   }
 
   /** Serve a file from the `swagger-ui` webjar. Returns the file bytes with a best-effort content type guessed from the extension (falls
-    * back to `application/octet-stream`). Missing files yield a 404.
+    * back to `application/octet-stream`). Missing files yield a 404. Classpath reads + byte copying happen inside `IO.blocking` so they
+    * don't starve the compute pool under load.
     */
   private def serveSwaggerAsset(relPath: String): IO[Response[IO]] = {
     Try((new WebJarAssetLocator).getFullPath("swagger-ui", relPath)) match {
       case Success(fullPath) =>
-        IO(Option(getClass.getClassLoader.getResourceAsStream(fullPath))).flatMap {
+        IO.blocking(Option(getClass.getClassLoader.getResourceAsStream(fullPath))).flatMap {
           case None     => NotFound()
           case Some(is) =>
-            IO(readAllBytes(is)).guarantee(IO(is.close())).flatMap { bytes =>
+            IO.blocking(readAllBytes(is)).guarantee(IO.blocking(is.close())).flatMap { bytes =>
               val ct = mediaTypeFromExtension(relPath)
               Ok(bytes).map(r => r.withContentType(`Content-Type`(ct)))
             }
         }
       case Failure(_: IllegalArgumentException) => NotFound()
-      case Failure(e)                           => InternalServerError(e.getMessage)
+      case Failure(e)                           =>
+        IO(log.warn(s"Failed to serve swagger-ui asset '$relPath'", e)) *> InternalServerError("Failed to serve swagger-ui asset")
     }
   }
 

--- a/http4sroutes/src/main/scala/pl/iterators/baklava/http4s/routes/BaklavaRoutes.scala
+++ b/http4sroutes/src/main/scala/pl/iterators/baklava/http4s/routes/BaklavaRoutes.scala
@@ -18,7 +18,16 @@ import scala.jdk.CollectionConverters.SeqHasAsJava
 import scala.util.{Failure, Success, Try}
 
 object BaklavaRoutes {
-  private val swaggerVersion = "5.17.11"
+
+  /** The swagger-ui webjar version is the source of truth; we serve assets at `/swagger-ui/<version>/...` so the version has to match the
+    * resources actually on the classpath. Read the webjar's own metadata rather than hard-coding it here — otherwise a webjar upgrade in
+    * build.sbt silently breaks these routes with 404s.
+    *
+    * Falls back to a safe constant only if the webjar is missing from the classpath (which would mean the user hasn't added the dependency
+    * properly), so runtime error messages are at least actionable.
+    */
+  private lazy val swaggerVersion: String =
+    Try(new WebJarAssetLocator().getWebJars.get("swagger-ui")).toOption.filter(_ != null).getOrElse("5.17.11")
 
   def routes(config: com.typesafe.config.Config): HttpRoutes[IO] = {
     val internalConfig = Config(config)
@@ -34,7 +43,15 @@ object BaklavaRoutes {
 
   private def coreRoutes(c: Config): HttpRoutes[IO] = HttpRoutes.of[IO] {
     case GET -> Root / "openapi" =>
-      Ok(openApiFileContent(c)).map(_.withContentType(`Content-Type`(MediaType.text.yaml)))
+      // `openApiFileContent` does blocking file I/O + YAML parsing; wrap in IO.blocking so
+      // exceptions land inside the effect (a missing or malformed file becomes a 404/500, not a
+      // crashed request handler).
+      IO.blocking(openApiFileContent(c))
+        .flatMap(content => Ok(content).map(_.withContentType(`Content-Type`(MediaType.text.yaml))))
+        .recoverWith {
+          case _: java.io.FileNotFoundException => NotFound("openapi.yml not found — run `sbt test` first to generate it")
+          case e: Throwable                     => InternalServerError(s"Failed to serve openapi: ${e.getMessage}")
+        }
 
     case GET -> Root / "swagger-ui" / version / "swagger-initializer.js" if version == swaggerVersion =>
       Ok(swaggerInitializerContent(c)).map(_.withContentType(`Content-Type`(MediaType.application.javascript)))
@@ -44,7 +61,10 @@ object BaklavaRoutes {
 
     case GET -> Root / "swagger" =>
       val swaggerUiUrl = s"${c.publicPathPrefix}swagger-ui/$swaggerVersion/index.html"
-      SeeOther(Location(Uri.unsafeFromString(swaggerUiUrl)))
+      Uri.fromString(swaggerUiUrl) match {
+        case Right(uri) => SeeOther(Location(uri))
+        case Left(err)  => InternalServerError(s"Invalid swagger-ui URL '$swaggerUiUrl': ${err.message}")
+      }
   }
 
   private def basicAuth(expectedUser: String, expectedPassword: String)(routes: HttpRoutes[IO]): HttpRoutes[IO] = {

--- a/http4sroutes/src/main/scala/pl/iterators/baklava/http4s/routes/BaklavaRoutes.scala
+++ b/http4sroutes/src/main/scala/pl/iterators/baklava/http4s/routes/BaklavaRoutes.scala
@@ -1,0 +1,173 @@
+package pl.iterators.baklava.http4s.routes
+
+import cats.data.{Kleisli, OptionT}
+import cats.effect.IO
+import io.swagger.v3.core.util.Yaml
+import io.swagger.v3.oas.models.servers.Server
+import io.swagger.v3.parser.OpenAPIV3Parser
+import org.http4s.*
+import org.http4s.dsl.io.*
+import org.http4s.headers.{Authorization, Location, `Content-Type`}
+import org.typelevel.ci.CIString
+import org.webjars.WebJarAssetLocator
+
+import java.io.{ByteArrayOutputStream, InputStream}
+import java.util.Base64
+import scala.io.Source
+import scala.jdk.CollectionConverters.SeqHasAsJava
+import scala.util.{Failure, Success, Try}
+
+object BaklavaRoutes {
+  private val swaggerVersion = "5.17.11"
+
+  def routes(config: com.typesafe.config.Config): HttpRoutes[IO] = {
+    val internalConfig = Config(config)
+    if (!internalConfig.enabled) HttpRoutes.empty[IO]
+    else {
+      val core = coreRoutes(internalConfig)
+      (internalConfig.basicAuthUser, internalConfig.basicAuthPassword) match {
+        case (Some(user), Some(password)) => basicAuth(user, password)(core)
+        case _                            => core
+      }
+    }
+  }
+
+  private def coreRoutes(c: Config): HttpRoutes[IO] = HttpRoutes.of[IO] {
+    case GET -> Root / "openapi" =>
+      Ok(openApiFileContent(c)).map(_.withContentType(`Content-Type`(MediaType.text.yaml)))
+
+    case GET -> Root / "swagger-ui" / version / "swagger-initializer.js" if version == swaggerVersion =>
+      Ok(swaggerInitializerContent(c)).map(_.withContentType(`Content-Type`(MediaType.application.javascript)))
+
+    case GET -> "swagger-ui" /: rest =>
+      serveSwaggerAsset(rest.segments.map(_.decoded()).mkString("/"))
+
+    case GET -> Root / "swagger" =>
+      val swaggerUiUrl = s"${c.publicPathPrefix}swagger-ui/$swaggerVersion/index.html"
+      SeeOther(Location(Uri.unsafeFromString(swaggerUiUrl)))
+  }
+
+  private def basicAuth(expectedUser: String, expectedPassword: String)(routes: HttpRoutes[IO]): HttpRoutes[IO] = {
+    val unauthorized: Response[IO] =
+      Response[IO](Status.Unauthorized).putHeaders(Header.Raw(CIString("WWW-Authenticate"), "Basic realm=\"docs\""))
+    Kleisli { (req: Request[IO]) =>
+      val ok = req.headers.get[Authorization].exists {
+        case Authorization(Credentials.Token(AuthScheme.Basic, token)) =>
+          Try(new String(Base64.getDecoder.decode(token), "UTF-8")).toOption.exists { decoded =>
+            decoded.split(":", 2) match {
+              case Array(u, p) => u == expectedUser && p == expectedPassword
+              case _           => false
+            }
+          }
+        case _ => false
+      }
+      if (ok) routes(req) else OptionT.pure[IO](unauthorized)
+    }
+  }
+
+  // Swagger UI's yaml includes a `servers:` block that Swagger UI uses as the API base URL. We
+  // parse, replace with the user-configured `api-public-path-prefix`, then re-serialize so the
+  // rendered docs can call the real API directly.
+  private def openApiFileContent(c: Config): String = {
+    val source = Source.fromFile(s"${c.fileSystemPath}/openapi/openapi.yml")
+    try {
+      val parser  = new OpenAPIV3Parser
+      val openApi = parser.readContents(source.mkString, null, null).getOpenAPI
+      val server  = new Server()
+      server.setUrl(c.apiPublicPathPrefix)
+      openApi.setServers(List(server).asJava)
+      Yaml.pretty(openApi)
+    } finally {
+      source.close()
+    }
+  }
+
+  private def swaggerInitializerContent(c: Config): String = {
+    val swaggerDocsUrl = s"${c.publicPathPrefix}openapi"
+    s"""
+       |window.onload = function() {
+       |  window.ui = SwaggerUIBundle({
+       |    url: "$swaggerDocsUrl",
+       |    dom_id: '#swagger-ui',
+       |    deepLinking: true,
+       |    presets: [
+       |      SwaggerUIBundle.presets.apis,
+       |      SwaggerUIStandalonePreset
+       |    ],
+       |    plugins: [
+       |      SwaggerUIBundle.plugins.DownloadUrl
+       |    ],
+       |    layout: "BaseLayout"
+       |  });
+       |};
+       |""".stripMargin
+  }
+
+  /** Serve a file from the `swagger-ui` webjar. Returns the file bytes with a best-effort content type guessed from the extension (falls
+    * back to `application/octet-stream`). Missing files yield a 404.
+    */
+  private def serveSwaggerAsset(relPath: String): IO[Response[IO]] = {
+    Try((new WebJarAssetLocator).getFullPath("swagger-ui", relPath)) match {
+      case Success(fullPath) =>
+        IO(Option(getClass.getClassLoader.getResourceAsStream(fullPath))).flatMap {
+          case None     => NotFound()
+          case Some(is) =>
+            IO(readAllBytes(is)).guarantee(IO(is.close())).flatMap { bytes =>
+              val ct = mediaTypeFromExtension(relPath)
+              Ok(bytes).map(r => r.withContentType(`Content-Type`(ct)))
+            }
+        }
+      case Failure(_: IllegalArgumentException) => NotFound()
+      case Failure(e)                           => InternalServerError(e.getMessage)
+    }
+  }
+
+  // Simple copy-through using a fixed buffer. Avoids `InputStream.readAllBytes` which isn't
+  // visible in this build's compile-time stub despite being runtime-available on Java 11.
+  private def readAllBytes(is: InputStream): Array[Byte] = {
+    val out  = new ByteArrayOutputStream()
+    val buf  = new Array[Byte](8192)
+    var read = is.read(buf)
+    while (read != -1) {
+      out.write(buf, 0, read)
+      read = is.read(buf)
+    }
+    out.toByteArray
+  }
+
+  private def mediaTypeFromExtension(path: String): MediaType = {
+    val lower = path.toLowerCase(java.util.Locale.ROOT)
+    if (lower.endsWith(".html")) MediaType.text.html
+    else if (lower.endsWith(".css")) MediaType.text.css
+    else if (lower.endsWith(".js")) MediaType.application.javascript
+    else if (lower.endsWith(".json")) MediaType.application.json
+    else if (lower.endsWith(".png")) MediaType.image.png
+    else if (lower.endsWith(".svg")) MediaType.image.`svg+xml`
+    else if (lower.endsWith(".map")) MediaType.application.json
+    else MediaType.application.`octet-stream`
+  }
+
+  private case class Config(
+      enabled: Boolean,
+      basicAuthUser: Option[String],
+      basicAuthPassword: Option[String],
+      fileSystemPath: String,
+      publicPathPrefix: String,
+      apiPublicPathPrefix: String
+  )
+
+  private object Config {
+    def apply(config: com.typesafe.config.Config): Config = {
+      val c = config.getConfig("baklava-routes")
+      Config(
+        enabled = c.getBoolean("enabled"),
+        basicAuthUser = Try(c.getString("basic-auth-user")).toOption,
+        basicAuthPassword = Try(c.getString("basic-auth-password")).toOption,
+        fileSystemPath = c.getString("filesystem-path"),
+        publicPathPrefix = c.getString("public-path-prefix"),
+        apiPublicPathPrefix = c.getString("api-public-path-prefix")
+      )
+    }
+  }
+
+}

--- a/http4sroutes/src/main/scala/pl/iterators/baklava/http4s/routes/BaklavaRoutes.scala
+++ b/http4sroutes/src/main/scala/pl/iterators/baklava/http4s/routes/BaklavaRoutes.scala
@@ -66,6 +66,11 @@ object BaklavaRoutes {
     case GET -> Root / "swagger" =>
       val swaggerUiUrl = s"${withTrailingSlash(c.publicPathPrefix)}swagger-ui/$swaggerVersion/index.html"
       IO.fromEither(Uri.fromString(swaggerUiUrl)).flatMap(uri => SeeOther(Location(uri)))
+
+    case req @ GET -> "docs" /: rest =>
+      val relPath  = rest.segments.map(_.decoded()).mkString("/")
+      val filename = if (relPath.isEmpty) "index.html" else relPath
+      StaticFile.fromString(s"${c.fileSystemPath}/simple/$filename", Some(req)).getOrElseF(NotFound())
   }
 
   private def openApiFileContent(c: Config): String =

--- a/http4sroutes/src/main/scala/pl/iterators/baklava/http4s/routes/BaklavaRoutes.scala
+++ b/http4sroutes/src/main/scala/pl/iterators/baklava/http4s/routes/BaklavaRoutes.scala
@@ -1,21 +1,19 @@
 package pl.iterators.baklava.http4s.routes
 
-import cats.data.{Kleisli, OptionT}
+import cats.data.Kleisli
 import cats.effect.IO
 import io.swagger.v3.core.util.Yaml
 import io.swagger.v3.oas.models.servers.Server
 import io.swagger.v3.parser.OpenAPIV3Parser
 import org.http4s.*
 import org.http4s.dsl.io.*
-import org.http4s.headers.{Authorization, Location, `Content-Type`}
-import org.typelevel.ci.CIString
+import org.http4s.headers.{Location, `Content-Type`}
+import org.http4s.server.middleware.authentication.BasicAuth
 import org.webjars.WebJarAssetLocator
 
-import java.io.{ByteArrayOutputStream, InputStream}
-import java.util.Base64
 import scala.io.Source
 import scala.jdk.CollectionConverters.SeqHasAsJava
-import scala.util.{Failure, Success, Try}
+import scala.util.{Try, Using}
 
 object BaklavaRoutes {
 
@@ -34,10 +32,6 @@ object BaklavaRoutes {
       )
     )
 
-  /** slf4j logger used for server-side logging of request-handling failures. The route responses stay generic (no `e.getMessage` in the
-    * client body) so internal details — filesystem paths, parser errors — never leak to unauthenticated clients when basic auth is
-    * disabled.
-    */
   private val log: org.slf4j.Logger = org.slf4j.LoggerFactory.getLogger("pl.iterators.baklava.http4s.routes.BaklavaRoutes")
 
   /** Ensure a public-path prefix ends with exactly one trailing slash. The configured prefix is concatenated with fixed sub-paths
@@ -50,13 +44,17 @@ object BaklavaRoutes {
   def routes(config: com.typesafe.config.Config): HttpRoutes[IO] = {
     val internalConfig = Config(config)
     if (!internalConfig.enabled) HttpRoutes.empty[IO]
-    else {
-      val core = coreRoutes(internalConfig)
+    else
       (internalConfig.basicAuthUser, internalConfig.basicAuthPassword) match {
-        case (Some(user), Some(password)) => basicAuth(user, password)(core)
-        case _                            => core
+        case (Some(user), Some(password)) =>
+          // `BasicAuth` expects `AuthedRoutes`; adapt the plain routes by ignoring the auth info.
+          val validate: BasicAuth.BasicAuthenticator[IO, Unit] = creds =>
+            IO.pure(if (creds.username == user && creds.password == password) Some(()) else None)
+          val authed: AuthedRoutes[Unit, IO] = Kleisli(ar => coreRoutes(internalConfig).run(ar.req))
+          val middleware                     = BasicAuth[IO, Unit]("docs", validate)
+          middleware(authed)
+        case _ => coreRoutes(internalConfig)
       }
-    }
   }
 
   private def coreRoutes(c: Config): HttpRoutes[IO] = HttpRoutes.of[IO] {
@@ -77,8 +75,15 @@ object BaklavaRoutes {
     case GET -> Root / "swagger-ui" / version / "swagger-initializer.js" if version == swaggerVersion =>
       Ok(swaggerInitializerContent(c)).map(_.withContentType(`Content-Type`(MediaType.application.javascript)))
 
-    case GET -> "swagger-ui" /: rest =>
-      serveSwaggerAsset(rest.segments.map(_.decoded()).mkString("/"))
+    case req @ GET -> "swagger-ui" /: rest =>
+      // Use http4s's built-in `StaticFile.fromResource` — it handles classpath lookup on a
+      // blocking dispatcher, streams the body, sets a content-type from the extension, and
+      // turns a missing resource into `OptionT.none` (translated to 404 here).
+      val relPath = rest.segments.map(_.decoded()).mkString("/")
+      Try((new WebJarAssetLocator).getFullPath("swagger-ui", relPath)).toOption match {
+        case Some(fullPath) => StaticFile.fromResource(fullPath, Some(req)).getOrElseF(NotFound())
+        case None           => NotFound()
+      }
 
     case GET -> Root / "swagger" =>
       val swaggerUiUrl = s"${withTrailingSlash(c.publicPathPrefix)}swagger-ui/$swaggerVersion/index.html"
@@ -90,40 +95,18 @@ object BaklavaRoutes {
       }
   }
 
-  private def basicAuth(expectedUser: String, expectedPassword: String)(routes: HttpRoutes[IO]): HttpRoutes[IO] = {
-    val unauthorized: Response[IO] =
-      Response[IO](Status.Unauthorized).putHeaders(Header.Raw(CIString("WWW-Authenticate"), "Basic realm=\"docs\""))
-    Kleisli { (req: Request[IO]) =>
-      val ok = req.headers.get[Authorization].exists {
-        case Authorization(Credentials.Token(AuthScheme.Basic, token)) =>
-          Try(new String(Base64.getDecoder.decode(token), "UTF-8")).toOption.exists { decoded =>
-            decoded.split(":", 2) match {
-              case Array(u, p) => u == expectedUser && p == expectedPassword
-              case _           => false
-            }
-          }
-        case _ => false
-      }
-      if (ok) routes(req) else OptionT.pure[IO](unauthorized)
-    }
-  }
-
   // Swagger UI's yaml includes a `servers:` block that Swagger UI uses as the API base URL. We
   // parse, replace with the user-configured `api-public-path-prefix`, then re-serialize so the
   // rendered docs can call the real API directly.
-  private def openApiFileContent(c: Config): String = {
-    val source = Source.fromFile(s"${c.fileSystemPath}/openapi/openapi.yml")
-    try {
+  private def openApiFileContent(c: Config): String =
+    Using.resource(Source.fromFile(s"${c.fileSystemPath}/openapi/openapi.yml")) { source =>
       val parser  = new OpenAPIV3Parser
       val openApi = parser.readContents(source.mkString, null, null).getOpenAPI
       val server  = new Server()
       server.setUrl(c.apiPublicPathPrefix)
       openApi.setServers(List(server).asJava)
       Yaml.pretty(openApi)
-    } finally {
-      source.close()
     }
-  }
 
   private def swaggerInitializerContent(c: Config): String = {
     val swaggerDocsUrl = s"${withTrailingSlash(c.publicPathPrefix)}openapi"
@@ -144,52 +127,6 @@ object BaklavaRoutes {
        |  });
        |};
        |""".stripMargin
-  }
-
-  /** Serve a file from the `swagger-ui` webjar. Returns the file bytes with a best-effort content type guessed from the extension (falls
-    * back to `application/octet-stream`). Missing files yield a 404. Classpath reads + byte copying happen inside `IO.blocking` so they
-    * don't starve the compute pool under load.
-    */
-  private def serveSwaggerAsset(relPath: String): IO[Response[IO]] = {
-    Try((new WebJarAssetLocator).getFullPath("swagger-ui", relPath)) match {
-      case Success(fullPath) =>
-        IO.blocking(Option(getClass.getClassLoader.getResourceAsStream(fullPath))).flatMap {
-          case None     => NotFound()
-          case Some(is) =>
-            IO.blocking(readAllBytes(is)).guarantee(IO.blocking(is.close())).flatMap { bytes =>
-              val ct = mediaTypeFromExtension(relPath)
-              Ok(bytes).map(r => r.withContentType(`Content-Type`(ct)))
-            }
-        }
-      case Failure(_: IllegalArgumentException) => NotFound()
-      case Failure(e)                           =>
-        IO(log.warn(s"Failed to serve swagger-ui asset '$relPath'", e)) *> InternalServerError("Failed to serve swagger-ui asset")
-    }
-  }
-
-  // Simple copy-through using a fixed buffer. Avoids `InputStream.readAllBytes` which isn't
-  // visible in this build's compile-time stub despite being runtime-available on Java 11.
-  private def readAllBytes(is: InputStream): Array[Byte] = {
-    val out  = new ByteArrayOutputStream()
-    val buf  = new Array[Byte](8192)
-    var read = is.read(buf)
-    while (read != -1) {
-      out.write(buf, 0, read)
-      read = is.read(buf)
-    }
-    out.toByteArray
-  }
-
-  private def mediaTypeFromExtension(path: String): MediaType = {
-    val lower = path.toLowerCase(java.util.Locale.ROOT)
-    if (lower.endsWith(".html")) MediaType.text.html
-    else if (lower.endsWith(".css")) MediaType.text.css
-    else if (lower.endsWith(".js")) MediaType.application.javascript
-    else if (lower.endsWith(".json")) MediaType.application.json
-    else if (lower.endsWith(".png")) MediaType.image.png
-    else if (lower.endsWith(".svg")) MediaType.image.`svg+xml`
-    else if (lower.endsWith(".map")) MediaType.application.json
-    else MediaType.application.`octet-stream`
   }
 
   private case class Config(

--- a/http4sroutes/src/main/scala/pl/iterators/baklava/http4s/routes/BaklavaRoutes.scala
+++ b/http4sroutes/src/main/scala/pl/iterators/baklava/http4s/routes/BaklavaRoutes.scala
@@ -2,6 +2,7 @@ package pl.iterators.baklava.http4s.routes
 
 import cats.data.Kleisli
 import cats.effect.IO
+import com.typesafe.config.{Config => TypesafeConfig}
 import io.swagger.v3.core.util.Yaml
 import io.swagger.v3.oas.models.servers.Server
 import io.swagger.v3.parser.OpenAPIV3Parser
@@ -11,19 +12,13 @@ import org.http4s.headers.{Location, `Content-Type`}
 import org.http4s.server.middleware.authentication.BasicAuth
 import org.webjars.WebJarAssetLocator
 
+import java.io.FileNotFoundException
 import scala.io.Source
 import scala.jdk.CollectionConverters.SeqHasAsJava
 import scala.util.{Try, Using}
 
 object BaklavaRoutes {
 
-  /** The swagger-ui webjar version is the source of truth; we serve assets at `/swagger-ui/<version>/...` so the version must match the
-    * resources actually on the classpath. Read the webjar's own metadata rather than hard-coding it here — otherwise a webjar upgrade in
-    * build.sbt silently breaks these routes with 404s.
-    *
-    * If the webjar is missing from the classpath (the user didn't add the dependency) we fail fast — letting the route respond with a
-    * confusing 404 at request time would be worse than a clear startup error.
-    */
   private lazy val swaggerVersion: String =
     Option(new WebJarAssetLocator().getWebJars.get("swagger-ui")).getOrElse(
       throw new IllegalStateException(
@@ -32,20 +27,15 @@ object BaklavaRoutes {
       )
     )
 
-  /** Ensure a public-path prefix ends with exactly one trailing slash. The configured prefix is concatenated with fixed sub-paths
-    * (`"swagger-ui/<v>/index.html"`, `"openapi"`); missing the separator silently produced `/api-docsswagger-ui/...` for
-    * `public-path-prefix = "/api-docs"`.
-    */
   private def withTrailingSlash(prefix: String): String =
     if (prefix.endsWith("/")) prefix else prefix + "/"
 
-  def routes(config: com.typesafe.config.Config): HttpRoutes[IO] = {
+  def routes(config: TypesafeConfig): HttpRoutes[IO] = {
     val internalConfig = Config(config)
     if (!internalConfig.enabled) HttpRoutes.empty[IO]
     else
       (internalConfig.basicAuthUser, internalConfig.basicAuthPassword) match {
         case (Some(user), Some(password)) =>
-          // `BasicAuth` expects `AuthedRoutes`; adapt the plain routes by ignoring the auth info.
           val validate: BasicAuth.BasicAuthenticator[IO, Unit] = creds =>
             IO.pure(if (creds.username == user && creds.password == password) Some(()) else None)
           val authed: AuthedRoutes[Unit, IO] = Kleisli(ar => coreRoutes(internalConfig).run(ar.req))
@@ -57,13 +47,9 @@ object BaklavaRoutes {
 
   private def coreRoutes(c: Config): HttpRoutes[IO] = HttpRoutes.of[IO] {
     case GET -> Root / "openapi" =>
-      // `openApiFileContent` does blocking file I/O + YAML parsing; wrap in IO.blocking so
-      // failures land inside the effect. A missing file gets a helpful 404; anything else
-      // propagates so the caller's own error middleware (`ErrorAction.log`, etc.) can decide
-      // how to log/respond — the routes module shouldn't pick a logging backend.
       IO.blocking(openApiFileContent(c))
         .flatMap(content => Ok(content).map(_.withContentType(`Content-Type`(MediaType.text.yaml))))
-        .recoverWith { case _: java.io.FileNotFoundException =>
+        .recoverWith { case _: FileNotFoundException =>
           NotFound("openapi document not available — run `sbt test` first to generate it")
         }
 
@@ -71,9 +57,6 @@ object BaklavaRoutes {
       Ok(swaggerInitializerContent(c)).map(_.withContentType(`Content-Type`(MediaType.application.javascript)))
 
     case req @ GET -> "swagger-ui" /: rest =>
-      // Use http4s's built-in `StaticFile.fromResource` — it handles classpath lookup on a
-      // blocking dispatcher, streams the body, sets a content-type from the extension, and
-      // turns a missing resource into `OptionT.none` (translated to 404 here).
       val relPath = rest.segments.map(_.decoded()).mkString("/")
       Try((new WebJarAssetLocator).getFullPath("swagger-ui", relPath)).toOption match {
         case Some(fullPath) => StaticFile.fromResource(fullPath, Some(req)).getOrElseF(NotFound())
@@ -85,9 +68,6 @@ object BaklavaRoutes {
       IO.fromEither(Uri.fromString(swaggerUiUrl)).flatMap(uri => SeeOther(Location(uri)))
   }
 
-  // Swagger UI's yaml includes a `servers:` block that Swagger UI uses as the API base URL. We
-  // parse, replace with the user-configured `api-public-path-prefix`, then re-serialize so the
-  // rendered docs can call the real API directly.
   private def openApiFileContent(c: Config): String =
     Using.resource(Source.fromFile(s"${c.fileSystemPath}/openapi/openapi.yml")) { source =>
       val parser  = new OpenAPIV3Parser
@@ -129,7 +109,7 @@ object BaklavaRoutes {
   )
 
   private object Config {
-    def apply(config: com.typesafe.config.Config): Config = {
+    def apply(config: TypesafeConfig): Config = {
       val c = config.getConfig("baklava-routes")
       Config(
         enabled = c.getBoolean("enabled"),

--- a/http4sroutes/src/main/scala/pl/iterators/baklava/http4s/routes/BaklavaRoutes.scala
+++ b/http4sroutes/src/main/scala/pl/iterators/baklava/http4s/routes/BaklavaRoutes.scala
@@ -32,8 +32,6 @@ object BaklavaRoutes {
       )
     )
 
-  private val log: org.slf4j.Logger = org.slf4j.LoggerFactory.getLogger("pl.iterators.baklava.http4s.routes.BaklavaRoutes")
-
   /** Ensure a public-path prefix ends with exactly one trailing slash. The configured prefix is concatenated with fixed sub-paths
     * (`"swagger-ui/<v>/index.html"`, `"openapi"`); missing the separator silently produced `/api-docsswagger-ui/...` for
     * `public-path-prefix = "/api-docs"`.
@@ -60,16 +58,13 @@ object BaklavaRoutes {
   private def coreRoutes(c: Config): HttpRoutes[IO] = HttpRoutes.of[IO] {
     case GET -> Root / "openapi" =>
       // `openApiFileContent` does blocking file I/O + YAML parsing; wrap in IO.blocking so
-      // exceptions land inside the effect (a missing or malformed file becomes a 404/500, not a
-      // crashed request handler). Error bodies are generic; the real cause goes to the log only.
+      // failures land inside the effect. A missing file gets a helpful 404; anything else
+      // propagates so the caller's own error middleware (`ErrorAction.log`, etc.) can decide
+      // how to log/respond — the routes module shouldn't pick a logging backend.
       IO.blocking(openApiFileContent(c))
         .flatMap(content => Ok(content).map(_.withContentType(`Content-Type`(MediaType.text.yaml))))
-        .recoverWith {
-          case _: java.io.FileNotFoundException =>
-            NotFound("openapi document not available — run `sbt test` first to generate it")
-          case e: Throwable =>
-            IO(log.warn(s"Failed to serve openapi document from ${c.fileSystemPath}/openapi/openapi.yml", e)) *>
-            InternalServerError("Failed to serve openapi document")
+        .recoverWith { case _: java.io.FileNotFoundException =>
+          NotFound("openapi document not available — run `sbt test` first to generate it")
         }
 
     case GET -> Root / "swagger-ui" / version / "swagger-initializer.js" if version == swaggerVersion =>
@@ -87,12 +82,7 @@ object BaklavaRoutes {
 
     case GET -> Root / "swagger" =>
       val swaggerUiUrl = s"${withTrailingSlash(c.publicPathPrefix)}swagger-ui/$swaggerVersion/index.html"
-      Uri.fromString(swaggerUiUrl) match {
-        case Right(uri) => SeeOther(Location(uri))
-        case Left(_)    =>
-          IO(log.warn(s"Invalid swagger-ui URL constructed from publicPathPrefix='${c.publicPathPrefix}': $swaggerUiUrl")) *>
-          InternalServerError("Misconfigured swagger-ui URL")
-      }
+      IO.fromEither(Uri.fromString(swaggerUiUrl)).flatMap(uri => SeeOther(Location(uri)))
   }
 
   // Swagger UI's yaml includes a `servers:` block that Swagger UI uses as the API base URL. We


### PR DESCRIPTION
## Summary

Closes #54. Adds a new `baklava-http4s-routes` module that mirrors the existing `baklava-pekko-http-routes` for http4s, so SwaggerUI can now be served from an http4s app.

New artifact: `pl.iterators::baklava-http4s-routes`

- \`pl.iterators.baklava.http4s.routes.BaklavaRoutes.routes(config)\` returns an \`HttpRoutes[IO]\`
- Exposes the same three endpoints as the pekko-http version under the same paths:
  - \`GET /openapi\` → serves \`target/baklava/openapi/openapi.yml\`, with its \`servers\` overridden to the configured \`api-public-path-prefix\` so SwaggerUI "Try it out" hits the real API
  - \`GET /swagger-ui/<version>/swagger-initializer.js\` → generated bootstrap pointing at \`/openapi\`
  - \`GET /swagger-ui/<version>/...\` → static assets from the \`swagger-ui\` webjar on the classpath
  - \`GET /swagger\` → 303 redirect to \`/swagger-ui/<version>/index.html\`
- Same \`baklava-routes { ... }\` config keys (\`enabled\`, \`basic-auth-user\`, \`basic-auth-password\`, \`filesystem-path\`, \`public-path-prefix\`, \`api-public-path-prefix\`) and same environment-variable overrides as the pekko-http version.
- HTTP Basic auth protection via a minimal inline middleware (decodes the header, compares constants, emits \`401 WWW-Authenticate: Basic realm="docs"\` on failure).

## Docs

- \`docs/installation.md\`: SwaggerUI section no longer says "Pekko HTTP only"; added \`baklava-http4s-routes\` dependency and extended the HTTP4s example config.
- \`docs/http4s.md\`: new "Serving Open API and Swagger UI" section mirroring the pekko-http doc with an http4s + Ember server example.

## Test plan

- [x] \`sbt 'project http4sroutes' '++ 2.13' compile\` — clean
- [x] \`sbt 'project http4sroutes' '++ 3' compile\` — clean
- [x] \`CI=true sbt '++ 2.13' compile\` — all 15 projects clean
- [x] \`CI=true sbt '++ 3' compile\` — all 15 projects clean