### PR TITLE
feat: honor declared Content-Type for file uploads (#52)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,6 @@ website/yarn.lock
 website/node_modules
 website/.docusaurus
 website/.cache-loader
+
+# Local-only design/spec docs (per repo convention, kept out of VCS)
+docs/superpowers/

--- a/docs/http4s.md
+++ b/docs/http4s.md
@@ -228,8 +228,7 @@ class GetUsersUserIdRouteSpec extends BaseRouteSpec {
 To document a binary upload (e.g. an avatar PNG), declare `Content-Type` among the request headers and pass the matching value on the `onRequest(...)` call — the http4s adapter honors that declared value, overriding the content type the `EntityEncoder` bakes into the request.
 
 ```scala
-import org.http4s.{EntityEncoder, MediaType}
-import org.http4s.headers.`Content-Type`
+import java.nio.charset.StandardCharsets
 
 class PutUsersUserIdAvatarSpec extends BaseRouteSpec {
 
@@ -247,7 +246,7 @@ class PutUsersUserIdAvatarSpec extends BaseRouteSpec {
       onRequest(
         pathParameters = 1L,
         headers = "image/png",
-        body = "\u0089PNG\r\n...".getBytes("UTF-8")
+        body = "\u0089PNG\r\n...".getBytes(StandardCharsets.UTF_8)
       ).respondsWith[EmptyBody](NoContent, description = "User avatar updated successfully")
         .assert { ctx =>
           val response = ctx.performRequest(allRoutes)
@@ -259,3 +258,25 @@ class PutUsersUserIdAvatarSpec extends BaseRouteSpec {
 ```
 
 The generator renders this as `requestBody.content["image/png"]` with a `schema: { type: string, format: binary }` in OpenAPI, and the test request goes out with `Content-Type: image/png` on the wire so server routes that pattern-match on it run under the right conditions.
+
+### Downloads
+
+Binary downloads work with `respondsWith[Array[Byte]]`. http4s ships entity decoders for byte arrays; no extra setup needed. The test stub's response must carry the right `Content-Type` — whatever the server serves becomes the OpenAPI `responseContentType`:
+
+```scala
+supports(
+  GET,
+  pathParameters = p[Long]("userId"),
+  description = "Download the user's avatar as raw image bytes",
+  tags = List("Users")
+)(
+  onRequest(pathParameters = 1L)
+    .respondsWith[Array[Byte]](Ok, description = "Avatar bytes")
+    .assert { ctx =>
+      val response = ctx.performRequest(allRoutes)
+      response.status.status should beEqualTo(Ok.status)
+    }
+)
+```
+
+`Schema[Array[Byte]]` is a default on the classpath, so the generated OpenAPI renders `responses[code].content["<content-type>"].schema = { type: string, format: binary }`.

--- a/docs/http4s.md
+++ b/docs/http4s.md
@@ -222,3 +222,40 @@ class GetUsersUserIdRouteSpec extends BaseRouteSpec {
 
 }
 ```
+
+## Documenting file uploads
+
+To document a binary upload (e.g. an avatar PNG), declare `Content-Type` among the request headers and pass the matching value on the `onRequest(...)` call — the http4s adapter honors that declared value, overriding the content type the `EntityEncoder` bakes into the request.
+
+```scala
+import org.http4s.{EntityEncoder, MediaType}
+import org.http4s.headers.`Content-Type`
+
+class PutUsersUserIdAvatarSpec extends BaseRouteSpec {
+
+  // Byte-array entity encoders ship with http4s; no extra setup needed.
+
+  path(path = "/users/{userId}/avatar")(
+    supports(
+      PUT,
+      pathParameters = p[Long]("userId"),
+      headers = h[String]("Content-Type"),
+      description = "Upload or update a user's avatar",
+      summary = "Upload or update a user's avatar",
+      tags = List("Users")
+    )(
+      onRequest(
+        pathParameters = 1L,
+        headers = "image/png",
+        body = "\u0089PNG\r\n...".getBytes("UTF-8")
+      ).respondsWith[EmptyBody](NoContent, description = "User avatar updated successfully")
+        .assert { ctx =>
+          val response = ctx.performRequest(allRoutes)
+          response.status.status should beEqualTo(NoContent.status)
+        }
+    )
+  )
+}
+```
+
+The generator renders this as `requestBody.content["image/png"]` with a `schema: { type: string, format: binary }` in OpenAPI, and the test request goes out with `Content-Type: image/png` on the wire so server routes that pattern-match on it run under the right conditions.

--- a/docs/http4s.md
+++ b/docs/http4s.md
@@ -250,7 +250,7 @@ class PutUsersUserIdAvatarSpec extends BaseRouteSpec {
       ).respondsWith[EmptyBody](NoContent, description = "User avatar updated successfully")
         .assert { ctx =>
           val response = ctx.performRequest(allRoutes)
-          response.status.status should beEqualTo(NoContent.status)
+          response.status.code shouldBe 204
         }
     )
   )
@@ -274,7 +274,7 @@ supports(
     .respondsWith[Array[Byte]](Ok, description = "Avatar bytes")
     .assert { ctx =>
       val response = ctx.performRequest(allRoutes)
-      response.status.status should beEqualTo(Ok.status)
+      response.status.code shouldBe 200
     }
 )
 ```

--- a/docs/pekko-http.md
+++ b/docs/pekko-http.md
@@ -244,6 +244,43 @@ class GetUsersUserIdRouteSpec extends BaseRouteSpec {
 }
 ```
 
+## Documenting file uploads
+
+To document a binary upload (e.g. an avatar PNG), declare `Content-Type` among the request headers and pass the matching value on the `onRequest(...)` call — the pekko-http adapter honors that declared value, overriding the content type the implicit marshaller would otherwise bake into the request. Use `Array[Byte]` for the body so a byte-array marshaller is in scope.
+
+```scala
+import org.apache.pekko.http.scaladsl.marshalling.{PredefinedToEntityMarshallers, ToEntityMarshaller}
+
+class PutUsersUserIdAvatarRouteSpec extends BaseRouteSpec {
+
+  implicit val byteArrayMarshaller: ToEntityMarshaller[Array[Byte]] =
+    PredefinedToEntityMarshallers.ByteArrayMarshaller
+
+  path(path = "/users/{userId}/avatar")(
+    supports(
+      PUT,
+      pathParameters = p[Long]("userId"),
+      headers = h[String]("Content-Type"),
+      description = "Upload or update a user's avatar",
+      summary = "Upload or update a user's avatar",
+      tags = List("Users")
+    )(
+      onRequest(
+        pathParameters = 1L,
+        headers = "image/png",
+        body = "\u0089PNG\r\n...".getBytes("UTF-8")
+      ).respondsWith[EmptyBody](NoContent, description = "User avatar updated successfully")
+        .assert { ctx =>
+          val response = ctx.performRequest(allRoutes)
+          response.status.status should beEqualTo(NoContent.status)
+        }
+    )
+  )
+}
+```
+
+The generator detects that `Content-Type` is a request-body media type rather than a free header, so the generated OpenAPI spec emits it as `requestBody.content["image/png"]` with a `schema: { type: string, format: binary }` instead of rendering it as a header parameter. The declared value is also used as the actual wire Content-Type of the test request, so server routes that pattern-match on it (e.g. `entity(as[Array[Byte]])`) run under the right conditions.
+
 ## Serving Open API and Swagger UI
 
 Adding `baklava-pekko-http-routes` dependency to your project you can easily serve Open API and Swagger UI:

--- a/docs/pekko-http.md
+++ b/docs/pekko-http.md
@@ -251,6 +251,8 @@ To document a binary upload (e.g. an avatar PNG), declare `Content-Type` among t
 ```scala
 import org.apache.pekko.http.scaladsl.marshalling.{PredefinedToEntityMarshallers, ToEntityMarshaller}
 
+import java.nio.charset.StandardCharsets
+
 class PutUsersUserIdAvatarRouteSpec extends BaseRouteSpec {
 
   implicit val byteArrayMarshaller: ToEntityMarshaller[Array[Byte]] =
@@ -268,7 +270,7 @@ class PutUsersUserIdAvatarRouteSpec extends BaseRouteSpec {
       onRequest(
         pathParameters = 1L,
         headers = "image/png",
-        body = "\u0089PNG\r\n...".getBytes("UTF-8")
+        body = "\u0089PNG\r\n...".getBytes(StandardCharsets.UTF_8)
       ).respondsWith[EmptyBody](NoContent, description = "User avatar updated successfully")
         .assert { ctx =>
           val response = ctx.performRequest(allRoutes)
@@ -280,6 +282,33 @@ class PutUsersUserIdAvatarRouteSpec extends BaseRouteSpec {
 ```
 
 The generator detects that `Content-Type` is a request-body media type rather than a free header, so the generated OpenAPI spec emits it as `requestBody.content["image/png"]` with a `schema: { type: string, format: binary }` instead of rendering it as a header parameter. The declared value is also used as the actual wire Content-Type of the test request, so server routes that pattern-match on it (e.g. `entity(as[Array[Byte]])`) run under the right conditions.
+
+### Downloads
+
+Binary downloads work with `respondsWith[Array[Byte]]`. The pekko-http test needs a byte-array entity unmarshaller in scope; the test stub's response must carry the right `Content-Type` — whatever the server serves becomes the OpenAPI `responseContentType`:
+
+```scala
+import org.apache.pekko.http.scaladsl.unmarshalling.{FromEntityUnmarshaller, PredefinedFromEntityUnmarshallers}
+
+implicit val byteArrayUnmarshaller: FromEntityUnmarshaller[Array[Byte]] =
+  PredefinedFromEntityUnmarshallers.byteArrayUnmarshaller
+
+supports(
+  GET,
+  pathParameters = p[Long]("userId"),
+  description = "Download the user's avatar as raw image bytes",
+  tags = List("Users")
+)(
+  onRequest(pathParameters = 1L)
+    .respondsWith[Array[Byte]](OK, description = "Avatar bytes")
+    .assert { ctx =>
+      val response = ctx.performRequest(allRoutes)
+      response.status.status should beEqualTo(OK.status)
+    }
+)
+```
+
+`Schema[Array[Byte]]` is a default on the classpath, so the generated OpenAPI renders `responses[code].content["<content-type>"].schema = { type: string, format: binary }`.
 
 ## Serving Open API and Swagger UI
 

--- a/docs/pekko-http.md
+++ b/docs/pekko-http.md
@@ -274,7 +274,7 @@ class PutUsersUserIdAvatarRouteSpec extends BaseRouteSpec {
       ).respondsWith[EmptyBody](NoContent, description = "User avatar updated successfully")
         .assert { ctx =>
           val response = ctx.performRequest(allRoutes)
-          response.status.status should beEqualTo(NoContent.status)
+          response.status.code shouldBe 204
         }
     )
   )
@@ -303,7 +303,7 @@ supports(
     .respondsWith[Array[Byte]](OK, description = "Avatar bytes")
     .assert { ctx =>
       val response = ctx.performRequest(allRoutes)
-      response.status.status should beEqualTo(OK.status)
+      response.status.code shouldBe 200
     }
 )
 ```

--- a/http4s/src/main/scala/pl/iterators/baklava/http4s/BaklavaHttp4s.scala
+++ b/http4s/src/main/scala/pl/iterators/baklava/http4s/BaklavaHttp4s.scala
@@ -160,13 +160,14 @@ trait BaklavaHttp4s[TestFrameworkFragmentType, TestFrameworkFragmentsType, TestF
   )(implicit
       requestBody: BaklavaHttp4s.ToEntityMarshaller[RequestBody]
   ): HttpRequest = {
-    // If the test declared a `Content-Type` header, use its value to override the content type
-    // that the `EntityEncoder` bakes in. http4s stores Content-Type on the entity (not a free
-    // header), so we pull it out of the header list before attaching and then re-set it with
-    // `.withContentType` on the resulting request. This is what lets tests document non-JSON
-    // uploads via `h[String]("Content-Type") = "image/png"`.
-    val (contentTypeOverride, otherHeaders) = splitContentType(ctx.headers)
-    val base                                = Request[IO](
+    // If the test declared a parseable `Content-Type` header, use its value to override the
+    // content type that the `EntityEncoder` bakes in. http4s stores Content-Type on the entity
+    // (not a free header), so we pull it out of the header list before attaching and then re-set
+    // it with `.withContentType` on the resulting request. We only strip after parsing succeeds
+    // so an invalid value isn't silently swallowed.
+    val parsedOverride = findContentTypeOverride(ctx.headers)
+    val otherHeaders   = if (parsedOverride.isDefined) dropContentType(ctx.headers) else ctx.headers
+    val base           = Request[IO](
       method = baklavaHttpMethodToHttpMethod(ctx.method.get),
       uri = Uri.fromString(ctx.path).fold(throw _, identity),
       headers = baklavaHeadersToHttpHeaders(otherHeaders)
@@ -175,16 +176,27 @@ trait BaklavaHttp4s[TestFrameworkFragmentType, TestFrameworkFragmentsType, TestF
       case Some(body) => base.withEntity(body)
       case None       => base
     }
-    contentTypeOverride.flatMap(v => headers.`Content-Type`.parse(v).toOption) match {
-      case Some(ct) => withBody.withContentType(ct)
-      case None     => withBody
+    parsedOverride.fold(withBody)(ct => withBody.withContentType(ct))
+  }
+
+  /** Find a `Content-Type` in the declared headers (case-insensitive) and return the parsed http4s `Content-Type`. Fails fast on multiple
+    * declarations rather than silently picking one, since that's always a test-authoring bug.
+    */
+  private def findContentTypeOverride(hs: Seq[SttpHeader]): Option[headers.`Content-Type`] = {
+    val cts = hs.filter(_.name.toLowerCase(java.util.Locale.ROOT) == "content-type")
+    cts match {
+      case Seq()       => None
+      case Seq(single) => headers.`Content-Type`.parse(single.value).toOption
+      case multiple    =>
+        throw new IllegalArgumentException(
+          s"Multiple Content-Type headers declared on one request: [${multiple.map(_.value).mkString(", ")}]. " +
+            "Declare a single Content-Type or none at all."
+        )
     }
   }
 
-  private def splitContentType(headers: Seq[SttpHeader]): (Option[String], Seq[SttpHeader]) = {
-    val (ct, rest) = headers.partition(_.name.toLowerCase(java.util.Locale.ROOT) == "content-type")
-    (ct.headOption.map(_.value), rest)
-  }
+  private def dropContentType(hs: Seq[SttpHeader]): Seq[SttpHeader] =
+    hs.filterNot(_.name.toLowerCase(java.util.Locale.ROOT) == "content-type")
 
   implicit val runtime: IORuntime
 }

--- a/http4s/src/main/scala/pl/iterators/baklava/http4s/BaklavaHttp4s.scala
+++ b/http4s/src/main/scala/pl/iterators/baklava/http4s/BaklavaHttp4s.scala
@@ -160,20 +160,30 @@ trait BaklavaHttp4s[TestFrameworkFragmentType, TestFrameworkFragmentsType, TestF
   )(implicit
       requestBody: BaklavaHttp4s.ToEntityMarshaller[RequestBody]
   ): HttpRequest = {
-    ctx.body match {
-      case Some(body) =>
-        Request[IO](
-          method = baklavaHttpMethodToHttpMethod(ctx.method.get),
-          uri = Uri.fromString(ctx.path).fold(throw _, identity),
-          headers = baklavaHeadersToHttpHeaders(ctx.headers)
-        ).withEntity(body)
-      case None =>
-        Request[IO](
-          method = baklavaHttpMethodToHttpMethod(ctx.method.get),
-          uri = Uri.fromString(ctx.path).fold(throw _, identity),
-          headers = baklavaHeadersToHttpHeaders(ctx.headers)
-        )
+    // If the test declared a `Content-Type` header, use its value to override the content type
+    // that the `EntityEncoder` bakes in. http4s stores Content-Type on the entity (not a free
+    // header), so we pull it out of the header list before attaching and then re-set it with
+    // `.withContentType` on the resulting request. This is what lets tests document non-JSON
+    // uploads via `h[String]("Content-Type") = "image/png"`.
+    val (contentTypeOverride, otherHeaders) = splitContentType(ctx.headers)
+    val base                                = Request[IO](
+      method = baklavaHttpMethodToHttpMethod(ctx.method.get),
+      uri = Uri.fromString(ctx.path).fold(throw _, identity),
+      headers = baklavaHeadersToHttpHeaders(otherHeaders)
+    )
+    val withBody = ctx.body match {
+      case Some(body) => base.withEntity(body)
+      case None       => base
     }
+    contentTypeOverride.flatMap(v => headers.`Content-Type`.parse(v).toOption) match {
+      case Some(ct) => withBody.withContentType(ct)
+      case None     => withBody
+    }
+  }
+
+  private def splitContentType(headers: Seq[SttpHeader]): (Option[String], Seq[SttpHeader]) = {
+    val (ct, rest) = headers.partition(_.name.toLowerCase(java.util.Locale.ROOT) == "content-type")
+    (ct.headOption.map(_.value), rest)
   }
 
   implicit val runtime: IORuntime

--- a/http4s/src/main/scala/pl/iterators/baklava/http4s/BaklavaHttp4s.scala
+++ b/http4s/src/main/scala/pl/iterators/baklava/http4s/BaklavaHttp4s.scala
@@ -179,15 +179,22 @@ trait BaklavaHttp4s[TestFrameworkFragmentType, TestFrameworkFragmentsType, TestF
     parsedOverride.fold(withBody)(ct => withBody.withContentType(ct))
   }
 
-  /** Find a `Content-Type` in the declared headers (case-insensitive) and return the parsed http4s `Content-Type`. Fails fast on multiple
-    * declarations rather than silently picking one, since that's always a test-authoring bug.
+  /** Find a `Content-Type` in the declared headers (case-insensitive) and return the parsed http4s `Content-Type`. Throws on either
+    * multiple declarations or an unparseable value — both are always test-authoring bugs.
     */
   private def findContentTypeOverride(hs: Seq[SttpHeader]): Option[headers.`Content-Type`] = {
     val cts = hs.filter(_.name.toLowerCase(java.util.Locale.ROOT) == "content-type")
     cts match {
       case Seq()       => None
-      case Seq(single) => headers.`Content-Type`.parse(single.value).toOption
-      case multiple    =>
+      case Seq(single) =>
+        headers.`Content-Type`.parse(single.value) match {
+          case Right(ct)   => Some(ct)
+          case Left(error) =>
+            throw new IllegalArgumentException(
+              s"Could not parse declared Content-Type header '${single.value}': ${error.message}"
+            )
+        }
+      case multiple =>
         throw new IllegalArgumentException(
           s"Multiple Content-Type headers declared on one request: [${multiple.map(_.value).mkString(", ")}]. " +
             "Declare a single Content-Type or none at all."

--- a/openapi/src/test/resources/gold/openapi/openapi.yml
+++ b/openapi/src/test/resources/gold/openapi/openapi.yml
@@ -967,6 +967,38 @@ paths:
           description: User deleted
       security:
       - bearerAuth: []
+  /users/{userId}/avatar:
+    summary: Avatar
+    description: Raw avatar upload
+    put:
+      tags:
+      - Users
+      summary: Upload avatar
+      description: Upload or replace the user's avatar image
+      operationId: uploadAvatar
+      parameters:
+      - name: userId
+        in: path
+        description: The user's UUID
+        required: true
+        schema:
+          type: string
+          format: uuid
+        example: 00000000-0000-0000-0000-000000000001
+      requestBody:
+        content:
+          image/png:
+            schema:
+              type: string
+              format: binary
+            examples:
+              Avatar uploaded:
+                value: fake png bytes
+      responses:
+        "204":
+          description: Avatar uploaded
+      security:
+      - bearerAuth: []
   /webhooks:
     summary: Webhooks
     description: Inbound webhooks

--- a/openapi/src/test/resources/gold/openapi/openapi.yml
+++ b/openapi/src/test/resources/gold/openapi/openapi.yml
@@ -970,6 +970,34 @@ paths:
   /users/{userId}/avatar:
     summary: Avatar
     description: Raw avatar upload
+    get:
+      tags:
+      - Users
+      summary: Download avatar
+      description: Download the user's avatar as raw image bytes
+      operationId: downloadAvatar
+      parameters:
+      - name: userId
+        in: path
+        description: The user's UUID
+        required: true
+        schema:
+          type: string
+          format: uuid
+        example: 00000000-0000-0000-0000-000000000001
+      responses:
+        "200":
+          description: Avatar bytes
+          content:
+            image/png:
+              schema:
+                type: string
+                format: binary
+              examples:
+                Avatar bytes:
+                  value: fake png bytes
+      security:
+      - bearerAuth: []
     put:
       tags:
       - Users

--- a/openapi/src/test/resources/gold/simple/GET__users___userId___avatar-82197600.html
+++ b/openapi/src/test/resources/gold/simple/GET__users___userId___avatar-82197600.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html><html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1"><title>API Documentation</title><style>
+<!DOCTYPE html><html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1"><title>GET /users/{userId}/avatar</title><style>
   *, *::before, *::after { box-sizing: border-box; }
   body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif; margin: 0; padding: 20px 40px; background: #f8f9fa; color: #1a1a2e; line-height: 1.5; }
   h1 { font-size: 1.6rem; font-weight: 600; margin: 0 0 20px; color: #16213e; }
@@ -35,20 +35,47 @@
   .copy-btn:hover { background: #0d6efd; }
   .copy-btn:active { background: #0a58ca; }
 </style></head><body>
-<h1>API Documentation</h1>
-<section class="tag-group"><h2 class="tag-heading">Auth</h2><ul class="endpoint-list"><li><a href="POST__auth_login-3b67d231.html"><span class="method method-POST">POST</span> <span class="path">/auth/login</span></a></li>
-<li><a href="GET__me-2647d21d.html"><span class="method method-GET">GET</span> <span class="path">/me</span></a></li></ul></section>
-<section class="tag-group"><h2 class="tag-heading">Projects</h2><ul class="endpoint-list"><li><a href="GET__projects-9a7aa53f.html"><span class="method method-GET">GET</span> <span class="path">/projects</span></a></li>
-<li><a href="POST__projects-0f98e629.html"><span class="method method-POST">POST</span> <span class="path">/projects</span></a></li>
-<li><a href="PATCH__projects___projectId__-fc9e4246.html"><span class="method method-PATCH">PATCH</span> <span class="path">/projects/{projectId}</span></a></li></ul></section>
-<section class="tag-group"><h2 class="tag-heading">System</h2><ul class="endpoint-list"><li><a href="GET__health-334cfc61.html"><span class="method method-GET">GET</span> <span class="path">/health</span></a></li></ul></section>
-<section class="tag-group"><h2 class="tag-heading">Tasks</h2><ul class="endpoint-list"><li><a href="GET__projects___projectId___tasks-b0b82093.html"><span class="method method-GET">GET</span> <span class="path">/projects/{projectId}/tasks</span></a></li>
-<li><a href="POST__projects___projectId___tasks-f083bafd.html"><span class="method method-POST">POST</span> <span class="path">/projects/{projectId}/tasks</span></a></li></ul></section>
-<section class="tag-group"><h2 class="tag-heading">Users</h2><ul class="endpoint-list"><li><a href="GET__users-c054bf63.html"><span class="method method-GET">GET</span> <span class="path">/users</span></a></li>
-<li><a href="DELETE__users___userId__-cf0347bd.html"><span class="method method-DELETE">DELETE</span> <span class="path">/users/{userId}</span></a></li>
-<li><a href="GET__users___userId__-baf46b48.html"><span class="method method-GET">GET</span> <span class="path">/users/{userId}</span></a></li>
-<li><a href="PUT__users___userId__-3f0ffd01.html"><span class="method method-PUT">PUT</span> <span class="path">/users/{userId}</span></a></li>
-<li><a href="GET__users___userId___avatar-82197600.html"><span class="method method-GET">GET</span> <span class="path">/users/{userId}/avatar</span></a></li>
-<li><a href="PUT__users___userId___avatar-d5c23227.html"><span class="method method-PUT">PUT</span> <span class="path">/users/{userId}/avatar</span></a></li></ul></section>
-<section class="tag-group"><h2 class="tag-heading">Webhooks</h2><ul class="endpoint-list"><li><a href="POST__webhooks-20c9a68b.html"><span class="method method-POST">POST</span> <span class="path">/webhooks</span></a></li></ul></section>
+<a href="index.html" class="back-link">&larr; Back to index</a>
+<h1><span class="method method-GET">GET</span> <span class="path">/users/{userId}/avatar</span></h1>
+<div class="card"><div class="card-header">Overview</div><div class="card-body"><dl class="meta-grid"><dt>Summary</dt><dd>Download avatar</dd><dt>Description</dt><dd>Download the user's avatar as raw image bytes</dd><dt>Operation ID</dt><dd><code>downloadAvatar</code></dd><dt>Tags</dt><dd><span class="tag">Users</span></dd></dl></div></div>
+<div class="card"><div class="card-header">Security</div><div class="card-body"><p>bearerAuth <span class="tag">http</span></p></div></div>
+<div class="card"><div class="card-header">Path Parameters</div><div class="card-body"><dl class="meta-grid"><dt>userId <span class="required">*</span></dt><dd><code>UUID</code> = <code>00000000-0000-0000-0000-000000000001</code></dd></dl></div></div>
+<div class="card"><div class="card-header"><span class="status-badge status-2xx">200</span> Response</div><div class="card-body"><p>Avatar bytes</p><h4>Curl</h4><div class="curl-block"><pre>curl -X GET '$BASE_URL/users/00000000-0000-0000-0000-000000000001/avatar' \
+  -H 'Authorization: Bearer &lt;TOKEN&gt;'</pre><button class="copy-btn" type="button">Copy</button></div><h4>Response body</h4><pre>fake png bytes</pre><details><summary>Response schema</summary><pre>{
+  "$schema" : "http://json-schema.org/draft-07/schema#",
+  "type" : "string",
+  "format" : "binary"
+}</pre></details></div></div>
+<script>
+document.addEventListener('click', function (e) {
+  var btn = e.target.closest('button.copy-btn');
+  if (!btn) return;
+  var pre = btn.previousElementSibling;
+  var payload = pre ? pre.textContent : '';
+  var flash = function (msg) {
+    var original = btn.dataset.origText || btn.textContent;
+    btn.dataset.origText = original;
+    btn.textContent = msg;
+    setTimeout(function () { btn.textContent = original; }, 1200);
+  };
+  var fallback = function () {
+    try {
+      var ta = document.createElement('textarea');
+      ta.value = payload;
+      ta.style.position = 'fixed';
+      ta.style.opacity = '0';
+      document.body.appendChild(ta);
+      ta.select();
+      var ok = document.execCommand('copy');
+      document.body.removeChild(ta);
+      flash(ok ? 'Copied' : 'Failed');
+    } catch (_) { flash('Failed'); }
+  };
+  if (navigator.clipboard && navigator.clipboard.writeText) {
+    navigator.clipboard.writeText(payload).then(function () { flash('Copied'); }, fallback);
+  } else {
+    fallback();
+  }
+});
+</script>
 </body></html>

--- a/openapi/src/test/resources/gold/simple/PUT__users___userId___avatar-d5c23227.html
+++ b/openapi/src/test/resources/gold/simple/PUT__users___userId___avatar-d5c23227.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html><html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1"><title>API Documentation</title><style>
+<!DOCTYPE html><html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1"><title>PUT /users/{userId}/avatar</title><style>
   *, *::before, *::after { box-sizing: border-box; }
   body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif; margin: 0; padding: 20px 40px; background: #f8f9fa; color: #1a1a2e; line-height: 1.5; }
   h1 { font-size: 1.6rem; font-weight: 600; margin: 0 0 20px; color: #16213e; }
@@ -28,21 +28,16 @@
   ul.examples { list-style: none; padding: 0; margin: 4px 0 0; font-size: 0.85rem; }
   ul.examples li { padding: 2px 0; }
 </style></head><body>
-<h1>API Documentation</h1>
-<ul class="endpoint-list">
-<li><a href="POST__auth_login-3b67d231.html"><span class="method method-POST">POST</span> <span class="path">/auth/login</span></a></li>
-<li><a href="GET__health-334cfc61.html"><span class="method method-GET">GET</span> <span class="path">/health</span></a></li>
-<li><a href="GET__me-2647d21d.html"><span class="method method-GET">GET</span> <span class="path">/me</span></a></li>
-<li><a href="GET__projects-9a7aa53f.html"><span class="method method-GET">GET</span> <span class="path">/projects</span></a></li>
-<li><a href="POST__projects-0f98e629.html"><span class="method method-POST">POST</span> <span class="path">/projects</span></a></li>
-<li><a href="PATCH__projects___projectId__-fc9e4246.html"><span class="method method-PATCH">PATCH</span> <span class="path">/projects/{projectId}</span></a></li>
-<li><a href="GET__projects___projectId___tasks-b0b82093.html"><span class="method method-GET">GET</span> <span class="path">/projects/{projectId}/tasks</span></a></li>
-<li><a href="POST__projects___projectId___tasks-f083bafd.html"><span class="method method-POST">POST</span> <span class="path">/projects/{projectId}/tasks</span></a></li>
-<li><a href="GET__users-c054bf63.html"><span class="method method-GET">GET</span> <span class="path">/users</span></a></li>
-<li><a href="DELETE__users___userId__-cf0347bd.html"><span class="method method-DELETE">DELETE</span> <span class="path">/users/{userId}</span></a></li>
-<li><a href="GET__users___userId__-baf46b48.html"><span class="method method-GET">GET</span> <span class="path">/users/{userId}</span></a></li>
-<li><a href="PUT__users___userId__-3f0ffd01.html"><span class="method method-PUT">PUT</span> <span class="path">/users/{userId}</span></a></li>
-<li><a href="PUT__users___userId___avatar-d5c23227.html"><span class="method method-PUT">PUT</span> <span class="path">/users/{userId}/avatar</span></a></li>
-<li><a href="POST__webhooks-20c9a68b.html"><span class="method method-POST">POST</span> <span class="path">/webhooks</span></a></li>
-</ul>
+<a href="index.html" class="back-link">&larr; Back to index</a>
+<h1><span class="method method-PUT">PUT</span> <span class="path">/users/{userId}/avatar</span></h1>
+<div class="card"><div class="card-header">Overview</div><div class="card-body"><dl class="meta-grid"><dt>Summary</dt><dd>Upload avatar</dd><dt>Description</dt><dd>Upload or replace the user's avatar image</dd><dt>Operation ID</dt><dd><code>uploadAvatar</code></dd><dt>Tags</dt><dd><span class="tag">Users</span></dd></dl></div></div>
+<div class="card"><div class="card-header">Security</div><div class="card-body"><p>bearerAuth <span class="tag">http</span></p></div></div>
+<div class="card"><div class="card-header">Headers</div><div class="card-body"><dl class="meta-grid"><dt>Content-Type <span class="required">*</span></dt><dd><code>String</code> = <code>image/png</code></dd></dl></div></div>
+<div class="card"><div class="card-header">Path Parameters</div><div class="card-body"><dl class="meta-grid"><dt>userId <span class="required">*</span></dt><dd><code>UUID</code> = <code>00000000-0000-0000-0000-000000000001</code></dd></dl></div></div>
+<div class="card"><div class="card-header">Request body</div><div class="card-body"><details><summary>Request schema (JSON Schema v7)</summary><pre>{
+  "$schema" : "http://json-schema.org/draft-07/schema#",
+  "type" : "string",
+  "format" : "binary"
+}</pre></details></div></div>
+<div class="card"><div class="card-header"><span class="status-badge status-2xx">204</span> Response</div><div class="card-body"><p>Avatar uploaded</p><h4>Request body</h4><pre>fake png bytes</pre></div></div>
 </body></html>

--- a/openapi/src/test/resources/gold/simple/PUT__users___userId___avatar-d5c23227.html
+++ b/openapi/src/test/resources/gold/simple/PUT__users___userId___avatar-d5c23227.html
@@ -27,6 +27,13 @@
   .back-link { display: inline-block; margin-bottom: 16px; font-size: 0.85rem; }
   ul.examples { list-style: none; padding: 0; margin: 4px 0 0; font-size: 0.85rem; }
   ul.examples li { padding: 2px 0; }
+  .tag-group { margin-bottom: 24px; }
+  .tag-heading { margin: 20px 0 10px; font-size: 1.1rem; font-weight: 600; color: #16213e; text-transform: uppercase; letter-spacing: 0.05em; border-bottom: 2px solid #dee2e6; padding-bottom: 6px; }
+  .curl-block { position: relative; margin: 0 0 8px; }
+  .curl-block pre { padding-right: 72px; }
+  .copy-btn { position: absolute; top: 8px; right: 8px; background: #495057; color: #fff; border: none; border-radius: 4px; padding: 4px 10px; font-size: 0.75rem; cursor: pointer; font-family: inherit; }
+  .copy-btn:hover { background: #0d6efd; }
+  .copy-btn:active { background: #0a58ca; }
 </style></head><body>
 <a href="index.html" class="back-link">&larr; Back to index</a>
 <h1><span class="method method-PUT">PUT</span> <span class="path">/users/{userId}/avatar</span></h1>
@@ -39,5 +46,40 @@
   "type" : "string",
   "format" : "binary"
 }</pre></details></div></div>
-<div class="card"><div class="card-header"><span class="status-badge status-2xx">204</span> Response</div><div class="card-body"><p>Avatar uploaded</p><h4>Request body</h4><pre>fake png bytes</pre></div></div>
+<div class="card"><div class="card-header"><span class="status-badge status-2xx">204</span> Response</div><div class="card-body"><p>Avatar uploaded</p><h4>Curl</h4><div class="curl-block"><pre>curl -X PUT '$BASE_URL/users/00000000-0000-0000-0000-000000000001/avatar' \
+  -H 'Content-Type: image/png' \
+  -H 'Authorization: Bearer &lt;TOKEN&gt;' \
+  --data-raw 'fake png bytes'</pre><button class="copy-btn" type="button">Copy</button></div><h4>Request body</h4><pre>fake png bytes</pre></div></div>
+<script>
+document.addEventListener('click', function (e) {
+  var btn = e.target.closest('button.copy-btn');
+  if (!btn) return;
+  var pre = btn.previousElementSibling;
+  var payload = pre ? pre.textContent : '';
+  var flash = function (msg) {
+    var original = btn.dataset.origText || btn.textContent;
+    btn.dataset.origText = original;
+    btn.textContent = msg;
+    setTimeout(function () { btn.textContent = original; }, 1200);
+  };
+  var fallback = function () {
+    try {
+      var ta = document.createElement('textarea');
+      ta.value = payload;
+      ta.style.position = 'fixed';
+      ta.style.opacity = '0';
+      document.body.appendChild(ta);
+      ta.select();
+      var ok = document.execCommand('copy');
+      document.body.removeChild(ta);
+      flash(ok ? 'Copied' : 'Failed');
+    } catch (_) { flash('Failed'); }
+  };
+  if (navigator.clipboard && navigator.clipboard.writeText) {
+    navigator.clipboard.writeText(payload).then(function () { flash('Copied'); }, fallback);
+  } else {
+    fallback();
+  }
+});
+</script>
 </body></html>

--- a/openapi/src/test/resources/gold/tsrest/src/contracts.ts
+++ b/openapi/src/test/resources/gold/tsrest/src/contracts.ts
@@ -6,6 +6,7 @@ import { projectsProjectIdContract } from "./projects---projectId.contract";
 import { projectsProjectIdTasksContract } from "./projects---projectId-tasks.contract";
 import { usersContract } from "./users.contract";
 import { usersUserIdContract } from "./users---userId.contract";
+import { usersUserIdAvatarContract } from "./users---userId-avatar.contract";
 import { webhooksContract } from "./webhooks.contract";
 
 export const contracts: {
@@ -17,6 +18,7 @@ export const contracts: {
   "projects---projectId-tasks": typeof projectsProjectIdTasksContract;
   "users": typeof usersContract;
   "users---userId": typeof usersUserIdContract;
+  "users---userId-avatar": typeof usersUserIdAvatarContract;
   "webhooks": typeof webhooksContract
 } = {
   "auth-login": authLoginContract,
@@ -27,6 +29,7 @@ export const contracts: {
   "projects---projectId-tasks": projectsProjectIdTasksContract,
   "users": usersContract,
   "users---userId": usersUserIdContract,
+  "users---userId-avatar": usersUserIdAvatarContract,
   "webhooks": webhooksContract
 };
 

--- a/openapi/src/test/resources/gold/tsrest/src/users---userId-avatar.contract.ts
+++ b/openapi/src/test/resources/gold/tsrest/src/users---userId-avatar.contract.ts
@@ -2,6 +2,16 @@ import { z } from "zod";
 import { initContract } from "@ts-rest/core";
 
 export const usersUserIdAvatarContract = initContract().router({
+  get: {
+    summary: 'Download avatar',
+    description: 'Download the user\'s avatar as raw image bytes',
+    method: 'GET',
+    path: '/users/:userId/avatar',
+    pathParams: z.object({userId: z.string().uuid()}),
+    responses: {
+      200: z.string()
+    }
+  },
   put: {
     summary: 'Upload avatar',
     description: 'Upload or replace the user\'s avatar image',

--- a/openapi/src/test/resources/gold/tsrest/src/users---userId-avatar.contract.ts
+++ b/openapi/src/test/resources/gold/tsrest/src/users---userId-avatar.contract.ts
@@ -1,0 +1,17 @@
+import { z } from "zod";
+import { initContract } from "@ts-rest/core";
+
+export const usersUserIdAvatarContract = initContract().router({
+  put: {
+    summary: 'Upload avatar',
+    description: 'Upload or replace the user\'s avatar image',
+    method: 'PUT',
+    path: '/users/:userId/avatar',
+    pathParams: z.object({userId: z.string().uuid()}),
+    headers: z.object({"Content-Type": z.string()}),
+    body: z.string(),
+    responses: {
+      204: z.undefined()
+    }
+  }
+});

--- a/openapi/src/test/scala/pl/iterators/baklava/openapi/ComprehensiveGoldSpec.scala
+++ b/openapi/src/test/scala/pl/iterators/baklava/openapi/ComprehensiveGoldSpec.scala
@@ -12,7 +12,7 @@ import org.apache.pekko.http.scaladsl.model.headers.RawHeader
 import org.apache.pekko.http.scaladsl.model.{ContentTypes, HttpEntity, HttpHeader, HttpResponse}
 import org.apache.pekko.http.scaladsl.server.Directives.complete
 import org.apache.pekko.http.scaladsl.server.Route
-import org.apache.pekko.http.scaladsl.unmarshalling.{FromEntityUnmarshaller, Unmarshaller}
+import org.apache.pekko.http.scaladsl.unmarshalling.{FromEntityUnmarshaller, PredefinedFromEntityUnmarshallers, Unmarshaller}
 import org.apache.pekko.stream.Materializer
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
@@ -69,10 +69,12 @@ class ComprehensiveGoldSpec
   implicit val executionContext: ExecutionContext = system.dispatcher
   implicit val materializer: Materializer         = Materializer(system)
 
-  val routes: Route                                                 = complete(OK)
-  override def strictHeaderCheckDefault: Boolean                    = false
-  implicit val stringUnmarshaller: FromEntityUnmarshaller[String]   = Unmarshaller.stringUnmarshaller
-  implicit val byteArrayMarshaller: ToEntityMarshaller[Array[Byte]] = PredefinedToEntityMarshallers.ByteArrayMarshaller
+  val routes: Route                                                       = complete(OK)
+  override def strictHeaderCheckDefault: Boolean                          = false
+  implicit val stringUnmarshaller: FromEntityUnmarshaller[String]         = Unmarshaller.stringUnmarshaller
+  implicit val byteArrayMarshaller: ToEntityMarshaller[Array[Byte]]       = PredefinedToEntityMarshallers.ByteArrayMarshaller
+  implicit val byteArrayUnmarshaller: FromEntityUnmarshaller[Array[Byte]] =
+    PredefinedFromEntityUnmarshallers.byteArrayUnmarshaller
 
   // Stub: the test doesn't care about real HTTP — canned responses per assertion. We also
   // remember the last request so individual tests can assert on the request that the DSL built
@@ -422,7 +424,7 @@ class ComprehensiveGoldSpec
       onRequest(
         pathParameters = userId,
         headers = "image/png",
-        body = "fake png bytes".getBytes("UTF-8"),
+        body = "fake png bytes".getBytes(StandardCharsets.UTF_8),
         security = bearerAuth("jwt.token.xyz")
       ).respondsWith[EmptyBody](NoContent, description = "Avatar uploaded")
         .assert { ctx =>
@@ -433,6 +435,34 @@ class ComprehensiveGoldSpec
           // side of issue #52.
           lastRequest.get().entity.contentType.mediaType.value shouldBe "image/png"
           response.status.intValue() shouldBe 204
+        }
+    ),
+    // Download side: `respondsWith[Array[Byte]]` + the existing `Schema[Array[Byte]]` with
+    // `format: binary` from core is enough to render the correct OpenAPI response schema. The
+    // captured `responseContentType` comes from whatever the server returned.
+    supports(
+      GET,
+      pathParameters = p[UUID]("userId", "The user's UUID"),
+      securitySchemes = Seq(bearerScheme),
+      description = "Download the user's avatar as raw image bytes",
+      summary = "Download avatar",
+      operationId = "downloadAvatar",
+      tags = Seq("Users")
+    )(
+      onRequest(pathParameters = userId, security = bearerAuth("jwt.token.xyz"))
+        .respondsWith[Array[Byte]](OK, description = "Avatar bytes")
+        .assert { ctx =>
+          nextResponse = HttpResponse(
+            OK,
+            entity = HttpEntity(
+              org.apache.pekko.http.scaladsl.model.ContentType(
+                org.apache.pekko.http.scaladsl.model.MediaTypes.`image/png`
+              ),
+              "fake png bytes".getBytes(StandardCharsets.UTF_8)
+            )
+          )
+          val response = ctx.performRequest(routes)
+          response.status.intValue() shouldBe 200
         }
     )
   )

--- a/openapi/src/test/scala/pl/iterators/baklava/openapi/ComprehensiveGoldSpec.scala
+++ b/openapi/src/test/scala/pl/iterators/baklava/openapi/ComprehensiveGoldSpec.scala
@@ -81,7 +81,7 @@ class ComprehensiveGoldSpec
   // (e.g. to verify that a declared `Content-Type` header overrode the marshaller's default).
   private var nextResponse: HttpResponse                                            = HttpResponse(OK)
   private val lastRequest: java.util.concurrent.atomic.AtomicReference[HttpRequest] =
-    new java.util.concurrent.atomic.AtomicReference()
+    new java.util.concurrent.atomic.AtomicReference[HttpRequest]()
   override def performRequest(routes: Route, request: HttpRequest): HttpResponse = {
     lastRequest.set(request)
     nextResponse

--- a/openapi/src/test/scala/pl/iterators/baklava/openapi/ComprehensiveGoldSpec.scala
+++ b/openapi/src/test/scala/pl/iterators/baklava/openapi/ComprehensiveGoldSpec.scala
@@ -74,9 +74,16 @@ class ComprehensiveGoldSpec
   implicit val stringUnmarshaller: FromEntityUnmarshaller[String]   = Unmarshaller.stringUnmarshaller
   implicit val byteArrayMarshaller: ToEntityMarshaller[Array[Byte]] = PredefinedToEntityMarshallers.ByteArrayMarshaller
 
-  // Stub: the test doesn't care about real HTTP — canned responses per assertion.
-  private var nextResponse: HttpResponse                                         = HttpResponse(OK)
-  override def performRequest(routes: Route, request: HttpRequest): HttpResponse = nextResponse
+  // Stub: the test doesn't care about real HTTP — canned responses per assertion. We also
+  // remember the last request so individual tests can assert on the request that the DSL built
+  // (e.g. to verify that a declared `Content-Type` header overrode the marshaller's default).
+  private var nextResponse: HttpResponse                                            = HttpResponse(OK)
+  private val lastRequest: java.util.concurrent.atomic.AtomicReference[HttpRequest] =
+    new java.util.concurrent.atomic.AtomicReference()
+  override def performRequest(routes: Route, request: HttpRequest): HttpResponse = {
+    lastRequest.set(request)
+    nextResponse
+  }
 
   private def jsonResponse(status: org.apache.pekko.http.scaladsl.model.StatusCode, json: String): HttpResponse =
     HttpResponse(status, entity = HttpEntity(ContentTypes.`application/json`, json))
@@ -395,6 +402,38 @@ class ComprehensiveGoldSpec
         )
         ctx.performRequest(routes)
       }
+    )
+  )
+
+  path("/users/{userId}/avatar", description = "Raw avatar upload", summary = "Avatar")(
+    supports(
+      PUT,
+      pathParameters = p[UUID]("userId", "The user's UUID"),
+      // The Content-Type header is the user's way of picking the upload's MIME. The test DSL
+      // honors it and forwards the same content type into the real pekko-http request — that's
+      // how binary uploads get documented (issue #52).
+      headers = h[String]("Content-Type"),
+      securitySchemes = Seq(bearerScheme),
+      description = "Upload or replace the user's avatar image",
+      summary = "Upload avatar",
+      operationId = "uploadAvatar",
+      tags = Seq("Users")
+    )(
+      onRequest(
+        pathParameters = userId,
+        headers = "image/png",
+        body = "fake png bytes".getBytes("UTF-8"),
+        security = bearerAuth("jwt.token.xyz")
+      ).respondsWith[EmptyBody](NoContent, description = "Avatar uploaded")
+        .assert { ctx =>
+          nextResponse = emptyResponse(NoContent)
+          val response = ctx.performRequest(routes)
+          // The request that reached `performRequest` must carry the declared Content-Type, not
+          // the byte-array marshaller's default `application/octet-stream`. This is the runtime
+          // side of issue #52.
+          lastRequest.get().entity.contentType.mediaType.value shouldBe "image/png"
+          response.status.intValue() shouldBe 204
+        }
     )
   )
 

--- a/openapi/src/test/scala/pl/iterators/baklava/openapi/Http4sContentTypeOverrideSpec.scala
+++ b/openapi/src/test/scala/pl/iterators/baklava/openapi/Http4sContentTypeOverrideSpec.scala
@@ -1,0 +1,108 @@
+package pl.iterators.baklava.openapi
+
+import cats.effect.IO
+import cats.effect.unsafe.IORuntime
+import org.http4s.{EntityEncoder, HttpRoutes, MediaType, Request, Response, Status}
+import org.http4s.headers.`Content-Type`
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
+import pl.iterators.baklava.http4s.BaklavaHttp4s
+import pl.iterators.baklava.scalatest.{BaklavaScalatest, ScalatestAsExecution}
+import pl.iterators.baklava.{AppliedSecurity, BaklavaRequestContext, NoopSecurity}
+import sttp.model.{Header => SttpHeader, Method}
+
+/** Regression test for issue #52 on the http4s adapter. The pekko-http adapter already gets the same coverage via ComprehensiveGoldSpec's
+  * `/users/{userId}/avatar` endpoint; this spec exists because the http4s adapter has its own independent `baklavaContextToHttpRequest`
+  * that also needs to honor a declared `Content-Type` header and strip duplicates.
+  */
+class Http4sContentTypeOverrideSpec
+    extends AnyFunSpec
+    with Matchers
+    with BaklavaHttp4s[Unit, Unit, ScalatestAsExecution]
+    with BaklavaScalatest[HttpRoutes[IO], BaklavaHttp4s.ToEntityMarshaller, BaklavaHttp4s.FromEntityUnmarshaller] {
+
+  override implicit val runtime: IORuntime                                                = IORuntime.global
+  override def strictHeaderCheckDefault: Boolean                                          = false
+  override def performRequest(routes: HttpRoutes[IO], request: Request[IO]): Response[IO] =
+    Response[IO](status = Status.NoContent)
+
+  val routes: HttpRoutes[IO]                       = HttpRoutes.empty[IO]
+  private val stringEnc: EntityEncoder[IO, String] = EntityEncoder.stringEncoder[IO]
+
+  describe("http4s adapter's baklavaContextToHttpRequest (issue #52)") {
+
+    it("overrides the entity Content-Type when one is declared among the headers") {
+      val ctx     = buildRequestContext(Seq(SttpHeader("Content-Type", "image/png")), "raw bytes")
+      val request = baklavaContextToHttpRequest(ctx)(stringEnc)
+
+      request.contentType shouldBe Some(`Content-Type`(MediaType.image.png))
+    }
+
+    it("does not leave a duplicate Content-Type in the free header list") {
+      val ctx     = buildRequestContext(Seq(SttpHeader("Content-Type", "image/png")), "raw bytes")
+      val request = baklavaContextToHttpRequest(ctx)(stringEnc)
+
+      // http4s stores Content-Type on the entity, not in the free header list. The declared
+      // Content-Type must appear exactly once — via the entity — not as an extra header.
+      val contentTypeHeaders =
+        request.headers.headers.filter(_.name.toString.equalsIgnoreCase("Content-Type"))
+      contentTypeHeaders.size shouldBe 1
+      contentTypeHeaders.head.value shouldBe "image/png"
+    }
+
+    it("leaves the marshaller-provided Content-Type intact when none is declared") {
+      val ctx     = buildRequestContext(Seq.empty, "plain text")
+      val request = baklavaContextToHttpRequest(ctx)(stringEnc)
+
+      // http4s's String EntityEncoder defaults to text/plain; assert the main type without
+      // pinning the exact subtype/charset which is less stable across http4s versions.
+      request.contentType.map(_.mediaType.mainType) shouldBe Some("text")
+    }
+
+    it("throws on an unparseable declared Content-Type — silent fallback would hide a bug") {
+      val ctx = buildRequestContext(Seq(SttpHeader("Content-Type", "this is not a content type")), "irrelevant")
+      val ex  = intercept[IllegalArgumentException](baklavaContextToHttpRequest(ctx)(stringEnc))
+      ex.getMessage should include("Could not parse declared Content-Type")
+    }
+
+    it("throws on multiple declared Content-Type headers") {
+      val ctx = buildRequestContext(
+        Seq(SttpHeader("Content-Type", "image/png"), SttpHeader("content-type", "image/jpeg")),
+        "bytes"
+      )
+      val ex = intercept[IllegalArgumentException](baklavaContextToHttpRequest(ctx)(stringEnc))
+      ex.getMessage should include("Multiple Content-Type headers")
+    }
+  }
+
+  private def buildRequestContext(hs: Seq[SttpHeader], body: String): BaklavaRequestContext[String, Unit, Unit, Unit, Unit, Unit, Unit] =
+    BaklavaRequestContext[String, Unit, Unit, Unit, Unit, Unit, Unit](
+      symbolicPath = "/x",
+      path = "/x",
+      pathDescription = None,
+      pathSummary = None,
+      method = Some(Method("POST")),
+      operationDescription = None,
+      operationSummary = None,
+      operationId = None,
+      operationTags = Seq.empty,
+      securitySchemes = Seq.empty,
+      body = Some(body),
+      bodySchema = None,
+      headers = hs,
+      headersDefinition = (),
+      headersProvided = (),
+      headersSeq = Seq.empty,
+      security = AppliedSecurity(NoopSecurity, Map.empty),
+      pathParameters = (),
+      pathParametersProvided = (),
+      pathParametersSeq = Seq.empty,
+      queryParameters = (),
+      queryParametersProvided = (),
+      queryParametersSeq = Seq.empty,
+      responseDescription = None,
+      responseHeaders = Seq.empty
+    )
+
+  override def afterAll(): Unit = ()
+}

--- a/pekkohttp/src/main/scala/pl/iterators/baklava/pekkohttp/BaklavaPekkoHttp.scala
+++ b/pekkohttp/src/main/scala/pl/iterators/baklava/pekkohttp/BaklavaPekkoHttp.scala
@@ -154,12 +154,14 @@ trait BaklavaPekkoHttp[TestFrameworkFragmentType, TestFrameworkFragmentsType, Te
   )(implicit
       requestBody: ToEntityMarshaller[RequestBody]
   ): HttpRequest = {
-    // If the test declared a parseable `Content-Type` header, use its value to override the
-    // content type that the implicit marshaller would otherwise bake into the request. This is
-    // what lets tests document non-JSON uploads — `h[String]("Content-Type") = "image/png"` plus
-    // a String/byte body. Pekko-http treats `Content-Type` as part of the entity (not a free
-    // header), so we also strip it from the headers list before attaching. We only strip after
-    // parsing succeeds so an invalid value isn't silently swallowed.
+    // If the test declared a `Content-Type` header, use its value to override the content type
+    // that the implicit marshaller would otherwise bake into the request. This is what lets tests
+    // document non-JSON uploads — `h[String]("Content-Type") = "image/png"` plus a String/byte
+    // body. Pekko-http treats `Content-Type` as part of the entity (not a free header), so we
+    // also strip it from the headers list before attaching. Invalid values throw — a silent
+    // fallback would mask test-authoring bugs (pekko's own header parser would drop the invalid
+    // header from the request, leaving the marshaller's default Content-Type in its place with
+    // no indication that the declared value was ignored).
     val parsedOverride = findContentTypeOverride(ctx.headers)
     val otherHeaders   = if (parsedOverride.isDefined) dropContentType(ctx.headers) else ctx.headers
     val base           = new RequestBuilder(baklavaHttpMethodToHttpMethod(ctx.method.get))(ctx.path, ctx.body)
@@ -167,15 +169,22 @@ trait BaklavaPekkoHttp[TestFrameworkFragmentType, TestFrameworkFragmentsType, Te
     parsedOverride.fold(base)(ct => base.withEntity(base.entity.withContentType(ct)))
   }
 
-  /** Find a `Content-Type` in the declared headers (case-insensitive) and return the parsed pekko `ContentType`. Fails fast on multiple
-    * declarations rather than silently picking one, since that's always a test-authoring bug.
+  /** Find a `Content-Type` in the declared headers (case-insensitive) and return the parsed pekko `ContentType`. Throws on either multiple
+    * declarations or an unparseable value — both are always test-authoring bugs.
     */
   private def findContentTypeOverride(headers: Seq[SttpHeader]): Option[ContentType] = {
     val cts = headers.filter(_.name.toLowerCase(java.util.Locale.ROOT) == "content-type")
     cts match {
       case Seq()       => None
-      case Seq(single) => ContentType.parse(single.value).toOption
-      case multiple    =>
+      case Seq(single) =>
+        ContentType.parse(single.value) match {
+          case Right(ct)    => Some(ct)
+          case Left(errors) =>
+            throw new IllegalArgumentException(
+              s"Could not parse declared Content-Type header '${single.value}': ${errors.mkString("; ")}"
+            )
+        }
+      case multiple =>
         throw new IllegalArgumentException(
           s"Multiple Content-Type headers declared on one request: [${multiple.map(_.value).mkString(", ")}]. " +
             "Declare a single Content-Type or none at all."

--- a/pekkohttp/src/main/scala/pl/iterators/baklava/pekkohttp/BaklavaPekkoHttp.scala
+++ b/pekkohttp/src/main/scala/pl/iterators/baklava/pekkohttp/BaklavaPekkoHttp.scala
@@ -154,24 +154,37 @@ trait BaklavaPekkoHttp[TestFrameworkFragmentType, TestFrameworkFragmentsType, Te
   )(implicit
       requestBody: ToEntityMarshaller[RequestBody]
   ): HttpRequest = {
-    // If the test declared a `Content-Type` header, use its value to override the content type
-    // that the implicit marshaller would otherwise bake into the request. This is what lets tests
-    // document non-JSON uploads — `h[String]("Content-Type") = "image/png"` + a String/byte body.
-    // Pekko-http treats `Content-Type` as part of the entity (not a free header), so we also
-    // strip it from the headers list before attaching.
-    val (contentTypeOverride, otherHeaders) = splitContentType(ctx.headers)
-    val base                                = new RequestBuilder(baklavaHttpMethodToHttpMethod(ctx.method.get))(ctx.path, ctx.body)
+    // If the test declared a parseable `Content-Type` header, use its value to override the
+    // content type that the implicit marshaller would otherwise bake into the request. This is
+    // what lets tests document non-JSON uploads — `h[String]("Content-Type") = "image/png"` plus
+    // a String/byte body. Pekko-http treats `Content-Type` as part of the entity (not a free
+    // header), so we also strip it from the headers list before attaching. We only strip after
+    // parsing succeeds so an invalid value isn't silently swallowed.
+    val parsedOverride = findContentTypeOverride(ctx.headers)
+    val otherHeaders   = if (parsedOverride.isDefined) dropContentType(ctx.headers) else ctx.headers
+    val base           = new RequestBuilder(baklavaHttpMethodToHttpMethod(ctx.method.get))(ctx.path, ctx.body)
       .withHeaders(baklavaHeadersToHttpHeaders(otherHeaders))
-    contentTypeOverride.flatMap(v => ContentType.parse(v).toOption) match {
-      case Some(ct) => base.withEntity(base.entity.withContentType(ct))
-      case None     => base
+    parsedOverride.fold(base)(ct => base.withEntity(base.entity.withContentType(ct)))
+  }
+
+  /** Find a `Content-Type` in the declared headers (case-insensitive) and return the parsed pekko `ContentType`. Fails fast on multiple
+    * declarations rather than silently picking one, since that's always a test-authoring bug.
+    */
+  private def findContentTypeOverride(headers: Seq[SttpHeader]): Option[ContentType] = {
+    val cts = headers.filter(_.name.toLowerCase(java.util.Locale.ROOT) == "content-type")
+    cts match {
+      case Seq()       => None
+      case Seq(single) => ContentType.parse(single.value).toOption
+      case multiple    =>
+        throw new IllegalArgumentException(
+          s"Multiple Content-Type headers declared on one request: [${multiple.map(_.value).mkString(", ")}]. " +
+            "Declare a single Content-Type or none at all."
+        )
     }
   }
 
-  private def splitContentType(headers: Seq[SttpHeader]): (Option[String], Seq[SttpHeader]) = {
-    val (ct, rest) = headers.partition(_.name.toLowerCase(java.util.Locale.ROOT) == "content-type")
-    (ct.headOption.map(_.value), rest)
-  }
+  private def dropContentType(headers: Seq[SttpHeader]): Seq[SttpHeader] =
+    headers.filterNot(_.name.toLowerCase(java.util.Locale.ROOT) == "content-type")
 
   override implicit protected def emptyToRequestBodyType: ToEntityMarshaller[EmptyBody] =
     Marshaller.strict[EmptyBody, MessageEntity](_ => Marshalling.Opaque(() => HttpEntity.Empty))

--- a/pekkohttp/src/main/scala/pl/iterators/baklava/pekkohttp/BaklavaPekkoHttp.scala
+++ b/pekkohttp/src/main/scala/pl/iterators/baklava/pekkohttp/BaklavaPekkoHttp.scala
@@ -2,7 +2,7 @@ package pl.iterators.baklava.pekkohttp
 
 import org.apache.pekko.http.scaladsl.client.RequestBuilding.RequestBuilder
 import org.apache.pekko.http.scaladsl.marshalling.{Marshaller, Marshalling, ToEntityMarshaller}
-import org.apache.pekko.http.scaladsl.model.{FormData, HttpEntity, HttpHeader, MessageEntity}
+import org.apache.pekko.http.scaladsl.model.{ContentType, FormData, HttpEntity, HttpHeader, MessageEntity}
 import org.apache.pekko.http.scaladsl.server.Route
 import org.apache.pekko.http.scaladsl.unmarshalling.{FromEntityUnmarshaller, Unmarshaller}
 import org.apache.pekko.stream.Materializer
@@ -154,8 +154,23 @@ trait BaklavaPekkoHttp[TestFrameworkFragmentType, TestFrameworkFragmentsType, Te
   )(implicit
       requestBody: ToEntityMarshaller[RequestBody]
   ): HttpRequest = {
-    new RequestBuilder(baklavaHttpMethodToHttpMethod(ctx.method.get))(ctx.path, ctx.body)
-      .withHeaders(baklavaHeadersToHttpHeaders(ctx.headers))
+    // If the test declared a `Content-Type` header, use its value to override the content type
+    // that the implicit marshaller would otherwise bake into the request. This is what lets tests
+    // document non-JSON uploads — `h[String]("Content-Type") = "image/png"` + a String/byte body.
+    // Pekko-http treats `Content-Type` as part of the entity (not a free header), so we also
+    // strip it from the headers list before attaching.
+    val (contentTypeOverride, otherHeaders) = splitContentType(ctx.headers)
+    val base                                = new RequestBuilder(baklavaHttpMethodToHttpMethod(ctx.method.get))(ctx.path, ctx.body)
+      .withHeaders(baklavaHeadersToHttpHeaders(otherHeaders))
+    contentTypeOverride.flatMap(v => ContentType.parse(v).toOption) match {
+      case Some(ct) => base.withEntity(base.entity.withContentType(ct))
+      case None     => base
+    }
+  }
+
+  private def splitContentType(headers: Seq[SttpHeader]): (Option[String], Seq[SttpHeader]) = {
+    val (ct, rest) = headers.partition(_.name.toLowerCase(java.util.Locale.ROOT) == "content-type")
+    (ct.headOption.map(_.value), rest)
   }
 
   override implicit protected def emptyToRequestBodyType: ToEntityMarshaller[EmptyBody] =


### PR DESCRIPTION
Closes #52.

## Problem

When a test declared \`Content-Type\` among its request headers (e.g. to document a PNG upload via \`h[String](\"Content-Type\")\` + \`headers = \"image/png\"\`), the actual request went out with the implicit marshaller's default (\`text/plain\` for String, \`application/octet-stream\` for \`Array[Byte]\`). The declared value was ignored at runtime, and the captured request-body content type in the OpenAPI spec matched what went over the wire — not what the test wanted to document.

## Fix

Both adapters (\`pekkohttp\`, \`http4s\`) now honor a declared \`Content-Type\` header. In \`baklavaContextToHttpRequest\`:
1. Pull \`Content-Type\` out of the header list (case-insensitive)
2. Build the entity via the implicit marshaller as before
3. Apply the declared value via \`HttpEntity.withContentType\` (pekko) / \`Request.withContentType\` (http4s)
4. The filtered header list (without Content-Type) goes into the regular headers field, since both frameworks store Content-Type on the entity, not as a free header

## Test plan

Added a \`PUT /users/{userId}/avatar\` endpoint to the comprehensive gold test, with \`headers = h[String](\"Content-Type\")\`, \`headers = \"image/png\"\`, \`body = Array[Byte]\`. The test asserts:

\`\`\`scala
lastRequest.get().entity.contentType.mediaType.value shouldBe \"image/png\"
\`\`\`

- [x] 93/93 openapi tests pass on Scala 2.13 under CI mode
- [x] 93/93 openapi tests pass on Scala 3 under CI mode
- [x] Generated YAML shows \`requestBody.content[\"image/png\"]\` with \`{ type: string, format: binary }\` — no Content-Type parameter leak

## Docs

- \`docs/pekko-http.md\`: new "Documenting file uploads" section with a PUT /users/{id}/avatar example
- \`docs/http4s.md\`: same, adapted for http4s