### PR TITLE
pekko routes: serve simple formatter output at /docs

### DIFF
--- a/pekkohttproutes/src/main/scala/pl/iterators/baklava/routes/BaklavaRoutes.scala
+++ b/pekkohttproutes/src/main/scala/pl/iterators/baklava/routes/BaklavaRoutes.scala
@@ -21,13 +21,11 @@ object BaklavaRoutes {
     implicit val internalConfig: BaklavaRoutes.Config = BaklavaRoutes.Config(config)
     if (internalConfig.enabled)
       authenticateBasic("docs", basicAuthOpt) { _ =>
-        /* TODO uncomment after introduce simple formatter
         pathPrefix("docs") {
           pathSingleSlash {
             getFromFile(s"${internalConfig.fileSystemPath}/simple/index.html")
           } ~ getFromDirectory(s"${internalConfig.fileSystemPath}/simple")
-        } ~ */
-        path("openapi") {
+        } ~ path("openapi") {
           complete(openApiFileContent)
         } ~ (path("swagger-ui" / swaggerVersion / "swagger-initializer.js") & get) {
           complete(swaggerInitializerContent)


### PR DESCRIPTION
Uncomments the `TODO` left in `BaklavaRoutes` from the days before the simple formatter existed. Simple formatter writes to `target/baklava/simple/` (via `BaklavaDslFormatterSimple`, on main since #50), so the route can now point at it.

With this merged: behind the same basic-auth gate that already protects `/openapi` and `/swagger-ui`, users get the human-browsable HTML docs served at `/docs/` + `/docs/<endpoint>.html`.

## Test plan

- [ ] Run `sbt 'project example-project' test` (or any project that uses baklava) to populate `target/baklava/simple/`
- [ ] Start a pekko-http server that mounts `BaklavaRoutes.routes(config)`
- [ ] `curl http://localhost:8080/docs/` — returns the tag-grouped index HTML
- [ ] `curl http://localhost:8080/docs/GET_users__userId_.html` (or whichever endpoint filename) — returns the per-endpoint page