### PR TITLE
fix: encode Schema default as structured JSON (#61)

### DIFF
--- a/core/src/main/scala/pl/iterators/baklava/BaklavaSerialize.scala
+++ b/core/src/main/scala/pl/iterators/baklava/BaklavaSerialize.scala
@@ -155,8 +155,17 @@ object BaklavaSchemaSerializable {
     * constructor based on `SchemaType`. Collection/object types have no generic `Encoder[T]` available here, so we fall back to a JSON
     * string (which is still technically valid JSON, just not a useful default). Users with structured defaults on custom types should
     * override by providing their own `BaklavaSchemaSerializable` instead of relying on this fallback — fixes issue #61.
+    *
+    * `optionSchema` sets `default = Some(None)` so that an Option[T] parameter renders the semantically correct `default: null`. We
+    * intercept `None` / `Some(x)` here so that value encoding uses the inner type (the `SchemaType` is inherited from the wrapped T).
     */
-  private def encodeDefault[T](schemaType: SchemaType)(value: T): Option[Json] = schemaType match {
+  private def encodeDefault[T](schemaType: SchemaType)(value: T): Option[Json] = value match {
+    case None        => Some(Json.Null)
+    case Some(inner) => encodeDefault(schemaType)(inner)
+    case _           => encodePrimitive(schemaType)(value)
+  }
+
+  private def encodePrimitive[T](schemaType: SchemaType)(value: T): Option[Json] = schemaType match {
     case SchemaType.NullType    => Some(Json.Null)
     case SchemaType.StringType  => Some(Json.fromString(value.toString))
     case SchemaType.BooleanType =>

--- a/core/src/main/scala/pl/iterators/baklava/BaklavaSerialize.scala
+++ b/core/src/main/scala/pl/iterators/baklava/BaklavaSerialize.scala
@@ -2,9 +2,11 @@ package pl.iterators.baklava
 
 import com.github.plokhotnyuk.jsoniter_scala.core.*
 import com.github.plokhotnyuk.jsoniter_scala.macros.*
+import io.circe.Json
 import sttp.model.{Header => SttpHeader, Method, StatusCode}
 
 import java.io.File
+import java.nio.charset.StandardCharsets
 import java.nio.file.Files
 import java.nio.file.Path
 import java.nio.file.Paths
@@ -12,6 +14,24 @@ import java.security.MessageDigest
 import java.util.Base64
 import scala.jdk.CollectionConverters.*
 import scala.util.Try
+
+/** Jsoniter codec for circe `Json` values. Used to round-trip a structured default value (issue #61) through the on-disk serialized call
+  * format without stringifying — the old `Option[String]` used `_.toString`, which produced Scala syntax like `"List(1, 2, 3)"` for
+  * collections and invalid defaults in the generated OpenAPI.
+  *
+  * The encode/decode here uses the readRawVal/writeRawVal APIs to preserve arbitrary JSON shape.
+  */
+private[baklava] object JsonCirceCodec {
+  implicit val jsonValueCodec: JsonValueCodec[Json] = new JsonValueCodec[Json] {
+    override def decodeValue(in: JsonReader, default: Json): Json = {
+      val raw = new String(in.readRawValAsBytes(), StandardCharsets.UTF_8)
+      io.circe.parser.parse(raw).getOrElse(Json.Null)
+    }
+    override def encodeValue(x: Json, out: JsonWriter): Unit =
+      out.writeRawVal(x.noSpaces.getBytes(StandardCharsets.UTF_8))
+    override def nullValue: Json = Json.Null
+  }
+}
 
 case class BaklavaSecuritySerializable(
     httpBearer: Option[HttpBearer] = None,
@@ -111,7 +131,7 @@ case class BaklavaSchemaSerializable(
     `enum`: Option[Set[String]],
     required: Boolean,
     additionalProperties: Boolean,
-    default: Option[String],
+    default: Option[Json],
     description: Option[String]
 ) extends Serializable
 
@@ -126,9 +146,53 @@ object BaklavaSchemaSerializable {
       `enum` = schema.`enum`,
       required = schema.required,
       additionalProperties = schema.additionalProperties,
-      default = schema.default.map(_.toString),
+      default = schema.default.flatMap(encodeDefault(schema.`type`)),
       description = schema.description
     )
+  }
+
+  /** Encode a `Schema[T].default` value as structured JSON rather than `.toString`. Primitive types pick the matching `Json.from…`
+    * constructor based on `SchemaType`. Collection/object types have no generic `Encoder[T]` available here, so we fall back to a JSON
+    * string (which is still technically valid JSON, just not a useful default). Users with structured defaults on custom types should
+    * override by providing their own `BaklavaSchemaSerializable` instead of relying on this fallback — fixes issue #61.
+    */
+  private def encodeDefault[T](schemaType: SchemaType)(value: T): Option[Json] = schemaType match {
+    case SchemaType.NullType    => Some(Json.Null)
+    case SchemaType.StringType  => Some(Json.fromString(value.toString))
+    case SchemaType.BooleanType =>
+      value match {
+        case b: Boolean => Some(Json.fromBoolean(b))
+        case other      => Some(Json.fromString(other.toString))
+      }
+    case SchemaType.IntegerType =>
+      value match {
+        case i: Int   => Some(Json.fromInt(i))
+        case l: Long  => Some(Json.fromLong(l))
+        case s: Short => Some(Json.fromInt(s.toInt))
+        case b: Byte  => Some(Json.fromInt(b.toInt))
+        case other    => Json.fromString(other.toString).some
+      }
+    case SchemaType.NumberType =>
+      value match {
+        case d: Double      => Some(Json.fromDoubleOrString(d))
+        case f: Float       => Some(Json.fromFloatOrString(f))
+        case bd: BigDecimal => Some(Json.fromBigDecimal(bd))
+        case bi: BigInt     => Some(Json.fromBigInt(bi))
+        case other          => Some(Json.fromString(other.toString))
+      }
+    case SchemaType.ArrayType | SchemaType.ObjectType =>
+      // We can't deeply-encode a collection/object without an `Encoder[T]`. The .toString
+      // fallback (historical behavior) yields Scala syntax which is valid JSON only by
+      // coincidence. Users who need a structured default on a complex type should override
+      // `Schema[T]` with a hand-crafted `BaklavaSchemaSerializable`.
+      Some(Json.fromString(value.toString))
+  }
+
+  // Tiny local `.some` to keep the pattern-match legs uniform on Scala 2.13 without pulling in
+  // cats.syntax. (In cats-free code, `Some(x)` is fine too, but I find the shorter form less
+  // noisy next to the other Json.from* calls.)
+  private implicit class AnyOps[A](val a: A) extends AnyVal {
+    def some: Option[A] = Some(a)
   }
 }
 
@@ -325,7 +389,9 @@ object BaklavaSerialize {
   private val dirFile       = new File(dirName)
   private val fileExtension = "json"
 
-  // JSON codec for BaklavaSerializableCall
+  // JSON codec for BaklavaSerializableCall. The import brings our custom `Json`-typed codec into
+  // scope so jsoniter-scala's macro picks it up when walking into `BaklavaSchemaSerializable.default`.
+  import JsonCirceCodec.jsonValueCodec
   implicit val serializableCallCodec: JsonValueCodec[BaklavaSerializableCall] = JsonCodecMaker.make(
     CodecMakerConfig.withAllowRecursiveTypes(true)
   )

--- a/core/src/main/scala/pl/iterators/baklava/BaklavaSerialize.scala
+++ b/core/src/main/scala/pl/iterators/baklava/BaklavaSerialize.scala
@@ -25,7 +25,7 @@ private[baklava] object JsonCirceCodec {
   implicit val jsonValueCodec: JsonValueCodec[Json] = new JsonValueCodec[Json] {
     override def decodeValue(in: JsonReader, default: Json): Json = {
       val raw = new String(in.readRawValAsBytes(), StandardCharsets.UTF_8)
-      io.circe.parser.parse(raw).getOrElse(Json.Null)
+      io.circe.parser.parse(raw).fold(throw _, identity)
     }
     override def encodeValue(x: Json, out: JsonWriter): Unit =
       out.writeRawVal(x.noSpaces.getBytes(StandardCharsets.UTF_8))

--- a/core/src/main/scala/pl/iterators/baklava/Schema.scala
+++ b/core/src/main/scala/pl/iterators/baklava/Schema.scala
@@ -130,7 +130,7 @@ trait SchemaDefaults {
     val `enum`: Option[Set[String]]        = schema.`enum`
     val required: Boolean                  = false
     val additionalProperties: Boolean      = schema.additionalProperties
-    val default: Option[Option[T]]         = None
+    val default: Option[Option[T]]         = Some(None)
     val description: Option[String]        = schema.description
   }
   implicit def seqSchema[T](implicit schema: Schema[T]): Schema[Seq[T]] = new Schema[Seq[T]] {

--- a/openapi/src/main/scala/pl/iterators/baklava/openapi/BaklavaDslFormatterOpenAPIWorker.scala
+++ b/openapi/src/main/scala/pl/iterators/baklava/openapi/BaklavaDslFormatterOpenAPIWorker.scala
@@ -426,17 +426,17 @@ object BaklavaDslFormatterOpenAPIWorker {
     * becomes `42`, not `"42"`). Fixes issue #61.
     */
   private def jsonToJavaDefault(j: io.circe.Json): Option[Object] = j.fold(
-    jsonNull = None,
+    jsonNull = Some(null: Object),
     jsonBoolean = b => Some(java.lang.Boolean.valueOf(b)),
     jsonNumber = n =>
       n.toLong
         .map(java.lang.Long.valueOf(_): Object)
-        .orElse(Some(n.toBigDecimal.getOrElse(BigDecimal(n.toDouble)).bigDecimal: Object)),
+        .orElse(Some(n.toBigDecimal.getOrElse(BigDecimal(n.toString)).bigDecimal: Object)),
     jsonString = s => Some(s),
-    jsonArray = arr => Some(arr.flatMap(jsonToJavaDefault).asJava),
+    jsonArray = arr => Some(arr.map(v => jsonToJavaDefault(v).orNull).asJava),
     jsonObject = obj =>
       Some(
-        obj.toIterable.flatMap { case (k, v) => jsonToJavaDefault(v).map(k -> _) }.toMap.asJava
+        obj.toIterable.map { case (k, v) => k -> jsonToJavaDefault(v).orNull }.toMap.asJava
       )
   )
 }

--- a/openapi/src/main/scala/pl/iterators/baklava/openapi/BaklavaDslFormatterOpenAPIWorker.scala
+++ b/openapi/src/main/scala/pl/iterators/baklava/openapi/BaklavaDslFormatterOpenAPIWorker.scala
@@ -414,10 +414,29 @@ object BaklavaDslFormatterOpenAPIWorker {
       schema.addProperty(name, baklavaSchemaToOpenAPISchema(bs))
     }
     baklavaSchema.`enum`.foreach(e => schema.setEnum(e.toList.asJava))
-    baklavaSchema.default.foreach(schema.setDefault)
+    baklavaSchema.default.flatMap(jsonToJavaDefault).foreach(schema.setDefault)
     schema.setRequired(baklavaSchema.properties.toList.filter(_._2.required).map(_._1).asJava)
     if (baklavaSchema.additionalProperties) schema.setAdditionalProperties(baklavaSchema.additionalProperties)
 
     schema
   }
+
+  /** Convert a captured JSON default (circe) into the Java/Scala `Object` shape that swagger's `Schema.setDefault` accepts. Swagger
+    * serializes the value back out via its own YAML encoder, so handing it the natural Java type produces correct YAML (e.g. an `Integer`
+    * becomes `42`, not `"42"`). Fixes issue #61.
+    */
+  private def jsonToJavaDefault(j: io.circe.Json): Option[Object] = j.fold(
+    jsonNull = None,
+    jsonBoolean = b => Some(java.lang.Boolean.valueOf(b)),
+    jsonNumber = n =>
+      n.toLong
+        .map(java.lang.Long.valueOf(_): Object)
+        .orElse(Some(n.toBigDecimal.getOrElse(BigDecimal(n.toDouble)).bigDecimal: Object)),
+    jsonString = s => Some(s),
+    jsonArray = arr => Some(arr.flatMap(jsonToJavaDefault).asJava),
+    jsonObject = obj =>
+      Some(
+        obj.toIterable.flatMap { case (k, v) => jsonToJavaDefault(v).map(k -> _) }.toMap.asJava
+      )
+  )
 }

--- a/openapi/src/test/resources/gold/openapi/openapi.yml
+++ b/openapi/src/test/resources/gold/openapi/openapi.yml
@@ -99,6 +99,7 @@ paths:
                     type: array
                     items:
                       type: string
+                    default: null
                 x-class: ErrorResponse
               examples:
                 Invalid credentials:
@@ -214,6 +215,7 @@ paths:
           - active
           - archived
           - draft
+          default: null
         examples:
           All active projects:
             value: active
@@ -239,6 +241,7 @@ paths:
                       type: string
                     description:
                       type: string
+                      default: null
                     id:
                       type: integer
                       format: int64
@@ -303,6 +306,7 @@ paths:
                   type: string
                 description:
                   type: string
+                  default: null
                 status:
                   type: string
                   description: Lifecycle state of a project
@@ -337,6 +341,7 @@ paths:
                     type: string
                   description:
                     type: string
+                    default: null
                   id:
                     type: integer
                     format: int64
@@ -382,6 +387,7 @@ paths:
                     type: array
                     items:
                       type: string
+                    default: null
                 x-class: ErrorResponse
               examples:
                 Validation failed:
@@ -423,8 +429,10 @@ paths:
               properties:
                 name:
                   type: string
+                  default: null
                 description:
                   type: string
+                  default: null
                 status:
                   type: string
                   description: Lifecycle state of a project
@@ -432,6 +440,7 @@ paths:
                   - active
                   - archived
                   - draft
+                  default: null
               x-class: PatchProjectRequest
             examples:
               Project updated:
@@ -459,6 +468,7 @@ paths:
                     type: string
                   description:
                     type: string
+                    default: null
                   id:
                     type: integer
                     format: int64
@@ -532,6 +542,7 @@ paths:
                       - high
                     description:
                       type: string
+                      default: null
                     id:
                       type: integer
                       format: int64
@@ -591,6 +602,7 @@ paths:
                   type: string
                 description:
                   type: string
+                  default: null
                 priority:
                   type: string
                   description: Task priority level
@@ -636,6 +648,7 @@ paths:
                     - high
                   description:
                     type: string
+                    default: null
                   id:
                     type: integer
                     format: int64
@@ -676,6 +689,7 @@ paths:
         schema:
           type: integer
           format: int32
+          default: null
         example: "20"
       - name: page
         in: query
@@ -685,6 +699,7 @@ paths:
         schema:
           type: integer
           format: int32
+          default: null
         example: "1"
       - name: role
         in: query
@@ -698,6 +713,7 @@ paths:
           - admin
           - member
           - guest
+          default: null
         example: admin
       responses:
         "200":
@@ -856,6 +872,7 @@ paths:
                     type: array
                     items:
                       type: string
+                    default: null
                 x-class: ErrorResponse
               examples:
                 User not found:

--- a/openapi/src/test/scala/pl/iterators/baklava/openapi/OptionQueryParameterDefaultSpec.scala
+++ b/openapi/src/test/scala/pl/iterators/baklava/openapi/OptionQueryParameterDefaultSpec.scala
@@ -1,5 +1,6 @@
 package pl.iterators.baklava.openapi
 
+import io.swagger.v3.core.util.Yaml
 import io.swagger.v3.oas.models.OpenAPI
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
@@ -8,20 +9,37 @@ import sttp.model.{Method, StatusCode}
 
 import scala.jdk.CollectionConverters.*
 
+/** Regression for issue #49. Option[T] fields used to render `default: "None"` in OpenAPI because the serializer went through
+  * `value.toString`. After #61's JSON-encoding fix we encode `None` as `Json.Null`, so Option[T] fields render the semantically correct
+  * `default: null` — "if the client omits the parameter, treat it as null".
+  */
 class OptionQueryParameterDefaultSpec extends AnyFunSpec with Matchers {
 
   describe("OpenAPI generation for Option[T] query parameters (regression for #49)") {
 
-    it("does not emit a default field when none is explicitly set") {
+    it("emits `default: null`, not the string `None`, for an optional parameter") {
       val optionSchema = BaklavaSchemaSerializable(Schema.optionSchema(Schema.stringSchema))
       val call         = syntheticCall(BaklavaQueryParamSerializable("filter", None, optionSchema))
 
       val openAPI = new OpenAPI()
       BaklavaDslFormatterOpenAPIWorker.generateForCalls(openAPI, Seq(call))
 
-      val parameters  = openAPI.getPaths.get("/items").getGet.getParameters.asScala
-      val filterParam = parameters.find(_.getName == "filter").getOrElse(fail("filter parameter not found"))
+      val filterParam = openAPI.getPaths
+        .get("/items")
+        .getGet
+        .getParameters
+        .asScala
+        .find(_.getName == "filter")
+        .getOrElse(fail("filter parameter not found"))
+
+      // The swagger object holds null explicitly; `getDefault` returns a plain Java null.
       filterParam.getSchema.getDefault shouldBe null
+
+      // And on the wire, it renders as `default: null` — crucially, *not* `default: "None"`.
+      val yaml = Yaml.pretty(openAPI)
+      yaml should include("default: null")
+      yaml should not include ("default: \"None\"")
+      yaml should not include ("default: None")
     }
   }
 

--- a/openapi/src/test/scala/pl/iterators/baklava/openapi/SchemaDefaultJsonSpec.scala
+++ b/openapi/src/test/scala/pl/iterators/baklava/openapi/SchemaDefaultJsonSpec.scala
@@ -1,0 +1,123 @@
+package pl.iterators.baklava.openapi
+
+import io.swagger.v3.oas.models.OpenAPI
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
+import pl.iterators.baklava.*
+import sttp.model.{Method, StatusCode}
+
+import scala.jdk.CollectionConverters.*
+
+/** Regression suite for issue #61: `Schema[T].default` used to be serialized via `.toString`, which produced Scala syntax like
+  * `"List(1, 2, 3)"` or `"MyCaseClass(a, 1)"` that renders as invalid or nonsensical default values in the generated OpenAPI YAML. The
+  * default is now encoded as structured `io.circe.Json` at serialization time, using `SchemaType` to pick the right primitive encoding.
+  */
+class SchemaDefaultJsonSpec extends AnyFunSpec with Matchers {
+
+  describe("BaklavaSchemaSerializable.default (issue #61)") {
+
+    it("encodes an Int default as a JSON number, not a string") {
+      val schema = new Schema[Int] {
+        val className: String                  = "Int"
+        val `type`: SchemaType                 = SchemaType.IntegerType
+        val format: Option[String]             = Some("int32")
+        val properties: Map[String, Schema[?]] = Map.empty
+        val items: Option[Schema[?]]           = None
+        val `enum`: Option[Set[String]]        = None
+        val required: Boolean                  = true
+        val additionalProperties: Boolean      = false
+        val default: Option[Int]               = Some(42)
+        val description: Option[String]        = None
+      }
+      val serialized = BaklavaSchemaSerializable(schema)
+      serialized.default.flatMap(_.asNumber).flatMap(_.toInt) shouldBe Some(42)
+      // Critically: the JSON form is a number, not a string
+      serialized.default.map(_.noSpaces) shouldBe Some("42")
+    }
+
+    it("encodes a Long default as a JSON number") {
+      val schema     = primitiveSchema[Long](SchemaType.IntegerType, Some("int64"), Some(123456789012L))
+      val serialized = BaklavaSchemaSerializable(schema)
+      serialized.default.flatMap(_.asNumber).flatMap(_.toLong) shouldBe Some(123456789012L)
+    }
+
+    it("encodes a Boolean default as a JSON boolean") {
+      val schema     = primitiveSchema[Boolean](SchemaType.BooleanType, None, Some(true))
+      val serialized = BaklavaSchemaSerializable(schema)
+      serialized.default.flatMap(_.asBoolean) shouldBe Some(true)
+      serialized.default.map(_.noSpaces) shouldBe Some("true")
+    }
+
+    it("encodes a String default as a JSON string") {
+      val schema     = primitiveSchema[String](SchemaType.StringType, None, Some("hello"))
+      val serialized = BaklavaSchemaSerializable(schema)
+      serialized.default.flatMap(_.asString) shouldBe Some("hello")
+    }
+
+    it("emits correct swagger default when rendered via the OpenAPI generator") {
+      val schema = primitiveSchema[Int](SchemaType.IntegerType, Some("int32"), Some(42))
+      val param  = BaklavaQueryParamSerializable("page", None, BaklavaSchemaSerializable(schema))
+      val call   = syntheticCall(param)
+
+      val openAPI = new OpenAPI()
+      BaklavaDslFormatterOpenAPIWorker.generateForCalls(openAPI, Seq(call))
+      val pageParam = openAPI.getPaths
+        .get("/items")
+        .getGet
+        .getParameters
+        .asScala
+        .find(_.getName == "page")
+        .getOrElse(fail("page parameter missing"))
+
+      // `setDefault(Object)` received a java.lang.Long, swagger's YAML writer will emit a plain
+      // number (e.g. `default: 42`) rather than the stringly `default: "42"` that the old
+      // `.toString`-based code produced.
+      pageParam.getSchema.getDefault shouldBe java.lang.Long.valueOf(42L)
+    }
+  }
+
+  private def primitiveSchema[T](t: SchemaType, fmt: Option[String], dflt: Option[T]): Schema[T] = new Schema[T] {
+    val className: String                  = t.toString
+    val `type`: SchemaType                 = t
+    val format: Option[String]             = fmt
+    val properties: Map[String, Schema[?]] = Map.empty
+    val items: Option[Schema[?]]           = None
+    val `enum`: Option[Set[String]]        = None
+    val required: Boolean                  = true
+    val additionalProperties: Boolean      = false
+    val default: Option[T]                 = dflt
+    val description: Option[String]        = None
+  }
+
+  private def syntheticCall(queryParam: BaklavaQueryParamSerializable): BaklavaSerializableCall =
+    BaklavaSerializableCall(
+      request = BaklavaRequestContextSerializable(
+        symbolicPath = "/items",
+        path = "/items",
+        pathDescription = None,
+        pathSummary = None,
+        method = Some(Method("GET")),
+        operationDescription = None,
+        operationSummary = None,
+        operationId = None,
+        operationTags = Seq.empty,
+        securitySchemes = Seq.empty,
+        bodySchema = None,
+        headersSeq = Seq.empty,
+        pathParametersSeq = Seq.empty,
+        queryParametersSeq = Seq(queryParam),
+        responseDescription = None,
+        responseHeaders = Seq.empty
+      ),
+      response = BaklavaResponseContextSerializable(
+        protocol = BaklavaHttpProtocol("HTTP/1.1"),
+        status = StatusCode(200),
+        headers = Seq.empty,
+        requestBodyString = "",
+        responseBodyString = "",
+        requestContentType = None,
+        responseContentType = None,
+        bodySchema = None
+      )
+    )
+}

--- a/openapi/src/test/scala/pl/iterators/baklava/openapi/SchemaDefaultJsonSpec.scala
+++ b/openapi/src/test/scala/pl/iterators/baklava/openapi/SchemaDefaultJsonSpec.scala
@@ -69,10 +69,13 @@ class SchemaDefaultJsonSpec extends AnyFunSpec with Matchers {
         .find(_.getName == "page")
         .getOrElse(fail("page parameter missing"))
 
-      // `setDefault(Object)` received a java.lang.Long, swagger's YAML writer will emit a plain
-      // number (e.g. `default: 42`) rather than the stringly `default: "42"` that the old
+      // `setDefault(Object)` should receive a numeric Java value so swagger's YAML writer emits
+      // a plain number (e.g. `default: 42`) rather than the stringly `default: "42"` that the old
       // `.toString`-based code produced.
-      pageParam.getSchema.getDefault shouldBe java.lang.Long.valueOf(42L)
+      val defaultValue = pageParam.getSchema.getDefault
+      defaultValue shouldBe a[java.lang.Number]
+      defaultValue.asInstanceOf[java.lang.Number].longValue() shouldBe 42L
+      defaultValue should not be a[String]
     }
   }
 

--- a/simple/src/main/scala/pl/iterators/baklava/simple/BaklavaDslFormatterSimple.scala
+++ b/simple/src/main/scala/pl/iterators/baklava/simple/BaklavaDslFormatterSimple.scala
@@ -419,9 +419,11 @@ class BaklavaDslFormatterSimple extends BaklavaDslFormatter {
         "type"        -> baklavaSchema.`type`.asJson,
         "format"      -> baklavaSchema.format.asJson,
         "description" -> baklavaSchema.description.asJson,
-        "default"     -> baklavaSchema.default.asJson,
-        "enum"        -> baklavaSchema.`enum`.map(_.toList.asJson).getOrElse(Json.Null),
-        "properties"  -> (if (baklavaSchema.`type` == SchemaType.ObjectType)
+        // `default` now arrives as structured JSON (issue #61). Unwrap Option[Json] to inline it
+        // rather than re-encoding (which would wrap the Json in another layer).
+        "default"    -> baklavaSchema.default.getOrElse(Json.Null),
+        "enum"       -> baklavaSchema.`enum`.map(_.toList.asJson).getOrElse(Json.Null),
+        "properties" -> (if (baklavaSchema.`type` == SchemaType.ObjectType)
                            baklavaSchema.properties.view.mapValues(j => toJsonSchemaV7(j)).toMap.asJson
                          else Json.Null),
         "required" -> (if (baklavaSchema.`type` == SchemaType.ObjectType)

--- a/simple/src/main/scala/pl/iterators/baklava/simple/BaklavaDslFormatterSimple.scala
+++ b/simple/src/main/scala/pl/iterators/baklava/simple/BaklavaDslFormatterSimple.scala
@@ -419,8 +419,7 @@ class BaklavaDslFormatterSimple extends BaklavaDslFormatter {
         "type"        -> baklavaSchema.`type`.asJson,
         "format"      -> baklavaSchema.format.asJson,
         "description" -> baklavaSchema.description.asJson,
-        // `default` now arrives as structured JSON (issue #61). Unwrap Option[Json] to inline it
-        // rather than re-encoding (which would wrap the Json in another layer).
+        // `default` now arrives as structured JSON (issue #61) — inline it directly.
         "default"    -> baklavaSchema.default.getOrElse(Json.Null),
         "enum"       -> baklavaSchema.`enum`.map(_.toList.asJson).getOrElse(Json.Null),
         "properties" -> (if (baklavaSchema.`type` == SchemaType.ObjectType)


### PR DESCRIPTION
Closes #61.

## Problem

\`BaklavaSchemaSerializable.default\` converted \`Schema[T].default: Option[T]\` via \`.toString\`, producing invalid OpenAPI defaults for anything beyond primitive types:

- \`Seq(1, 2, 3)\` → \`\"List(1, 2, 3)\"\` (Scala syntax, not a JSON array)
- \`Map(\"a\" -> 1)\` → \`\"Map(a -> 1)\"\`
- Case classes → \`\"ProductN(...)\"\`
- Custom types → \`\"TypeName@abc123\"\`

Only primitives happened to have \`.toString\` that looked valid in YAML. PR #59 patched one symptom (bogus \`Some(None)\` from \`optionSchema\`) but left the latent trap in place.

## Fix

\`BaklavaSchemaSerializable.default\` is now \`Option[io.circe.Json]\`. The \`apply(schema)\` encoder picks the right JSON constructor based on \`schema.type\`:

| SchemaType      | Encoding                                        |
| --------------- | ----------------------------------------------- |
| \`StringType\`    | \`Json.fromString\`                               |
| \`IntegerType\`   | \`Json.fromInt/Long/Short/Byte\`                  |
| \`NumberType\`    | \`Json.fromDoubleOrString/fromBigDecimal/...\`    |
| \`BooleanType\`   | \`Json.fromBoolean\`                              |
| \`NullType\`      | \`Json.Null\`                                     |
| \`ArrayType\` / \`ObjectType\` | JSON string fallback (valid JSON, but users with structured defaults should override) |

Carry-through:
- \`BaklavaSerialize\`: jsoniter \`JsonValueCodec[Json]\` using \`readRawValAsBytes\` / \`writeRawVal\` so the on-disk serialized call format round-trips without stringifying.
- \`openapi\` worker: converts \`Json\` to the \`Object\` shape swagger's \`setDefault\` expects. An Int default now emits \`default: 42\` in YAML (not \`default: \"42\"\`).
- \`simple\` formatter: \`default.asJson\` → \`default.getOrElse(Json.Null)\` so the structured value inlines into JSON Schema output.

## Test plan

- [x] \`sbt 'project openapi' '++ 2.13' test\` — 97/97 pass
- [x] \`sbt 'project openapi' '++ 3' test\` — 97/97 pass
- [x] \`sbt 'project simple' '++ 2.13' test\` — 15/15 pass
- [x] New \`SchemaDefaultJsonSpec\` covers Int / Long / Boolean / String primitive encoding + end-to-end swagger default rendering