### PR TITLE
pekko routes: serve simple formatter, webjar-derived version, typed content-types

### DIFF
--- a/pekkohttproutes/src/main/scala/pl/iterators/baklava/routes/BaklavaRoutes.scala
+++ b/pekkohttproutes/src/main/scala/pl/iterators/baklava/routes/BaklavaRoutes.scala
@@ -4,7 +4,7 @@ import io.swagger.v3.core.util.Yaml
 import io.swagger.v3.oas.models.servers.Server
 import io.swagger.v3.parser.OpenAPIV3Parser
 import org.apache.pekko.http.scaladsl.model.headers.Location
-import org.apache.pekko.http.scaladsl.model.{HttpResponse, StatusCodes}
+import org.apache.pekko.http.scaladsl.model.{ContentType, HttpCharsets, HttpEntity, HttpResponse, MediaType, MediaTypes, StatusCodes}
 import org.apache.pekko.http.scaladsl.server.Directives.*
 import org.apache.pekko.http.scaladsl.server.Route
 import org.apache.pekko.http.scaladsl.server.directives.{Credentials, RouteDirectives}
@@ -12,25 +12,36 @@ import org.webjars.WebJarAssetLocator
 
 import scala.io.Source
 import scala.jdk.CollectionConverters.SeqHasAsJava
-import scala.util.{Failure, Success, Try}
+import scala.util.{Failure, Success, Try, Using}
 
 object BaklavaRoutes {
-  private val swaggerVersion = "5.17.11"
+
+  private lazy val swaggerVersion: String =
+    Option(new WebJarAssetLocator().getWebJars.get("swagger-ui")).getOrElse(
+      throw new IllegalStateException(
+        "swagger-ui webjar not on the classpath — add `\"org.webjars\" % \"swagger-ui\" % \"...\"` to your project's dependencies " +
+          "or remove baklava-pekko-http-routes if you don't intend to serve SwaggerUI."
+      )
+    )
+
+  private val yamlContentType: ContentType.WithFixedCharset =
+    MediaType.customWithFixedCharset("application", "yaml", HttpCharsets.`UTF-8`).toContentType
+
+  private val javascriptContentType: ContentType.NonBinary =
+    MediaTypes.`application/javascript`.toContentType(HttpCharsets.`UTF-8`)
 
   def routes(config: com.typesafe.config.Config): Route = {
     implicit val internalConfig: BaklavaRoutes.Config = BaklavaRoutes.Config(config)
     if (internalConfig.enabled)
       authenticateBasic("docs", basicAuthOpt) { _ =>
-        /* TODO uncomment after introduce simple formatter
         pathPrefix("docs") {
           pathSingleSlash {
             getFromFile(s"${internalConfig.fileSystemPath}/simple/index.html")
           } ~ getFromDirectory(s"${internalConfig.fileSystemPath}/simple")
-        } ~ */
-        path("openapi") {
-          complete(openApiFileContent)
+        } ~ path("openapi") {
+          complete(HttpEntity(yamlContentType, openApiFileContent))
         } ~ (path("swagger-ui" / swaggerVersion / "swagger-initializer.js") & get) {
-          complete(swaggerInitializerContent)
+          complete(HttpEntity(javascriptContentType, swaggerInitializerContent))
         } ~ pathPrefix("swagger-ui") {
           swaggerWebJar
         } ~ pathPrefix("swagger") {
@@ -51,19 +62,15 @@ object BaklavaRoutes {
       case _ => Some("")
     }
 
-  private def openApiFileContent(implicit internalConfig: BaklavaRoutes.Config): String = {
-    val source = Source.fromFile(s"${internalConfig.fileSystemPath}/openapi/openapi.yml")
-    try {
+  private def openApiFileContent(implicit internalConfig: BaklavaRoutes.Config): String =
+    Using.resource(Source.fromFile(s"${internalConfig.fileSystemPath}/openapi/openapi.yml")) { source =>
       val parser  = new OpenAPIV3Parser
       val openApi = parser.readContents(source.mkString, null, null).getOpenAPI
       val server  = new Server()
       server.setUrl(internalConfig.apiPublicPathPrefix)
       openApi.setServers(List(server).asJava)
       Yaml.pretty(openApi)
-    } finally {
-      source.close()
     }
-  }
 
   private def swaggerInitializerContent(implicit internalConfig: BaklavaRoutes.Config): String = {
     val swaggerDocsUrl = s"${internalConfig.publicPathPrefix}openapi"


### PR DESCRIPTION
Supersedes #84. Three fixes in `pekkohttproutes`, all verified by a real smoke test that boots pekko-http against sample baklava output and curls the endpoints:

1. **Serve simple formatter at `/docs`**. Uncomments the pre-existing TODO — the simple formatter lands HTML under `target/baklava/simple/`, this serves it behind the same basic-auth gate.

2. **Derive `swaggerVersion` from the webjar instead of hard-coding `"5.17.11"`**. The build currently ships `swagger-ui` 5.32.1, so `/swagger` was redirecting to `/swagger-ui/5.17.11/index.html` — an asset that doesn't exist on the classpath. Smoke test: the redirect now points at `5.32.1`, which serves real content. Fails fast at startup if the webjar is missing (same pattern as the http4s-routes module).

3. **Return proper content-types for `/openapi` and the initializer**. Pekko's default string marshaller sends `text/plain; charset=UTF-8`; browsers and Swagger UI expect `application/yaml` and `application/javascript; charset=UTF-8` respectively.

Also replaces raw `try/finally` around `Source.fromFile` with `scala.util.Using.resource`.

## Test plan

- [x] `sbt '+pekkohttproutes/compile'` green on Scala 2.13.18 and 3.3.7
- [x] Smoke test: `publishLocal` + standalone pekko-http server bound to :9091
  - [x] `GET /openapi` → 200, `Content-Type: application/yaml`
  - [x] `GET /swagger` → 303 → `/swagger-ui/5.32.1/index.html` (webjar version)
  - [x] `GET /swagger-ui/5.32.1/swagger-initializer.js` → 200, `application/javascript; charset=UTF-8`
  - [x] `GET /swagger-ui/5.32.1/swagger-ui.css` → 200, full webjar asset
  - [x] `GET /docs/` → 200, simple formatter's `index.html`
  - [x] `GET /docs/<endpoint>.html` → 200