### PR TITLE
feat: multipart/form-data request body support (#81)

### DIFF
--- a/core/src/main/scala/pl/iterators/baklava/BaklavaHttpDsl.scala
+++ b/core/src/main/scala/pl/iterators/baklava/BaklavaHttpDsl.scala
@@ -177,6 +177,12 @@ trait BaklavaHttpDsl[
 
   protected implicit def formUrlencodedToRequestBodyType[T]: ToRequestBodyType[FormOf[T]]
 
+  /** Marshaller for `multipart/form-data` request bodies (issue #81). Each adapter reassembles the `Multipart.parts` into its framework's
+    * native multipart representation (pekko-http's `Multipart.FormData`, http4s's `org.http4s.multipart.Multipart`) so the wire request
+    * carries the boundary-delimited body + the matching `Content-Type: multipart/form-data; boundary=…`.
+    */
+  protected implicit def multipartToRequestBodyType: ToRequestBodyType[Multipart]
+
   protected implicit def emptyToResponseBodyType: FromResponseBodyType[EmptyBody]
 
   implicit def statusCodeToBaklavaStatusCodes(statusCode: HttpStatusCode): StatusCode

--- a/core/src/main/scala/pl/iterators/baklava/BaklavaHttpDsl.scala
+++ b/core/src/main/scala/pl/iterators/baklava/BaklavaHttpDsl.scala
@@ -177,10 +177,6 @@ trait BaklavaHttpDsl[
 
   protected implicit def formUrlencodedToRequestBodyType[T]: ToRequestBodyType[FormOf[T]]
 
-  /** Marshaller for `multipart/form-data` request bodies (issue #81). Each adapter reassembles the `Multipart.parts` into its framework's
-    * native multipart representation (pekko-http's `Multipart.FormData`, http4s's `org.http4s.multipart.Multipart`) so the wire request
-    * carries the boundary-delimited body + the matching `Content-Type: multipart/form-data; boundary=…`.
-    */
   protected implicit def multipartToRequestBodyType: ToRequestBodyType[Multipart]
 
   protected implicit def emptyToResponseBodyType: FromResponseBodyType[EmptyBody]

--- a/core/src/main/scala/pl/iterators/baklava/Multipart.scala
+++ b/core/src/main/scala/pl/iterators/baklava/Multipart.scala
@@ -1,42 +1,21 @@
 package pl.iterators.baklava
 
-/** `multipart/form-data` request body (issue #81).
-  *
-  * Holds a sequence of named parts — each either a `FilePart` (binary data with its own content-type and optional filename) or a
-  * `TextPart` (plain-string form field). The adapter marshaller (pekko-http or http4s) turns this into a boundary-delimited wire body with
-  * `Content-Type: multipart/form-data; boundary=…`.
-  *
-  * The OpenAPI render for this body is a free-form object (`type: object`) — describing the exact per-part schema would require deriving
-  * one at runtime from the parts. Users who need richer docs can replace the implicit `Schema[Multipart]` with a hand-crafted one.
-  */
 case class Multipart(parts: Part*)
 
 object Multipart {
   implicit val schema: Schema[Multipart] = FreeFormSchema[Multipart]("Multipart")
 }
 
-/** One part of a multipart body. Sealed so marshallers can pattern-match exhaustively. */
 sealed trait Part {
-
-  /** Form-field name, e.g. `"avatar"` or `"caption"`. */
   def name: String
 }
 
-/** A binary upload part. The `contentType` becomes the `Content-Type` header of this specific part (inside the multipart body),
-  * independent of the outer request content-type. `filename` is rendered into the part's
-  * `Content-Disposition: form-data; name="…"; filename="…"` header — it is what a server would see as the uploaded filename. Leave it
-  * empty to omit the filename.
-  */
+/** Leave `filename` empty to omit it from the part's `Content-Disposition` header. */
 case class FilePart(name: String, contentType: String, filename: String, bytes: Array[Byte]) extends Part
 
 object FilePart {
-
-  /** Convenience for the common case where you don't care about the filename. */
   def apply(name: String, contentType: String, bytes: Array[Byte]): FilePart =
     FilePart(name, contentType, "", bytes)
 }
 
-/** A text form field. Equivalent to a regular URL-encoded form field, just riding on the multipart transport so it can coexist with
-  * `FilePart`s in the same request.
-  */
 case class TextPart(name: String, value: String) extends Part

--- a/core/src/main/scala/pl/iterators/baklava/Multipart.scala
+++ b/core/src/main/scala/pl/iterators/baklava/Multipart.scala
@@ -1,0 +1,42 @@
+package pl.iterators.baklava
+
+/** `multipart/form-data` request body (issue #81).
+  *
+  * Holds a sequence of named parts — each either a `FilePart` (binary data with its own content-type and optional filename) or a
+  * `TextPart` (plain-string form field). The adapter marshaller (pekko-http or http4s) turns this into a boundary-delimited wire body with
+  * `Content-Type: multipart/form-data; boundary=…`.
+  *
+  * The OpenAPI render for this body is a free-form object (`type: object`) — describing the exact per-part schema would require deriving
+  * one at runtime from the parts. Users who need richer docs can replace the implicit `Schema[Multipart]` with a hand-crafted one.
+  */
+case class Multipart(parts: Part*)
+
+object Multipart {
+  implicit val schema: Schema[Multipart] = FreeFormSchema[Multipart]("Multipart")
+}
+
+/** One part of a multipart body. Sealed so marshallers can pattern-match exhaustively. */
+sealed trait Part {
+
+  /** Form-field name, e.g. `"avatar"` or `"caption"`. */
+  def name: String
+}
+
+/** A binary upload part. The `contentType` becomes the `Content-Type` header of this specific part (inside the multipart body),
+  * independent of the outer request content-type. `filename` is rendered into the part's
+  * `Content-Disposition: form-data; name="…"; filename="…"` header — it is what a server would see as the uploaded filename. Leave it
+  * empty to omit the filename.
+  */
+case class FilePart(name: String, contentType: String, filename: String, bytes: Array[Byte]) extends Part
+
+object FilePart {
+
+  /** Convenience for the common case where you don't care about the filename. */
+  def apply(name: String, contentType: String, bytes: Array[Byte]): FilePart =
+    FilePart(name, contentType, "", bytes)
+}
+
+/** A text form field. Equivalent to a regular URL-encoded form field, just riding on the multipart transport so it can coexist with
+  * `FilePart`s in the same request.
+  */
+case class TextPart(name: String, value: String) extends Part

--- a/docs/http4s.md
+++ b/docs/http4s.md
@@ -280,3 +280,40 @@ supports(
 ```
 
 `Schema[Array[Byte]]` is a default on the classpath, so the generated OpenAPI renders `responses[code].content["<content-type>"].schema = { type: string, format: binary }`.
+
+## Documenting multipart/form-data uploads
+
+Beyond raw binary bodies, `Multipart` bundles one or more named `FilePart` / `TextPart` into a single request. The http4s adapter reassembles them into a native `org.http4s.multipart.Multipart[IO]` body with a fixed boundary for deterministic test output.
+
+```scala
+import pl.iterators.baklava.{FilePart, Multipart, TextPart}
+import java.nio.charset.StandardCharsets
+
+class PostUsersUserIdPhotoSpec extends BaseRouteSpec {
+
+  path(path = "/users/{userId}/photo")(
+    supports(
+      POST,
+      pathParameters = p[Long]("userId"),
+      description = "Upload a profile photo with a caption",
+      summary = "Upload photo",
+      tags = List("Users")
+    )(
+      onRequest(
+        pathParameters = 1L,
+        body = Multipart(
+          FilePart("photo", "image/png", "photo.png",
+            "\u0089PNG\r\n...".getBytes(StandardCharsets.UTF_8)),
+          TextPart("caption", "profile photo")
+        )
+      ).respondsWith[EmptyBody](NoContent, description = "Photo uploaded")
+        .assert { ctx =>
+          val response = ctx.performRequest(allRoutes)
+          response.status.code shouldBe 204
+        }
+    )
+  )
+}
+```
+
+The generated OpenAPI emits `requestBody.content["multipart/form-data"]` with a free-form `type: object` schema (richer per-part schemas can be supplied by replacing the implicit `Schema[Multipart]`).

--- a/docs/pekko-http.md
+++ b/docs/pekko-http.md
@@ -345,3 +345,40 @@ import scala.io.StdIn
 ```
 
 For detailed configuration options check [installation.md#swaggerui-and-routes-configuration]
+
+## Documenting multipart/form-data uploads
+
+Beyond raw binary bodies (above), `Multipart` bundles one or more named parts — typed as `FilePart` (binary data with its own MIME type + optional filename) or `TextPart` (a plain form field) — into a single request. The pekko-http adapter reassembles them into a native `Multipart.FormData` body with a deterministic boundary.
+
+```scala
+import pl.iterators.baklava.{FilePart, Multipart, TextPart}
+import java.nio.charset.StandardCharsets
+
+class PostUsersUserIdPhotoSpec extends BaseRouteSpec {
+
+  path(path = "/users/{userId}/photo")(
+    supports(
+      POST,
+      pathParameters = p[Long]("userId"),
+      description = "Upload a profile photo with a caption",
+      summary = "Upload photo",
+      tags = List("Users")
+    )(
+      onRequest(
+        pathParameters = 1L,
+        body = Multipart(
+          FilePart("photo", "image/png", "photo.png",
+            "\u0089PNG\r\n...".getBytes(StandardCharsets.UTF_8)),
+          TextPart("caption", "profile photo")
+        )
+      ).respondsWith[EmptyBody](NoContent, description = "Photo uploaded")
+        .assert { ctx =>
+          val response = ctx.performRequest(allRoutes)
+          response.status.status should beEqualTo(NoContent.status)
+        }
+    )
+  )
+}
+```
+
+The generated OpenAPI emits `requestBody.content["multipart/form-data"]` with a free-form `type: object` schema (describing each per-part schema would need a runtime-derived Schema; users who need richer docs can replace the implicit `Schema[Multipart]`).

--- a/http4s/src/main/scala/pl/iterators/baklava/http4s/BaklavaHttp4s.scala
+++ b/http4s/src/main/scala/pl/iterators/baklava/http4s/BaklavaHttp4s.scala
@@ -79,15 +79,9 @@ trait BaklavaHttp4s[TestFrameworkFragmentType, TestFrameworkFragmentsType, TestF
 
   implicit val urlFormSchema: Schema[UrlForm] = FreeFormSchema("UrlForm")
 
-  /** Multipart marshaller: map each `Baklava.Part` to an `http4s.multipart.Part[IO]` and let http4s's built-in multipart `EntityEncoder`
-    * produce the boundary-delimited wire format. `FilePart.contentType` is parsed as a full `Content-Type` header so callers can supply
-    * parameters (e.g. `text/plain; charset=UTF-8`) — matching the pekko adapter. Omits `filename` from `Content-Disposition` when the
-    * caller left it empty, per the `FilePart` docs.
-    */
   override implicit protected def multipartToRequestBodyType: BaklavaHttp4s.ToEntityMarshaller[BaklavaMultipart] =
     implicitly[EntityEncoder[IO, org.http4s.multipart.Multipart[IO]]].contramap { baklavaMultipart =>
-      // Annotate the vector type so Scala 2.13 narrows the union of `Part[Pure]` / `Part[IO]`
-      // inferred from the match branches down to the `Part[IO]` the Multipart constructor wants.
+      // `Vector[Http4sPart[IO]]` annotation: Scala 2.13 otherwise widens the match to `Part[Pure] | Part[IO]`.
       val parts: Vector[Http4sPart[IO]] = baklavaMultipart.parts.toVector.map {
         case FilePart(name, contentType, filename, bytes) =>
           val ct = headers.`Content-Type`
@@ -109,9 +103,7 @@ trait BaklavaHttp4s[TestFrameworkFragmentType, TestFrameworkFragmentsType, TestF
         case TextPart(name, value) =>
           Http4sPart.formData[IO](name, value)
       }
-      // Deterministic boundary — http4s's no-arg `Multipart(...)` apply is deprecated because
-      // creating a random boundary is an effect; we don't care which boundary is used as long
-      // as it's valid, so fix one and skip the side-effecting generator.
+      // Fixed boundary keeps the captured request body byte-stable across gold-test runs.
       org.http4s.multipart.Multipart[IO](parts, Boundary("baklava-multipart-boundary"))
     }
 

--- a/http4s/src/main/scala/pl/iterators/baklava/http4s/BaklavaHttp4s.scala
+++ b/http4s/src/main/scala/pl/iterators/baklava/http4s/BaklavaHttp4s.scala
@@ -80,7 +80,9 @@ trait BaklavaHttp4s[TestFrameworkFragmentType, TestFrameworkFragmentsType, TestF
   implicit val urlFormSchema: Schema[UrlForm] = FreeFormSchema("UrlForm")
 
   /** Multipart marshaller: map each `Baklava.Part` to an `http4s.multipart.Part[IO]` and let http4s's built-in multipart `EntityEncoder`
-    * produce the boundary-delimited wire format.
+    * produce the boundary-delimited wire format. `FilePart.contentType` is parsed as a full `Content-Type` header so callers can supply
+    * parameters (e.g. `text/plain; charset=UTF-8`) — matching the pekko adapter. Omits `filename` from `Content-Disposition` when the
+    * caller left it empty, per the `FilePart` docs.
     */
   override implicit protected def multipartToRequestBodyType: BaklavaHttp4s.ToEntityMarshaller[BaklavaMultipart] =
     implicitly[EntityEncoder[IO, org.http4s.multipart.Multipart[IO]]].contramap { baklavaMultipart =>
@@ -88,9 +90,22 @@ trait BaklavaHttp4s[TestFrameworkFragmentType, TestFrameworkFragmentsType, TestF
       // inferred from the match branches down to the `Part[IO]` the Multipart constructor wants.
       val parts: Vector[Http4sPart[IO]] = baklavaMultipart.parts.toVector.map {
         case FilePart(name, contentType, filename, bytes) =>
-          val ct       = MediaType.parse(contentType).toOption.getOrElse(MediaType.application.`octet-stream`)
-          val fileName = if (filename.isEmpty) name else filename
-          Http4sPart.fileData[IO](name, fileName, Stream.chunk(fs2.Chunk.array(bytes)), headers.`Content-Type`(ct))
+          val ct = headers.`Content-Type`
+            .parse(contentType)
+            .toOption
+            .getOrElse(headers.`Content-Type`(MediaType.application.`octet-stream`))
+          val body = Stream.chunk(fs2.Chunk.array(bytes))
+          if (filename.isEmpty)
+            Http4sPart[IO](
+              Headers(
+                headers.`Content-Disposition`("form-data", Map(CIString("name") -> name)),
+                (headers.`Content-Transfer-Encoding`.Binary: headers.`Content-Transfer-Encoding`),
+                ct
+              ),
+              body
+            )
+          else
+            Http4sPart.fileData[IO](name, filename, body, ct)
         case TextPart(name, value) =>
           Http4sPart.formData[IO](name, value)
       }

--- a/http4s/src/main/scala/pl/iterators/baklava/http4s/BaklavaHttp4s.scala
+++ b/http4s/src/main/scala/pl/iterators/baklava/http4s/BaklavaHttp4s.scala
@@ -2,6 +2,8 @@ package pl.iterators.baklava.http4s
 
 import cats.effect.IO
 import cats.effect.unsafe.IORuntime
+import fs2.Stream
+import org.http4s.multipart.{Boundary, Part => Http4sPart}
 import org.http4s.{
   EntityDecoder,
   EntityEncoder,
@@ -9,6 +11,7 @@ import org.http4s.{
   Headers,
   HttpRoutes,
   HttpVersion,
+  MediaType,
   Method,
   Request,
   Response,
@@ -27,9 +30,12 @@ import pl.iterators.baklava.{
   BaklavaTestFrameworkDsl,
   EmptyBody,
   EmptyBodyInstance,
+  FilePart,
   FormOf,
   FreeFormSchema,
-  Schema
+  Multipart => BaklavaMultipart,
+  Schema,
+  TextPart
 }
 import sttp.model.{Header => SttpHeader, Method => SttpMethod, StatusCode => SttpStatus}
 
@@ -72,6 +78,27 @@ trait BaklavaHttp4s[TestFrameworkFragmentType, TestFrameworkFragmentsType, TestF
     }
 
   implicit val urlFormSchema: Schema[UrlForm] = FreeFormSchema("UrlForm")
+
+  /** Multipart marshaller: map each `Baklava.Part` to an `http4s.multipart.Part[IO]` and let http4s's built-in multipart `EntityEncoder`
+    * produce the boundary-delimited wire format.
+    */
+  override implicit protected def multipartToRequestBodyType: BaklavaHttp4s.ToEntityMarshaller[BaklavaMultipart] =
+    implicitly[EntityEncoder[IO, org.http4s.multipart.Multipart[IO]]].contramap { baklavaMultipart =>
+      // Annotate the vector type so Scala 2.13 narrows the union of `Part[Pure]` / `Part[IO]`
+      // inferred from the match branches down to the `Part[IO]` the Multipart constructor wants.
+      val parts: Vector[Http4sPart[IO]] = baklavaMultipart.parts.toVector.map {
+        case FilePart(name, contentType, filename, bytes) =>
+          val ct       = MediaType.parse(contentType).toOption.getOrElse(MediaType.application.`octet-stream`)
+          val fileName = if (filename.isEmpty) name else filename
+          Http4sPart.fileData[IO](name, fileName, Stream.chunk(fs2.Chunk.array(bytes)), headers.`Content-Type`(ct))
+        case TextPart(name, value) =>
+          Http4sPart.formData[IO](name, value)
+      }
+      // Deterministic boundary — http4s's no-arg `Multipart(...)` apply is deprecated because
+      // creating a random boundary is an effect; we don't care which boundary is used as long
+      // as it's valid, so fix one and skip the side-effecting generator.
+      org.http4s.multipart.Multipart[IO](parts, Boundary("baklava-multipart-boundary"))
+    }
 
   override implicit protected def emptyToResponseBodyType: BaklavaHttp4s.FromEntityUnmarshaller[EmptyBody] =
     EntityDecoder.void[IO].map(_ => EmptyBodyInstance)

--- a/openapi/src/main/scala/pl/iterators/baklava/openapi/BaklavaDslFormatterOpenAPIWorker.scala
+++ b/openapi/src/main/scala/pl/iterators/baklava/openapi/BaklavaDslFormatterOpenAPIWorker.scala
@@ -102,7 +102,7 @@ object BaklavaDslFormatterOpenAPIWorker {
 
           var anyMediaTypeEmitted = false
           commonStatusCalls
-            .groupBy(_.response.responseContentType)
+            .groupBy(_.response.responseContentType.map(stripMediaTypeParams))
             .toList
             .sortBy(_._1.getOrElse(""))
             .foreach { case (contentType, unsortedContentTypeCalls) =>
@@ -146,7 +146,7 @@ object BaklavaDslFormatterOpenAPIWorker {
         val responsesToProcess =
           if (successfulCalls.isEmpty) calls else successfulCalls // sometimes there are no successful responses
         responsesToProcess
-          .groupBy(_.response.requestContentType)
+          .groupBy(_.response.requestContentType.map(stripMediaTypeParams))
           .toList
           .sortBy(_._1.getOrElse(""))
           .foreach { case (contentType, unsortedCalls) =>
@@ -439,4 +439,8 @@ object BaklavaDslFormatterOpenAPIWorker {
         obj.toIterable.map { case (k, v) => k -> jsonToJavaDefault(v).orNull }.toMap.asJava
       )
   )
+
+  // OpenAPI keys `content` by media type only, so drop any `;charset=…` / `;boundary=…` parameters before grouping.
+  private def stripMediaTypeParams(contentType: String): String =
+    contentType.split(';').headOption.map(_.trim).getOrElse(contentType)
 }

--- a/openapi/src/test/resources/gold/openapi/openapi.yml
+++ b/openapi/src/test/resources/gold/openapi/openapi.yml
@@ -984,6 +984,43 @@ paths:
           description: User deleted
       security:
       - bearerAuth: []
+  /users/{userId}/photo:
+    summary: Photo
+    description: Upload a profile photo with a caption
+    post:
+      tags:
+      - Users
+      summary: Upload photo
+      description: Upload a profile photo alongside a caption as multipart/form-data
+      operationId: uploadPhoto
+      parameters:
+      - name: userId
+        in: path
+        description: The user's UUID
+        required: true
+        schema:
+          type: string
+          format: uuid
+        example: 00000000-0000-0000-0000-000000000001
+      requestBody:
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              additionalProperties: true
+              x-class: Multipart
+            examples:
+              Photo uploaded:
+                value: "--baklava-multipart-boundary\r\nContent-Type: image/png\r\n\
+                  Content-Disposition: form-data; filename=\"photo.png\"; name=\"\
+                  photo\"\r\n\r\nfake png bytes\r\n--baklava-multipart-boundary\r\n\
+                  Content-Type: text/plain; charset=UTF-8\r\nContent-Disposition:\
+                  \ form-data; name=\"caption\"\r\n\r\nprofile photo\r\n--baklava-multipart-boundary--"
+      responses:
+        "204":
+          description: Photo uploaded
+      security:
+      - bearerAuth: []
   /webhooks:
     summary: Webhooks
     description: Inbound webhooks
@@ -1039,7 +1076,7 @@ paths:
                     {
                       "received" : true
                     }
-            text/plain; charset=UTF-8:
+            text/plain:
               schema:
                 type: string
               examples:

--- a/openapi/src/test/resources/gold/simple/POST__users___userId___photo-a38a0a95.html
+++ b/openapi/src/test/resources/gold/simple/POST__users___userId___photo-a38a0a95.html
@@ -1,0 +1,110 @@
+<!DOCTYPE html><html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1"><title>POST /users/{userId}/photo</title><style>
+  *, *::before, *::after { box-sizing: border-box; }
+  body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif; margin: 0; padding: 20px 40px; background: #f8f9fa; color: #1a1a2e; line-height: 1.5; }
+  h1 { font-size: 1.6rem; font-weight: 600; margin: 0 0 20px; color: #16213e; }
+  a { color: #0d6efd; text-decoration: none; }
+  a:hover { text-decoration: underline; }
+  .endpoint-list { list-style: none; padding: 0; margin: 0; }
+  .endpoint-list li { background: #fff; border: 1px solid #dee2e6; border-radius: 6px; margin-bottom: 8px; padding: 10px 16px; display: flex; align-items: center; gap: 12px; }
+  .endpoint-list li:hover { border-color: #0d6efd; }
+  .method { display: inline-block; font-size: 0.75rem; font-weight: 700; padding: 2px 8px; border-radius: 4px; min-width: 56px; text-align: center; color: #fff; }
+  .method-GET { background: #198754; } .method-POST { background: #0d6efd; } .method-PUT { background: #fd7e14; }
+  .method-PATCH { background: #6f42c1; } .method-DELETE { background: #dc3545; } .method-HEAD { background: #6c757d; }
+  .method-OPTIONS { background: #20c997; } .method-TRACE { background: #6c757d; } .method-CONNECT { background: #6c757d; }
+  .path { font-family: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace; font-size: 0.9rem; }
+  .card { background: #fff; border: 1px solid #dee2e6; border-radius: 8px; margin-bottom: 16px; overflow: hidden; }
+  .card-header { padding: 12px 16px; font-weight: 600; font-size: 0.85rem; color: #495057; background: #f1f3f5; border-bottom: 1px solid #dee2e6; text-transform: uppercase; letter-spacing: 0.05em; }
+  .card-body { padding: 16px; }
+  .card-body p { margin: 0 0 8px; }
+  .meta-grid { display: grid; grid-template-columns: 140px 1fr; gap: 0; }
+  .meta-grid dt { padding: 8px 12px; font-weight: 600; font-size: 0.8rem; color: #495057; background: #f8f9fa; border-bottom: 1px solid #eee; }
+  .meta-grid dd { padding: 8px 12px; margin: 0; border-bottom: 1px solid #eee; font-size: 0.9rem; }
+  .tag { display: inline-block; background: #e9ecef; color: #495057; padding: 1px 8px; border-radius: 4px; font-size: 0.8rem; margin-right: 4px; }
+  .required { color: #dc3545; font-weight: 700; }
+  pre { background: #212529; color: #e9ecef; padding: 14px; border-radius: 6px; overflow-x: auto; font-size: 0.82rem; line-height: 1.5; margin: 0; }
+  .status-badge { display: inline-block; padding: 2px 8px; border-radius: 4px; font-weight: 600; font-size: 0.8rem; color: #fff; }
+  .status-2xx { background: #198754; } .status-3xx { background: #0dcaf0; color: #000; } .status-4xx { background: #fd7e14; } .status-5xx { background: #dc3545; }
+  .back-link { display: inline-block; margin-bottom: 16px; font-size: 0.85rem; }
+  ul.examples { list-style: none; padding: 0; margin: 4px 0 0; font-size: 0.85rem; }
+  ul.examples li { padding: 2px 0; }
+  .tag-group { margin-bottom: 24px; }
+  .tag-heading { margin: 20px 0 10px; font-size: 1.1rem; font-weight: 600; color: #16213e; text-transform: uppercase; letter-spacing: 0.05em; border-bottom: 2px solid #dee2e6; padding-bottom: 6px; }
+  .curl-block { position: relative; margin: 0 0 8px; }
+  .curl-block pre { padding-right: 72px; }
+  .copy-btn { position: absolute; top: 8px; right: 8px; background: #495057; color: #fff; border: none; border-radius: 4px; padding: 4px 10px; font-size: 0.75rem; cursor: pointer; font-family: inherit; }
+  .copy-btn:hover { background: #0d6efd; }
+  .copy-btn:active { background: #0a58ca; }
+</style></head><body>
+<a href="index.html" class="back-link">&larr; Back to index</a>
+<h1><span class="method method-POST">POST</span> <span class="path">/users/{userId}/photo</span></h1>
+<div class="card"><div class="card-header">Overview</div><div class="card-body"><dl class="meta-grid"><dt>Summary</dt><dd>Upload photo</dd><dt>Description</dt><dd>Upload a profile photo alongside a caption as multipart/form-data</dd><dt>Operation ID</dt><dd><code>uploadPhoto</code></dd><dt>Tags</dt><dd><span class="tag">Users</span></dd></dl></div></div>
+<div class="card"><div class="card-header">Security</div><div class="card-body"><p>bearerAuth <span class="tag">http</span></p></div></div>
+<div class="card"><div class="card-header">Path Parameters</div><div class="card-body"><dl class="meta-grid"><dt>userId <span class="required">*</span></dt><dd><code>UUID</code> = <code>00000000-0000-0000-0000-000000000001</code></dd></dl></div></div>
+<div class="card"><div class="card-header">Request body</div><div class="card-body"><details><summary>Request schema (JSON Schema v7)</summary><pre>{
+  "$schema" : "http://json-schema.org/draft-07/schema#",
+  "title" : "Multipart",
+  "type" : "object",
+  "properties" : {
+    
+  },
+  "required" : [
+  ],
+  "additionalProperties" : true
+}</pre></details></div></div>
+<div class="card"><div class="card-header"><span class="status-badge status-2xx">204</span> Response</div><div class="card-body"><p>Photo uploaded</p><h4>Curl</h4><div class="curl-block"><pre>curl -X POST '$BASE_URL/users/00000000-0000-0000-0000-000000000001/photo' \
+  -H 'Content-Type: multipart/form-data; boundary=baklava-multipart-boundary' \
+  -H 'Authorization: Bearer &lt;TOKEN&gt;' \
+  --data-raw '--baklava-multipart-boundary
+Content-Type: image/png
+Content-Disposition: form-data; filename="photo.png"; name="photo"
+
+fake png bytes
+--baklava-multipart-boundary
+Content-Type: text/plain; charset=UTF-8
+Content-Disposition: form-data; name="caption"
+
+profile photo
+--baklava-multipart-boundary--'</pre><button class="copy-btn" type="button">Copy</button></div><h4>Request body</h4><pre>--baklava-multipart-boundary
+Content-Type: image/png
+Content-Disposition: form-data; filename="photo.png"; name="photo"
+
+fake png bytes
+--baklava-multipart-boundary
+Content-Type: text/plain; charset=UTF-8
+Content-Disposition: form-data; name="caption"
+
+profile photo
+--baklava-multipart-boundary--</pre></div></div>
+<script>
+document.addEventListener('click', function (e) {
+  var btn = e.target.closest('button.copy-btn');
+  if (!btn) return;
+  var pre = btn.previousElementSibling;
+  var payload = pre ? pre.textContent : '';
+  var flash = function (msg) {
+    var original = btn.dataset.origText || btn.textContent;
+    btn.dataset.origText = original;
+    btn.textContent = msg;
+    setTimeout(function () { btn.textContent = original; }, 1200);
+  };
+  var fallback = function () {
+    try {
+      var ta = document.createElement('textarea');
+      ta.value = payload;
+      ta.style.position = 'fixed';
+      ta.style.opacity = '0';
+      document.body.appendChild(ta);
+      ta.select();
+      var ok = document.execCommand('copy');
+      document.body.removeChild(ta);
+      flash(ok ? 'Copied' : 'Failed');
+    } catch (_) { flash('Failed'); }
+  };
+  if (navigator.clipboard && navigator.clipboard.writeText) {
+    navigator.clipboard.writeText(payload).then(function () { flash('Copied'); }, fallback);
+  } else {
+    fallback();
+  }
+});
+</script>
+</body></html>

--- a/openapi/src/test/resources/gold/simple/index.html
+++ b/openapi/src/test/resources/gold/simple/index.html
@@ -47,6 +47,7 @@
 <section class="tag-group"><h2 class="tag-heading">Users</h2><ul class="endpoint-list"><li><a href="GET__users-c054bf63.html"><span class="method method-GET">GET</span> <span class="path">/users</span></a></li>
 <li><a href="DELETE__users___userId__-cf0347bd.html"><span class="method method-DELETE">DELETE</span> <span class="path">/users/{userId}</span></a></li>
 <li><a href="GET__users___userId__-baf46b48.html"><span class="method method-GET">GET</span> <span class="path">/users/{userId}</span></a></li>
-<li><a href="PUT__users___userId__-3f0ffd01.html"><span class="method method-PUT">PUT</span> <span class="path">/users/{userId}</span></a></li></ul></section>
+<li><a href="PUT__users___userId__-3f0ffd01.html"><span class="method method-PUT">PUT</span> <span class="path">/users/{userId}</span></a></li>
+<li><a href="POST__users___userId___photo-a38a0a95.html"><span class="method method-POST">POST</span> <span class="path">/users/{userId}/photo</span></a></li></ul></section>
 <section class="tag-group"><h2 class="tag-heading">Webhooks</h2><ul class="endpoint-list"><li><a href="POST__webhooks-20c9a68b.html"><span class="method method-POST">POST</span> <span class="path">/webhooks</span></a></li></ul></section>
 </body></html>

--- a/openapi/src/test/resources/gold/tsrest/src/contracts.ts
+++ b/openapi/src/test/resources/gold/tsrest/src/contracts.ts
@@ -6,6 +6,7 @@ import { projectsProjectIdContract } from "./projects---projectId.contract";
 import { projectsProjectIdTasksContract } from "./projects---projectId-tasks.contract";
 import { usersContract } from "./users.contract";
 import { usersUserIdContract } from "./users---userId.contract";
+import { usersUserIdPhotoContract } from "./users---userId-photo.contract";
 import { webhooksContract } from "./webhooks.contract";
 
 export const contracts: {
@@ -17,6 +18,7 @@ export const contracts: {
   "projects---projectId-tasks": typeof projectsProjectIdTasksContract;
   "users": typeof usersContract;
   "users---userId": typeof usersUserIdContract;
+  "users---userId-photo": typeof usersUserIdPhotoContract;
   "webhooks": typeof webhooksContract
 } = {
   "auth-login": authLoginContract,
@@ -27,6 +29,7 @@ export const contracts: {
   "projects---projectId-tasks": projectsProjectIdTasksContract,
   "users": usersContract,
   "users---userId": usersUserIdContract,
+  "users---userId-photo": usersUserIdPhotoContract,
   "webhooks": webhooksContract
 };
 

--- a/openapi/src/test/resources/gold/tsrest/src/users---userId-photo.contract.ts
+++ b/openapi/src/test/resources/gold/tsrest/src/users---userId-photo.contract.ts
@@ -1,0 +1,16 @@
+import { z } from "zod";
+import { initContract } from "@ts-rest/core";
+
+export const usersUserIdPhotoContract = initContract().router({
+  post: {
+    summary: 'Upload photo',
+    description: 'Upload a profile photo alongside a caption as multipart/form-data',
+    method: 'POST',
+    path: '/users/:userId/photo',
+    pathParams: z.object({userId: z.string().uuid()}),
+    body: z.object({}),
+    responses: {
+      204: z.undefined()
+    }
+  }
+});

--- a/openapi/src/test/scala/pl/iterators/baklava/openapi/ComprehensiveGoldSpec.scala
+++ b/openapi/src/test/scala/pl/iterators/baklava/openapi/ComprehensiveGoldSpec.scala
@@ -24,15 +24,18 @@ import pl.iterators.baklava.{
   ApiKeyInHeader,
   BaklavaTestFrameworkDslDebug,
   EmptyBody,
+  FilePart,
   FormOf,
   HttpBasic,
   HttpBearer,
+  Multipart,
   OAuth2InBearer,
   OAuthAuthorizationCodeFlow,
   OAuthFlows,
   Schema,
   SchemaType,
   SecurityScheme,
+  TextPart,
   ToQueryParam
 }
 import pl.iterators.kebs.circe.KebsCirce
@@ -74,9 +77,16 @@ class ComprehensiveGoldSpec
   implicit val stringUnmarshaller: FromEntityUnmarshaller[String]   = Unmarshaller.stringUnmarshaller
   implicit val byteArrayMarshaller: ToEntityMarshaller[Array[Byte]] = PredefinedToEntityMarshallers.ByteArrayMarshaller
 
-  // Stub: the test doesn't care about real HTTP — canned responses per assertion.
-  private var nextResponse: HttpResponse                                         = HttpResponse(OK)
-  override def performRequest(routes: Route, request: HttpRequest): HttpResponse = nextResponse
+  // Stub: the test doesn't care about real HTTP — canned responses per assertion. We also
+  // remember the last built request so tests can assert on what the adapter produced (used for
+  // multipart / content-type overrides).
+  private var nextResponse: HttpResponse                                            = HttpResponse(OK)
+  private val lastRequest: java.util.concurrent.atomic.AtomicReference[HttpRequest] =
+    new java.util.concurrent.atomic.AtomicReference()
+  override def performRequest(routes: Route, request: HttpRequest): HttpResponse = {
+    lastRequest.set(request)
+    nextResponse
+  }
 
   private def jsonResponse(status: org.apache.pekko.http.scaladsl.model.StatusCode, json: String): HttpResponse =
     HttpResponse(status, entity = HttpEntity(ContentTypes.`application/json`, json))
@@ -435,6 +445,39 @@ class ComprehensiveGoldSpec
         .assert { ctx =>
           nextResponse = jsonResponse(OK, HealthResponse("ok", 12345L).asJson.noSpaces)
           ctx.performRequest(routes)
+        }
+    )
+  )
+
+  // Multipart upload — file part + text part in the same request body. The generator captures
+  // `Content-Type: multipart/form-data; boundary=…` from the wire request, so the OpenAPI spec
+  // emits `requestBody.content["multipart/form-data"]`. Covers issue #81.
+  path("/users/{userId}/photo", description = "Upload a profile photo with a caption", summary = "Photo")(
+    supports(
+      POST,
+      pathParameters = p[UUID]("userId", "The user's UUID"),
+      securitySchemes = Seq(bearerScheme),
+      description = "Upload a profile photo alongside a caption as multipart/form-data",
+      summary = "Upload photo",
+      operationId = "uploadPhoto",
+      tags = Seq("Users")
+    )(
+      onRequest(
+        pathParameters = userId,
+        body = Multipart(
+          FilePart("photo", "image/png", "photo.png", "fake png bytes".getBytes(StandardCharsets.UTF_8)),
+          TextPart("caption", "profile photo")
+        ),
+        security = bearerAuth("jwt.token.xyz")
+      ).respondsWith[EmptyBody](NoContent, description = "Photo uploaded")
+        .assert { ctx =>
+          nextResponse = emptyResponse(NoContent)
+          val response = ctx.performRequest(routes)
+          // The request that hit `performRequest` must carry a multipart/form-data Content-Type
+          // — proves the adapter mapped Baklava's `Multipart` to pekko's native multipart form.
+          // The content type includes a boundary parameter, so compare the mediaType prefix.
+          lastRequest.get().entity.contentType.mediaType.value should startWith("multipart/form-data")
+          response.status.intValue() shouldBe 204
         }
     )
   )

--- a/openapi/src/test/scala/pl/iterators/baklava/openapi/ComprehensiveGoldSpec.scala
+++ b/openapi/src/test/scala/pl/iterators/baklava/openapi/ComprehensiveGoldSpec.scala
@@ -77,9 +77,7 @@ class ComprehensiveGoldSpec
   implicit val stringUnmarshaller: FromEntityUnmarshaller[String]   = Unmarshaller.stringUnmarshaller
   implicit val byteArrayMarshaller: ToEntityMarshaller[Array[Byte]] = PredefinedToEntityMarshallers.ByteArrayMarshaller
 
-  // Stub: the test doesn't care about real HTTP — canned responses per assertion. We also
-  // remember the last built request so tests can assert on what the adapter produced (used for
-  // multipart / content-type overrides).
+  // Canned per-assertion responses; `lastRequest` lets tests inspect what the adapter actually built.
   private var nextResponse: HttpResponse                                            = HttpResponse(OK)
   private val lastRequest: java.util.concurrent.atomic.AtomicReference[HttpRequest] =
     new java.util.concurrent.atomic.AtomicReference[HttpRequest]()
@@ -449,9 +447,6 @@ class ComprehensiveGoldSpec
     )
   )
 
-  // Multipart upload — file part + text part in the same request body. The generator captures
-  // `Content-Type: multipart/form-data; boundary=…` from the wire request, so the OpenAPI spec
-  // emits `requestBody.content["multipart/form-data"]`. Covers issue #81.
   path("/users/{userId}/photo", description = "Upload a profile photo with a caption", summary = "Photo")(
     supports(
       POST,
@@ -473,9 +468,6 @@ class ComprehensiveGoldSpec
         .assert { ctx =>
           nextResponse = emptyResponse(NoContent)
           val response = ctx.performRequest(routes)
-          // The request that hit `performRequest` must carry a multipart/form-data Content-Type
-          // — proves the adapter mapped Baklava's `Multipart` to pekko's native multipart form.
-          // The content type includes a boundary parameter, so compare the mediaType prefix.
           lastRequest.get().entity.contentType.mediaType.value should startWith("multipart/form-data")
           response.status.intValue() shouldBe 204
         }

--- a/openapi/src/test/scala/pl/iterators/baklava/openapi/ComprehensiveGoldSpec.scala
+++ b/openapi/src/test/scala/pl/iterators/baklava/openapi/ComprehensiveGoldSpec.scala
@@ -82,7 +82,7 @@ class ComprehensiveGoldSpec
   // multipart / content-type overrides).
   private var nextResponse: HttpResponse                                            = HttpResponse(OK)
   private val lastRequest: java.util.concurrent.atomic.AtomicReference[HttpRequest] =
-    new java.util.concurrent.atomic.AtomicReference()
+    new java.util.concurrent.atomic.AtomicReference[HttpRequest]()
   override def performRequest(routes: Route, request: HttpRequest): HttpResponse = {
     lastRequest.set(request)
     nextResponse

--- a/pekkohttp/src/main/scala/pl/iterators/baklava/pekkohttp/BaklavaPekkoHttp.scala
+++ b/pekkohttp/src/main/scala/pl/iterators/baklava/pekkohttp/BaklavaPekkoHttp.scala
@@ -2,7 +2,15 @@ package pl.iterators.baklava.pekkohttp
 
 import org.apache.pekko.http.scaladsl.client.RequestBuilding.RequestBuilder
 import org.apache.pekko.http.scaladsl.marshalling.{Marshaller, Marshalling, ToEntityMarshaller}
-import org.apache.pekko.http.scaladsl.model.{ContentType, FormData, HttpEntity, HttpHeader, MessageEntity}
+import org.apache.pekko.http.scaladsl.model.{
+  ContentType,
+  ContentTypes,
+  FormData,
+  HttpEntity,
+  HttpHeader,
+  MessageEntity,
+  Multipart => PekkoMultipart
+}
 import org.apache.pekko.http.scaladsl.server.Route
 import org.apache.pekko.http.scaladsl.unmarshalling.{FromEntityUnmarshaller, Unmarshaller}
 import org.apache.pekko.stream.Materializer
@@ -17,9 +25,12 @@ import pl.iterators.baklava.{
   BaklavaTestFrameworkDsl,
   EmptyBody,
   EmptyBodyInstance,
+  FilePart,
   FormOf,
   FreeFormSchema,
-  Schema
+  Multipart => BaklavaMultipart,
+  Schema,
+  TextPart
 }
 import sttp.model.{Header => SttpHeader, Method, StatusCode}
 
@@ -204,6 +215,24 @@ trait BaklavaPekkoHttp[TestFrameworkFragmentType, TestFrameworkFragmentsType, Te
     }
 
   implicit val formDataSchema: Schema[FormData] = FreeFormSchema("FormData")
+
+  /** Multipart marshaller: each `Part` becomes a pekko-http `BodyPart` with the right Content-Disposition / Content-Type headers, then we
+    * serialize with a *fixed* boundary so the captured request body is deterministic across test runs (pekko-http's default marshaller
+    * uses a random boundary per call, which would break the gold test).
+    */
+  override implicit protected def multipartToRequestBodyType: ToEntityMarshaller[BaklavaMultipart] =
+    Marshaller.strict[BaklavaMultipart, MessageEntity] { baklavaMultipart =>
+      val parts = baklavaMultipart.parts.map {
+        case FilePart(name, contentType, filename, bytes) =>
+          val ct     = ContentType.parse(contentType).fold(_ => ContentTypes.`application/octet-stream`, identity)
+          val entity = HttpEntity(ct, bytes)
+          if (filename.nonEmpty) PekkoMultipart.FormData.BodyPart(name, entity, Map("filename" -> filename))
+          else PekkoMultipart.FormData.BodyPart(name, entity)
+        case TextPart(name, value) =>
+          PekkoMultipart.FormData.BodyPart(name, HttpEntity(value))
+      }
+      Marshalling.Opaque(() => PekkoMultipart.FormData(parts: _*).toEntity(boundary = "baklava-multipart-boundary"))
+    }
 
   override implicit protected def emptyToResponseBodyType: FromEntityUnmarshaller[EmptyBody] =
     Unmarshaller.strict(_ => EmptyBodyInstance)

--- a/pekkohttp/src/main/scala/pl/iterators/baklava/pekkohttp/BaklavaPekkoHttp.scala
+++ b/pekkohttp/src/main/scala/pl/iterators/baklava/pekkohttp/BaklavaPekkoHttp.scala
@@ -216,10 +216,6 @@ trait BaklavaPekkoHttp[TestFrameworkFragmentType, TestFrameworkFragmentsType, Te
 
   implicit val formDataSchema: Schema[FormData] = FreeFormSchema("FormData")
 
-  /** Multipart marshaller: each `Part` becomes a pekko-http `BodyPart` with the right Content-Disposition / Content-Type headers, then we
-    * serialize with a *fixed* boundary so the captured request body is deterministic across test runs (pekko-http's default marshaller
-    * uses a random boundary per call, which would break the gold test).
-    */
   override implicit protected def multipartToRequestBodyType: ToEntityMarshaller[BaklavaMultipart] =
     Marshaller.strict[BaklavaMultipart, MessageEntity] { baklavaMultipart =>
       val parts = baklavaMultipart.parts.map {
@@ -231,6 +227,7 @@ trait BaklavaPekkoHttp[TestFrameworkFragmentType, TestFrameworkFragmentsType, Te
         case TextPart(name, value) =>
           PekkoMultipart.FormData.BodyPart(name, HttpEntity(value))
       }
+      // Fixed boundary keeps the captured request body byte-stable across gold-test runs.
       Marshalling.Opaque(() => PekkoMultipart.FormData(parts: _*).toEntity(boundary = "baklava-multipart-boundary"))
     }
 


### PR DESCRIPTION
Closes #81.

## Summary

Adds a Baklava-level \`Multipart(parts: Part*)\` body primitive with \`FilePart\` / \`TextPart\` variants. Both pekko-http and http4s adapters reassemble it into their framework's native multipart representation with a fixed boundary for deterministic output.

## Design decisions (from #81)

1. **Full multipart with mixed parts** — \`FilePart\` (binary + content-type + optional filename) and \`TextPart\` (plain form field). Single-file shortcut not added; users with just one file part pass a one-element \`Multipart(FilePart(...))\`.
2. **\`Array[Byte]\`** bodies for file parts, not streaming. Large uploads can be a follow-up when needed.
3. **\`Multipart(parts: Part*)\`** — no type parameter; parts are heterogeneous, so there's no meaningful \`T\` to carry.

## Scope

- Core: new \`Multipart\`, sealed \`Part\`, \`FilePart\`, \`TextPart\` types; abstract \`multipartToRequestBodyType\` on \`BaklavaHttpDsl\`.
- \`pekkohttp\` + \`http4s\`: per-adapter marshaller with a **fixed boundary** (the default generators use a random boundary per call, which would break gold tests).
- \`openapi\` worker: \`stripMediaTypeParams\` strips \`;boundary=…\` / \`;charset=…\` from captured Content-Types so \`requestBody.content\` is keyed by the plain media type (\`multipart/form-data\`), not a wire-level Content-Type.
- Gold test: new \`POST /users/{userId}/photo\` endpoint with one \`FilePart\` + one \`TextPart\`. \`.assert\` verifies the wire Content-Type starts with \`multipart/form-data\`.
- Docs: new "Documenting multipart/form-data uploads" section in \`pekko-http.md\` and \`http4s.md\`.

## Known limitation

The OpenAPI schema for a \`Multipart\` body is currently \`type: object\` (free-form). A richer per-part schema (\`photo: { type: string, format: binary }\` + \`caption: { type: string }\`) would need a runtime-derived \`Schema[Multipart]\` built from the captured parts. Users who need richer docs today can replace the implicit \`Schema[Multipart]\` with a hand-crafted one. Follow-up issue worth filing if anyone hits this.

## Test plan

- [x] \`sbt 'project openapi' '++ 2.13' test\` — 93/93 pass
- [x] \`sbt 'project openapi' '++ 3' test\` — 93/93 pass
- [x] Generated YAML shows \`multipart/form-data\` as a clean media-type key
- [x] Runtime assertion on the test's request verifies \`Content-Type\` is \`multipart/form-data; boundary=baklava-multipart-boundary\`