### PR TITLE
feat: honor declared Content-Type for file uploads (#52)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,6 @@ website/yarn.lock
 website/node_modules
 website/.docusaurus
 website/.cache-loader
+
+# Local-only design/spec docs (per repo convention, kept out of VCS)
+docs/superpowers/

--- a/docs/http4s.md
+++ b/docs/http4s.md
@@ -223,40 +223,60 @@ class GetUsersUserIdRouteSpec extends BaseRouteSpec {
 }
 ```
 
-## Serving Open API and Swagger UI
+## Documenting file uploads
 
-Adding `baklava-http4s-routes` dependency to your project you can easily serve Open API and Swagger UI:
+To document a binary upload (e.g. an avatar PNG), declare `Content-Type` among the request headers and pass the matching value on the `onRequest(...)` call — the http4s adapter honors that declared value, overriding the content type the `EntityEncoder` bakes into the request.
 
 ```scala
-import cats.effect.{IO, IOApp}
-import com.comcast.ip4s.*
-import com.typesafe.config.{Config, ConfigFactory}
-import org.http4s.ember.server.EmberServerBuilder
-import org.http4s.server.Router
-import org.http4s.HttpRoutes
-import pl.iterators.baklava.http4s.routes.BaklavaRoutes
+import java.nio.charset.StandardCharsets
 
-object Main extends IOApp.Simple {
-  def run: IO[Unit] = {
-    val apiRoutes: HttpRoutes[IO] = ??? // all your API routes
-    val config: Config            = ConfigFactory.load()
+class PutUsersUserIdAvatarSpec extends BaseRouteSpec {
 
-    val appRoutes: HttpRoutes[IO] = Router(
-      "/"    -> BaklavaRoutes.routes(config),
-      "/v1"  -> apiRoutes
+  // Byte-array entity encoders ship with http4s; no extra setup needed.
+
+  path(path = "/users/{userId}/avatar")(
+    supports(
+      PUT,
+      pathParameters = p[Long]("userId"),
+      headers = h[String]("Content-Type"),
+      description = "Upload or update a user's avatar",
+      summary = "Upload or update a user's avatar",
+      tags = List("Users")
+    )(
+      onRequest(
+        pathParameters = 1L,
+        headers = "image/png",
+        body = "\u0089PNG\r\n...".getBytes(StandardCharsets.UTF_8)
+      ).respondsWith[EmptyBody](NoContent, description = "User avatar updated successfully")
+        .assert { ctx =>
+          val response = ctx.performRequest(allRoutes)
+          response.status.code shouldBe 204
+        }
     )
-
-    EmberServerBuilder
-      .default[IO]
-      .withHost(host"0.0.0.0")
-      .withPort(port"8080")
-      .withHttpApp(appRoutes.orNotFound)
-      .build
-      .useForever
-  }
+  )
 }
 ```
 
-For detailed configuration options check [the SwaggerUI and routes configuration section](installation.md#swaggerui-and-routes-configuration).
+The generator renders this as `requestBody.content["image/png"]` with a `schema: { type: string, format: binary }` in OpenAPI, and the test request goes out with `Content-Type: image/png` on the wire so server routes that pattern-match on it run under the right conditions.
 
-The http4s and pekko-http variants expose the same endpoints (`GET /openapi`, `GET /swagger-ui/<version>/…`, `GET /swagger`) and share the same configuration keys under `baklava-routes`.
+### Downloads
+
+Binary downloads work with `respondsWith[Array[Byte]]`. http4s ships entity decoders for byte arrays; no extra setup needed. The test stub's response must carry the right `Content-Type` — whatever the server serves becomes the OpenAPI `responseContentType`:
+
+```scala
+supports(
+  GET,
+  pathParameters = p[Long]("userId"),
+  description = "Download the user's avatar as raw image bytes",
+  tags = List("Users")
+)(
+  onRequest(pathParameters = 1L)
+    .respondsWith[Array[Byte]](Ok, description = "Avatar bytes")
+    .assert { ctx =>
+      val response = ctx.performRequest(allRoutes)
+      response.status.code shouldBe 200
+    }
+)
+```
+
+`Schema[Array[Byte]]` is a default on the classpath, so the generated OpenAPI renders `responses[code].content["<content-type>"].schema = { type: string, format: binary }`.

--- a/docs/pekko-http.md
+++ b/docs/pekko-http.md
@@ -244,6 +244,72 @@ class GetUsersUserIdRouteSpec extends BaseRouteSpec {
 }
 ```
 
+## Documenting file uploads
+
+To document a binary upload (e.g. an avatar PNG), declare `Content-Type` among the request headers and pass the matching value on the `onRequest(...)` call — the pekko-http adapter honors that declared value, overriding the content type the implicit marshaller would otherwise bake into the request. Use `Array[Byte]` for the body so a byte-array marshaller is in scope.
+
+```scala
+import org.apache.pekko.http.scaladsl.marshalling.{PredefinedToEntityMarshallers, ToEntityMarshaller}
+
+import java.nio.charset.StandardCharsets
+
+class PutUsersUserIdAvatarRouteSpec extends BaseRouteSpec {
+
+  implicit val byteArrayMarshaller: ToEntityMarshaller[Array[Byte]] =
+    PredefinedToEntityMarshallers.ByteArrayMarshaller
+
+  path(path = "/users/{userId}/avatar")(
+    supports(
+      PUT,
+      pathParameters = p[Long]("userId"),
+      headers = h[String]("Content-Type"),
+      description = "Upload or update a user's avatar",
+      summary = "Upload or update a user's avatar",
+      tags = List("Users")
+    )(
+      onRequest(
+        pathParameters = 1L,
+        headers = "image/png",
+        body = "\u0089PNG\r\n...".getBytes(StandardCharsets.UTF_8)
+      ).respondsWith[EmptyBody](NoContent, description = "User avatar updated successfully")
+        .assert { ctx =>
+          val response = ctx.performRequest(allRoutes)
+          response.status.code shouldBe 204
+        }
+    )
+  )
+}
+```
+
+The generator detects that `Content-Type` is a request-body media type rather than a free header, so the generated OpenAPI spec emits it as `requestBody.content["image/png"]` with a `schema: { type: string, format: binary }` instead of rendering it as a header parameter. The declared value is also used as the actual wire Content-Type of the test request, so server routes that pattern-match on it (e.g. `entity(as[Array[Byte]])`) run under the right conditions.
+
+### Downloads
+
+Binary downloads work with `respondsWith[Array[Byte]]`. The pekko-http test needs a byte-array entity unmarshaller in scope; the test stub's response must carry the right `Content-Type` — whatever the server serves becomes the OpenAPI `responseContentType`:
+
+```scala
+import org.apache.pekko.http.scaladsl.unmarshalling.{FromEntityUnmarshaller, PredefinedFromEntityUnmarshallers}
+
+implicit val byteArrayUnmarshaller: FromEntityUnmarshaller[Array[Byte]] =
+  PredefinedFromEntityUnmarshallers.byteArrayUnmarshaller
+
+supports(
+  GET,
+  pathParameters = p[Long]("userId"),
+  description = "Download the user's avatar as raw image bytes",
+  tags = List("Users")
+)(
+  onRequest(pathParameters = 1L)
+    .respondsWith[Array[Byte]](OK, description = "Avatar bytes")
+    .assert { ctx =>
+      val response = ctx.performRequest(allRoutes)
+      response.status.code shouldBe 200
+    }
+)
+```
+
+`Schema[Array[Byte]]` is a default on the classpath, so the generated OpenAPI renders `responses[code].content["<content-type>"].schema = { type: string, format: binary }`.
+
 ## Serving Open API and Swagger UI
 
 Adding `baklava-pekko-http-routes` dependency to your project you can easily serve Open API and Swagger UI:
@@ -278,4 +344,4 @@ import scala.io.StdIn
   }
 ```
 
-For detailed configuration options check [the SwaggerUI and routes configuration section](installation.md#swaggerui-and-routes-configuration).
+For detailed configuration options check [installation.md#swaggerui-and-routes-configuration]

--- a/http4s/src/main/scala/pl/iterators/baklava/http4s/BaklavaHttp4s.scala
+++ b/http4s/src/main/scala/pl/iterators/baklava/http4s/BaklavaHttp4s.scala
@@ -160,21 +160,50 @@ trait BaklavaHttp4s[TestFrameworkFragmentType, TestFrameworkFragmentsType, TestF
   )(implicit
       requestBody: BaklavaHttp4s.ToEntityMarshaller[RequestBody]
   ): HttpRequest = {
-    ctx.body match {
-      case Some(body) =>
-        Request[IO](
-          method = baklavaHttpMethodToHttpMethod(ctx.method.get),
-          uri = Uri.fromString(ctx.path).fold(throw _, identity),
-          headers = baklavaHeadersToHttpHeaders(ctx.headers)
-        ).withEntity(body)
-      case None =>
-        Request[IO](
-          method = baklavaHttpMethodToHttpMethod(ctx.method.get),
-          uri = Uri.fromString(ctx.path).fold(throw _, identity),
-          headers = baklavaHeadersToHttpHeaders(ctx.headers)
+    // If the test declared a parseable `Content-Type` header, use its value to override the
+    // content type that the `EntityEncoder` bakes in. http4s stores Content-Type on the entity
+    // (not a free header), so we pull it out of the header list before attaching and then re-set
+    // it with `.withContentType` on the resulting request. We only strip after parsing succeeds
+    // so an invalid value isn't silently swallowed.
+    val parsedOverride = findContentTypeOverride(ctx.headers)
+    val otherHeaders   = if (parsedOverride.isDefined) dropContentType(ctx.headers) else ctx.headers
+    val base           = Request[IO](
+      method = baklavaHttpMethodToHttpMethod(ctx.method.get),
+      uri = Uri.fromString(ctx.path).fold(throw _, identity),
+      headers = baklavaHeadersToHttpHeaders(otherHeaders)
+    )
+    val withBody = ctx.body match {
+      case Some(body) => base.withEntity(body)
+      case None       => base
+    }
+    parsedOverride.fold(withBody)(ct => withBody.withContentType(ct))
+  }
+
+  /** Find a `Content-Type` in the declared headers (case-insensitive) and return the parsed http4s `Content-Type`. Throws on either
+    * multiple declarations or an unparseable value — both are always test-authoring bugs.
+    */
+  private def findContentTypeOverride(hs: Seq[SttpHeader]): Option[headers.`Content-Type`] = {
+    val cts = hs.filter(_.name.toLowerCase(java.util.Locale.ROOT) == "content-type")
+    cts match {
+      case Seq()       => None
+      case Seq(single) =>
+        headers.`Content-Type`.parse(single.value) match {
+          case Right(ct)   => Some(ct)
+          case Left(error) =>
+            throw new IllegalArgumentException(
+              s"Could not parse declared Content-Type header '${single.value}': ${error.message}"
+            )
+        }
+      case multiple =>
+        throw new IllegalArgumentException(
+          s"Multiple Content-Type headers declared on one request: [${multiple.map(_.value).mkString(", ")}]. " +
+            "Declare a single Content-Type or none at all."
         )
     }
   }
+
+  private def dropContentType(hs: Seq[SttpHeader]): Seq[SttpHeader] =
+    hs.filterNot(_.name.toLowerCase(java.util.Locale.ROOT) == "content-type")
 
   implicit val runtime: IORuntime
 }

--- a/openapi/src/test/scala/pl/iterators/baklava/openapi/Http4sContentTypeOverrideSpec.scala
+++ b/openapi/src/test/scala/pl/iterators/baklava/openapi/Http4sContentTypeOverrideSpec.scala
@@ -1,0 +1,108 @@
+package pl.iterators.baklava.openapi
+
+import cats.effect.IO
+import cats.effect.unsafe.IORuntime
+import org.http4s.{EntityEncoder, HttpRoutes, MediaType, Request, Response, Status}
+import org.http4s.headers.`Content-Type`
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
+import pl.iterators.baklava.http4s.BaklavaHttp4s
+import pl.iterators.baklava.scalatest.{BaklavaScalatest, ScalatestAsExecution}
+import pl.iterators.baklava.{AppliedSecurity, BaklavaRequestContext, NoopSecurity}
+import sttp.model.{Header => SttpHeader, Method}
+
+/** Regression test for issue #52 on the http4s adapter. Parallel to `PekkoContentTypeOverrideSpec`; both adapters have their own
+  * independent `baklavaContextToHttpRequest` that needs to honor a declared `Content-Type` header (and reject duplicates / unparseable
+  * values).
+  */
+class Http4sContentTypeOverrideSpec
+    extends AnyFunSpec
+    with Matchers
+    with BaklavaHttp4s[Unit, Unit, ScalatestAsExecution]
+    with BaklavaScalatest[HttpRoutes[IO], BaklavaHttp4s.ToEntityMarshaller, BaklavaHttp4s.FromEntityUnmarshaller] {
+
+  override implicit val runtime: IORuntime                                                = IORuntime.global
+  override def strictHeaderCheckDefault: Boolean                                          = false
+  override def performRequest(routes: HttpRoutes[IO], request: Request[IO]): Response[IO] =
+    Response[IO](status = Status.NoContent)
+
+  val routes: HttpRoutes[IO]                       = HttpRoutes.empty[IO]
+  private val stringEnc: EntityEncoder[IO, String] = EntityEncoder.stringEncoder[IO]
+
+  describe("http4s adapter's baklavaContextToHttpRequest (issue #52)") {
+
+    it("overrides the entity Content-Type when one is declared among the headers") {
+      val ctx     = buildRequestContext(Seq(SttpHeader("Content-Type", "image/png")), "raw bytes")
+      val request = baklavaContextToHttpRequest(ctx)(stringEnc)
+
+      request.contentType shouldBe Some(`Content-Type`(MediaType.image.png))
+    }
+
+    it("does not leave a duplicate Content-Type in the free header list") {
+      val ctx     = buildRequestContext(Seq(SttpHeader("Content-Type", "image/png")), "raw bytes")
+      val request = baklavaContextToHttpRequest(ctx)(stringEnc)
+
+      // http4s stores Content-Type on the entity, not in the free header list. The declared
+      // Content-Type must appear exactly once — via the entity — not as an extra header.
+      val contentTypeHeaders =
+        request.headers.headers.filter(_.name.toString.equalsIgnoreCase("Content-Type"))
+      contentTypeHeaders.size shouldBe 1
+      contentTypeHeaders.head.value shouldBe "image/png"
+    }
+
+    it("leaves the marshaller-provided Content-Type intact when none is declared") {
+      val ctx     = buildRequestContext(Seq.empty, "plain text")
+      val request = baklavaContextToHttpRequest(ctx)(stringEnc)
+
+      // http4s's String EntityEncoder defaults to text/plain; assert the main type without
+      // pinning the exact subtype/charset which is less stable across http4s versions.
+      request.contentType.map(_.mediaType.mainType) shouldBe Some("text")
+    }
+
+    it("throws on an unparseable declared Content-Type — silent fallback would hide a bug") {
+      val ctx = buildRequestContext(Seq(SttpHeader("Content-Type", "this is not a content type")), "irrelevant")
+      val ex  = intercept[IllegalArgumentException](baklavaContextToHttpRequest(ctx)(stringEnc))
+      ex.getMessage should include("Could not parse declared Content-Type")
+    }
+
+    it("throws on multiple declared Content-Type headers") {
+      val ctx = buildRequestContext(
+        Seq(SttpHeader("Content-Type", "image/png"), SttpHeader("content-type", "image/jpeg")),
+        "bytes"
+      )
+      val ex = intercept[IllegalArgumentException](baklavaContextToHttpRequest(ctx)(stringEnc))
+      ex.getMessage should include("Multiple Content-Type headers")
+    }
+  }
+
+  private def buildRequestContext(hs: Seq[SttpHeader], body: String): BaklavaRequestContext[String, Unit, Unit, Unit, Unit, Unit, Unit] =
+    BaklavaRequestContext[String, Unit, Unit, Unit, Unit, Unit, Unit](
+      symbolicPath = "/x",
+      path = "/x",
+      pathDescription = None,
+      pathSummary = None,
+      method = Some(Method("POST")),
+      operationDescription = None,
+      operationSummary = None,
+      operationId = None,
+      operationTags = Seq.empty,
+      securitySchemes = Seq.empty,
+      body = Some(body),
+      bodySchema = None,
+      headers = hs,
+      headersDefinition = (),
+      headersProvided = (),
+      headersSeq = Seq.empty,
+      security = AppliedSecurity(NoopSecurity, Map.empty),
+      pathParameters = (),
+      pathParametersProvided = (),
+      pathParametersSeq = Seq.empty,
+      queryParameters = (),
+      queryParametersProvided = (),
+      queryParametersSeq = Seq.empty,
+      responseDescription = None,
+      responseHeaders = Seq.empty
+    )
+
+  override def afterAll(): Unit = ()
+}

--- a/openapi/src/test/scala/pl/iterators/baklava/openapi/PekkoContentTypeOverrideSpec.scala
+++ b/openapi/src/test/scala/pl/iterators/baklava/openapi/PekkoContentTypeOverrideSpec.scala
@@ -1,0 +1,112 @@
+package pl.iterators.baklava.openapi
+
+import org.apache.pekko.actor.ActorSystem
+import org.apache.pekko.http.scaladsl.marshalling.{Marshal, ToEntityMarshaller}
+import org.apache.pekko.http.scaladsl.model.{HttpHeader, HttpRequest, HttpResponse, MediaTypes}
+import org.apache.pekko.http.scaladsl.server.Route
+import org.apache.pekko.http.scaladsl.unmarshalling.FromEntityUnmarshaller
+import org.apache.pekko.stream.Materializer
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
+import pl.iterators.baklava.pekkohttp.BaklavaPekkoHttp
+import pl.iterators.baklava.scalatest.{BaklavaScalatest, ScalatestAsExecution}
+import pl.iterators.baklava.{AppliedSecurity, BaklavaRequestContext, NoopSecurity}
+import sttp.model.{Header => SttpHeader, Method}
+
+import scala.concurrent.ExecutionContext
+
+/** Regression test for issue #52 on the pekko-http adapter. Parallel to `Http4sContentTypeOverrideSpec`; both adapters have their own
+  * independent `baklavaContextToHttpRequest` that needs to honor a declared `Content-Type` header (and reject duplicates / unparseable
+  * values).
+  */
+class PekkoContentTypeOverrideSpec
+    extends AnyFunSpec
+    with Matchers
+    with BaklavaPekkoHttp[Unit, Unit, ScalatestAsExecution]
+    with BaklavaScalatest[Route, ToEntityMarshaller, FromEntityUnmarshaller] {
+
+  private implicit val system: ActorSystem        = ActorSystem("pekko-content-type-override")
+  implicit val executionContext: ExecutionContext = system.dispatcher
+  implicit val materializer: Materializer         = Materializer(system)
+
+  val routes: Route                                                              = Route.seal(_ => throw new UnsupportedOperationException)
+  override def strictHeaderCheckDefault: Boolean                                 = false
+  override def performRequest(routes: Route, request: HttpRequest): HttpResponse =
+    throw new UnsupportedOperationException("this spec only exercises request-building, not routing")
+
+  describe("pekko-http adapter's baklavaContextToHttpRequest (issue #52)") {
+
+    it("overrides the entity Content-Type when one is declared among the headers") {
+      val ctx     = buildRequestContext(Seq(SttpHeader("Content-Type", "image/png")), "raw bytes")
+      val request = baklavaContextToHttpRequest(ctx)
+
+      request.entity.contentType.mediaType shouldBe MediaTypes.`image/png`
+    }
+
+    it("does not leave a duplicate Content-Type in the free header list") {
+      val ctx     = buildRequestContext(Seq(SttpHeader("Content-Type", "image/png")), "raw bytes")
+      val request = baklavaContextToHttpRequest(ctx)
+
+      val ctHeaders: Seq[HttpHeader] = request.headers.filter(_.is("content-type"))
+      ctHeaders shouldBe empty
+      request.entity.contentType.mediaType shouldBe MediaTypes.`image/png`
+    }
+
+    it("leaves the marshaller-provided Content-Type intact when none is declared") {
+      val ctx     = buildRequestContext(Seq.empty, "plain text")
+      val request = baklavaContextToHttpRequest(ctx)
+
+      request.entity.contentType.mediaType.mainType shouldBe "text"
+    }
+
+    it("throws on an unparseable declared Content-Type — silent fallback would hide a bug") {
+      val ctx = buildRequestContext(Seq(SttpHeader("Content-Type", "this is not a content type")), "irrelevant")
+      val ex  = intercept[IllegalArgumentException](baklavaContextToHttpRequest(ctx))
+      ex.getMessage should include("Could not parse declared Content-Type")
+    }
+
+    it("throws on multiple declared Content-Type headers") {
+      val ctx = buildRequestContext(
+        Seq(SttpHeader("Content-Type", "image/png"), SttpHeader("content-type", "image/jpeg")),
+        "bytes"
+      )
+      val ex = intercept[IllegalArgumentException](baklavaContextToHttpRequest(ctx))
+      ex.getMessage should include("Multiple Content-Type headers")
+    }
+  }
+
+  // Silence "unused" warning: ensure Marshal is reachable from this compile unit if a future
+  // marshaller needs threading. Practically, String has a default ToEntityMarshaller in pekko.
+  locally(Marshal)
+
+  private def buildRequestContext(hs: Seq[SttpHeader], body: String): BaklavaRequestContext[String, Unit, Unit, Unit, Unit, Unit, Unit] =
+    BaklavaRequestContext[String, Unit, Unit, Unit, Unit, Unit, Unit](
+      symbolicPath = "/x",
+      path = "/x",
+      pathDescription = None,
+      pathSummary = None,
+      method = Some(Method("POST")),
+      operationDescription = None,
+      operationSummary = None,
+      operationId = None,
+      operationTags = Seq.empty,
+      securitySchemes = Seq.empty,
+      body = Some(body),
+      bodySchema = None,
+      headers = hs,
+      headersDefinition = (),
+      headersProvided = (),
+      headersSeq = Seq.empty,
+      security = AppliedSecurity(NoopSecurity, Map.empty),
+      pathParameters = (),
+      pathParametersProvided = (),
+      pathParametersSeq = Seq.empty,
+      queryParameters = (),
+      queryParametersProvided = (),
+      queryParametersSeq = Seq.empty,
+      responseDescription = None,
+      responseHeaders = Seq.empty
+    )
+
+  override def afterAll(): Unit = system.terminate()
+}

--- a/openapi/src/test/scala/pl/iterators/baklava/openapi/PekkoContentTypeOverrideSpec.scala
+++ b/openapi/src/test/scala/pl/iterators/baklava/openapi/PekkoContentTypeOverrideSpec.scala
@@ -1,8 +1,8 @@
 package pl.iterators.baklava.openapi
 
 import org.apache.pekko.actor.ActorSystem
-import org.apache.pekko.http.scaladsl.marshalling.{Marshal, ToEntityMarshaller}
-import org.apache.pekko.http.scaladsl.model.{HttpHeader, HttpRequest, HttpResponse, MediaTypes}
+import org.apache.pekko.http.scaladsl.marshalling.ToEntityMarshaller
+import org.apache.pekko.http.scaladsl.model.{HttpRequest, HttpResponse, MediaTypes}
 import org.apache.pekko.http.scaladsl.server.Route
 import org.apache.pekko.http.scaladsl.unmarshalling.FromEntityUnmarshaller
 import org.apache.pekko.stream.Materializer
@@ -47,7 +47,7 @@ class PekkoContentTypeOverrideSpec
       val ctx     = buildRequestContext(Seq(SttpHeader("Content-Type", "image/png")), "raw bytes")
       val request = baklavaContextToHttpRequest(ctx)
 
-      val ctHeaders: Seq[HttpHeader] = request.headers.filter(_.is("content-type"))
+      val ctHeaders = request.headers.filter(_.is("content-type"))
       ctHeaders shouldBe empty
       request.entity.contentType.mediaType shouldBe MediaTypes.`image/png`
     }
@@ -74,10 +74,6 @@ class PekkoContentTypeOverrideSpec
       ex.getMessage should include("Multiple Content-Type headers")
     }
   }
-
-  // Silence "unused" warning: ensure Marshal is reachable from this compile unit if a future
-  // marshaller needs threading. Practically, String has a default ToEntityMarshaller in pekko.
-  locally(Marshal)
 
   private def buildRequestContext(hs: Seq[SttpHeader], body: String): BaklavaRequestContext[String, Unit, Unit, Unit, Unit, Unit, Unit] =
     BaklavaRequestContext[String, Unit, Unit, Unit, Unit, Unit, Unit](
@@ -108,5 +104,5 @@ class PekkoContentTypeOverrideSpec
       responseHeaders = Seq.empty
     )
 
-  override def afterAll(): Unit = system.terminate()
+  override def afterAll(): Unit = { val _ = system.terminate() }
 }

--- a/openapi/src/test/scala/pl/iterators/baklava/openapi/PekkoContentTypeOverrideSpec.scala
+++ b/openapi/src/test/scala/pl/iterators/baklava/openapi/PekkoContentTypeOverrideSpec.scala
@@ -2,7 +2,7 @@ package pl.iterators.baklava.openapi
 
 import org.apache.pekko.actor.ActorSystem
 import org.apache.pekko.http.scaladsl.marshalling.ToEntityMarshaller
-import org.apache.pekko.http.scaladsl.model.{HttpRequest, HttpResponse, MediaTypes}
+import org.apache.pekko.http.scaladsl.model.MediaTypes
 import org.apache.pekko.http.scaladsl.server.Route
 import org.apache.pekko.http.scaladsl.unmarshalling.FromEntityUnmarshaller
 import org.apache.pekko.stream.Materializer

--- a/pekkohttp/src/main/scala/pl/iterators/baklava/pekkohttp/BaklavaPekkoHttp.scala
+++ b/pekkohttp/src/main/scala/pl/iterators/baklava/pekkohttp/BaklavaPekkoHttp.scala
@@ -2,7 +2,7 @@ package pl.iterators.baklava.pekkohttp
 
 import org.apache.pekko.http.scaladsl.client.RequestBuilding.RequestBuilder
 import org.apache.pekko.http.scaladsl.marshalling.{Marshaller, Marshalling, ToEntityMarshaller}
-import org.apache.pekko.http.scaladsl.model.{FormData, HttpEntity, HttpHeader, MessageEntity}
+import org.apache.pekko.http.scaladsl.model.{ContentType, FormData, HttpEntity, HttpHeader, MessageEntity}
 import org.apache.pekko.http.scaladsl.server.Route
 import org.apache.pekko.http.scaladsl.unmarshalling.{FromEntityUnmarshaller, Unmarshaller}
 import org.apache.pekko.stream.Materializer
@@ -154,9 +154,46 @@ trait BaklavaPekkoHttp[TestFrameworkFragmentType, TestFrameworkFragmentsType, Te
   )(implicit
       requestBody: ToEntityMarshaller[RequestBody]
   ): HttpRequest = {
-    new RequestBuilder(baklavaHttpMethodToHttpMethod(ctx.method.get))(ctx.path, ctx.body)
-      .withHeaders(baklavaHeadersToHttpHeaders(ctx.headers))
+    // If the test declared a `Content-Type` header, use its value to override the content type
+    // that the implicit marshaller would otherwise bake into the request. This is what lets tests
+    // document non-JSON uploads — `h[String]("Content-Type") = "image/png"` plus a String/byte
+    // body. Pekko-http treats `Content-Type` as part of the entity (not a free header), so we
+    // also strip it from the headers list before attaching. Invalid values throw — a silent
+    // fallback would mask test-authoring bugs (pekko's own header parser would drop the invalid
+    // header from the request, leaving the marshaller's default Content-Type in its place with
+    // no indication that the declared value was ignored).
+    val parsedOverride = findContentTypeOverride(ctx.headers)
+    val otherHeaders   = if (parsedOverride.isDefined) dropContentType(ctx.headers) else ctx.headers
+    val base           = new RequestBuilder(baklavaHttpMethodToHttpMethod(ctx.method.get))(ctx.path, ctx.body)
+      .withHeaders(baklavaHeadersToHttpHeaders(otherHeaders))
+    parsedOverride.fold(base)(ct => base.withEntity(base.entity.withContentType(ct)))
   }
+
+  /** Find a `Content-Type` in the declared headers (case-insensitive) and return the parsed pekko `ContentType`. Throws on either multiple
+    * declarations or an unparseable value — both are always test-authoring bugs.
+    */
+  private def findContentTypeOverride(headers: Seq[SttpHeader]): Option[ContentType] = {
+    val cts = headers.filter(_.name.toLowerCase(java.util.Locale.ROOT) == "content-type")
+    cts match {
+      case Seq()       => None
+      case Seq(single) =>
+        ContentType.parse(single.value) match {
+          case Right(ct)    => Some(ct)
+          case Left(errors) =>
+            throw new IllegalArgumentException(
+              s"Could not parse declared Content-Type header '${single.value}': ${errors.mkString("; ")}"
+            )
+        }
+      case multiple =>
+        throw new IllegalArgumentException(
+          s"Multiple Content-Type headers declared on one request: [${multiple.map(_.value).mkString(", ")}]. " +
+            "Declare a single Content-Type or none at all."
+        )
+    }
+  }
+
+  private def dropContentType(headers: Seq[SttpHeader]): Seq[SttpHeader] =
+    headers.filterNot(_.name.toLowerCase(java.util.Locale.ROOT) == "content-type")
 
   override implicit protected def emptyToRequestBodyType: ToEntityMarshaller[EmptyBody] =
     Marshaller.strict[EmptyBody, MessageEntity](_ => Marshalling.Opaque(() => HttpEntity.Empty))


### PR DESCRIPTION
Supersedes #80 — this branch drops the gold fixture churn and moves the pekko-side regression to a focused spec, parallel to the http4s one.

## Changes

- `pekkohttp/.../BaklavaPekkoHttp.scala` — `baklavaContextToHttpRequest` picks up a \`h[String](\"Content-Type\")\` header and overrides the entity's content-type (pekko treats Content-Type as part of the entity, not a free header). Throws on invalid or multiple declared values.
- `http4s/.../BaklavaHttp4s.scala` — same behavior for http4s's \`Request\[IO\]\`.
- `openapi/.../PekkoContentTypeOverrideSpec.scala` **(new)** — 5 focused cases for the pekko adapter: override works, no duplicate CT header, default preserved, throws on unparseable, throws on multiple.
- `openapi/.../Http4sContentTypeOverrideSpec.scala` **(new)** — 5 parallel cases for http4s.
- Docs updated for both adapters with a binary-upload example.

## Why this supersedes #80

#80 exercised the pekko side by adding a `/users/{userId}/avatar` endpoint to `ComprehensiveGoldSpec`, which regenerated all three gold outputs (openapi yaml + simple HTML + tsrest). A focused spec reaches the same behavior without touching gold fixtures — the gold files exist to guard against *generator regressions*, not *adapter regressions*, so an adapter-level concern doesn't belong in them.

## Test plan

- [x] `sbt openapi/test` — 102 tests pass (10 new, 92 existing)
- [x] Both new specs exercise `baklavaContextToHttpRequest` directly without booting a server