### PR TITLE
feat: Postman Collection v2.1 generator (#23)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,11 +75,11 @@ jobs:
 
       - name: Make target directories
         if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main')
-        run: mkdir -p scalatest/target http4sroutes/target http4s/target openapi/target pekkohttproutes/target simple/target sbtplugin/target munit/target core/target tsrest/target specs2/target pekkohttp/target project/target
+        run: mkdir -p scalatest/target http4sroutes/target http4s/target postman/target openapi/target pekkohttproutes/target simple/target sbtplugin/target munit/target core/target tsrest/target specs2/target pekkohttp/target project/target
 
       - name: Compress target directories
         if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main')
-        run: tar cf targets.tar scalatest/target http4sroutes/target http4s/target openapi/target pekkohttproutes/target simple/target sbtplugin/target munit/target core/target tsrest/target specs2/target pekkohttp/target project/target
+        run: tar cf targets.tar scalatest/target http4sroutes/target http4s/target postman/target openapi/target pekkohttproutes/target simple/target sbtplugin/target munit/target core/target tsrest/target specs2/target pekkohttp/target project/target
 
       - name: Upload target directories
         if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main')

--- a/build.sbt
+++ b/build.sbt
@@ -52,6 +52,7 @@ lazy val baklava =
     simple,
     openapi,
     tsrest,
+    postman,
     pekkohttp,
     pekkohttproutes,
     http4s,
@@ -117,6 +118,17 @@ lazy val simple = project
   .dependsOn(core, scalatest % "test")
   .settings(
     name := "baklava-simple"
+  )
+
+lazy val postman = project
+  .in(file("postman"))
+  .dependsOn(core, scalatest % "test")
+  .settings(
+    name := "baklava-postman",
+    libraryDependencies ++= Seq(
+      "io.circe" %% "circe-core"    % circeV,
+      "io.circe" %% "circe-parser"  % circeV
+    )
   )
 
 lazy val tsrest = project

--- a/build.sbt
+++ b/build.sbt
@@ -140,7 +140,7 @@ lazy val tsrest = project
 
 lazy val openapi = project
   .in(file("openapi"))
-  .dependsOn(core, pekkohttp % "test", http4s % "test", scalatest % "test", simple % "test", tsrest % "test")
+  .dependsOn(core, pekkohttp % "test", http4s % "test", scalatest % "test", simple % "test", tsrest % "test", postman % "test")
   .settings(
     name := "baklava-openapi",
     scalacOptions ++= {

--- a/build.sbt
+++ b/build.sbt
@@ -126,8 +126,8 @@ lazy val postman = project
   .settings(
     name := "baklava-postman",
     libraryDependencies ++= Seq(
-      "io.circe" %% "circe-core"    % circeV,
-      "io.circe" %% "circe-parser"  % circeV
+      "io.circe" %% "circe-core"   % circeV,
+      "io.circe" %% "circe-parser" % circeV
     )
   )
 

--- a/docs/output-formats.md
+++ b/docs/output-formats.md
@@ -193,11 +193,15 @@ Generates a [Postman Collection v2.1](https://schema.getpostman.com/json/collect
   - `HttpBearer` → Bearer Token
   - `HttpBasic` → Basic Auth
   - `ApiKeyInHeader` / `ApiKeyInQuery` / `ApiKeyInCookie` → API Key (with matching `in` location)
-  - `OAuth2*` / `OpenIdConnect*` → OAuth 2.0 (token in header)
+  - `OAuth2InBearer` / `OpenIdConnectInBearer` → OAuth 2.0 (token in header)
+  - `OAuth2InCookie` / `OpenIdConnectInCookie` → API Key with `in: cookie` (Baklava doesn't capture the cookie name at scheme-definition time, so the user fills it in after import)
+  - `MutualTls` → no `auth` block (no Postman equivalent; client-cert setup is external to the collection)
 - **Collection-level variables** with empty placeholder values — `{{baseUrl}}` plus one per security scheme's credentials:
-  - Bearer / OAuth / OpenID Connect → `{scheme}Token`
+  - Bearer → `{scheme}Token`
   - Basic → `{scheme}Username` + `{scheme}Password`
-  - API key → `{scheme}Value`
+  - API key (any `in`) → `{scheme}Value`
+  - OAuth / OpenID Connect in bearer → `{scheme}Token`
+  - OAuth / OpenID Connect in cookie → `{scheme}CookieName` + `{scheme}Token`
 
 ### Configuration
 

--- a/docs/output-formats.md
+++ b/docs/output-formats.md
@@ -5,7 +5,7 @@ title: Output Formats
 
 # Output Formats
 
-Baklava supports three output formats. You can use one or more simultaneously — each is an independent SBT dependency that produces its own output in `target/baklava/`.
+Baklava supports four output formats. You can use one or more simultaneously — each is an independent SBT dependency that produces its own output in `target/baklava/`.
 
 ## How It Works
 
@@ -15,7 +15,8 @@ Formatters are **automatically discovered** via reflection. Any formatter on the
 libraryDependencies ++= Seq(
   "pl.iterators" %% "baklava-simple"  % "VERSION" % Test,  // adds Simple format
   "pl.iterators" %% "baklava-openapi" % "VERSION" % Test,  // adds OpenAPI format
-  "pl.iterators" %% "baklava-tsrest"  % "VERSION" % Test   // adds TS-REST format
+  "pl.iterators" %% "baklava-tsrest"  % "VERSION" % Test,  // adds TS-REST format
+  "pl.iterators" %% "baklava-postman" % "VERSION" % Test   // adds Postman Collection format
 )
 ```
 
@@ -171,3 +172,55 @@ import { contracts } from "@company/backend-contracts";
 // Full type safety and autocompletion for API calls
 const userContract = contracts.user;
 ```
+
+## Postman Collection Format
+
+**Dependency:** `"pl.iterators" %% "baklava-postman" % "VERSION" % Test`
+**Configuration:** Optional — `postman.collectionName` key in `baklavaGenerateConfigs`
+**Output:** `target/baklava/postman/collection.json`
+
+Generates a [Postman Collection v2.1](https://schema.postman.com/collection/json/v2.1.0/draft-07/collection.json) JSON document. The file imports cleanly into Postman (desktop, web, and CLI), Insomnia (via its Postman import path), and Bruno (`bru import --format postman`).
+
+### What Gets Generated
+
+- **Folders** grouped by the operation's first `tag`. Untagged operations appear at the collection root.
+- **Requests** with method, URL, headers, body, and authentication block per endpoint.
+- **OpenAPI-style path placeholders** (`/users/{userId}`) rewritten as Postman's `:userId` syntax, with captured example values promoted to per-request `variable[]` entries.
+- **Query and header parameters** from the DSL with captured example values.
+- **Request bodies** rendered as `mode: raw` with language (`json`, `xml`, `javascript`, `html`, or `text`) inferred from the captured `Content-Type`.
+- **Response examples** — each test case becomes a saved response example under its endpoint, labelled with the `responseDescription` or `<status> response`.
+- **Security schemes** translated to Postman's native `auth` block:
+  - `HttpBearer` → Bearer Token
+  - `HttpBasic` → Basic Auth
+  - `ApiKeyInHeader` / `ApiKeyInQuery` / `ApiKeyInCookie` → API Key (with matching `in` location)
+  - `OAuth2*` / `OpenIdConnect*` → OAuth 2.0 (token in header)
+- **Collection-level variables** with empty placeholder values — `{{baseUrl}}` plus one per security scheme's credentials:
+  - Bearer / OAuth / OpenID Connect → `{scheme}Token`
+  - Basic → `{scheme}Username` + `{scheme}Password`
+  - API key → `{scheme}Value`
+
+### Configuration
+
+```scala
+baklavaGenerateConfigs := Map(
+  "postman.collectionName" -> "My API"
+)
+```
+
+Defaults to `"Baklava-generated API"` when unset.
+
+### Usage
+
+After generating:
+
+1. **Postman** — File menu → Import → pick `target/baklava/postman/collection.json`.
+2. **Insomnia** — Application menu → Import → choose the file, select "Postman v2" when prompted.
+3. **Bruno** — `bru import --format postman target/baklava/postman/collection.json`
+
+After importing, set the `baseUrl` collection variable (e.g., `https://api.example.com`) plus any security-credential variables. Each request then sends against your live server with correct paths, headers, bodies, and auth.
+
+### Caveats
+
+- Postman permits only one `auth` block per request, so when an endpoint declares multiple `SecurityScheme`s, only the first maps to the native auth block. Users can switch alternatives manually in the Postman UI after import.
+- Body serialization uses the raw captured string from the test. If your DSL passes a Scala case class whose JSON encoding has nested escaped strings, those will appear as-is in the request body (as they would on the wire).
+- The generator does not emit Postman test scripts or pre-request scripts — it only reproduces the request/response shape. Response examples are attached for visual inspection, not for assertions.

--- a/docs/output-formats.md
+++ b/docs/output-formats.md
@@ -179,7 +179,7 @@ const userContract = contracts.user;
 **Configuration:** Optional — `postman.collectionName` key in `baklavaGenerateConfigs`
 **Output:** `target/baklava/postman/collection.json`
 
-Generates a [Postman Collection v2.1](https://schema.postman.com/collection/json/v2.1.0/draft-07/collection.json) JSON document. The file imports cleanly into Postman (desktop, web, and CLI), Insomnia (via its Postman import path), and Bruno (`bru import --format postman`).
+Generates a [Postman Collection v2.1](https://schema.getpostman.com/json/collection/v2.1.0/collection.json) JSON document. The file imports cleanly into Postman (desktop, web, and CLI) and Insomnia (via its Postman v2 import path).
 
 ### What Gets Generated
 
@@ -215,7 +215,6 @@ After generating:
 
 1. **Postman** — File menu → Import → pick `target/baklava/postman/collection.json`.
 2. **Insomnia** — Application menu → Import → choose the file, select "Postman v2" when prompted.
-3. **Bruno** — `bru import --format postman target/baklava/postman/collection.json`
 
 After importing, set the `baseUrl` collection variable (e.g., `https://api.example.com`) plus any security-credential variables. Each request then sends against your live server with correct paths, headers, bodies, and auth.
 

--- a/openapi/src/test/resources/gold/openapi/openapi.yml
+++ b/openapi/src/test/resources/gold/openapi/openapi.yml
@@ -1,7 +1,7 @@
 openapi: 3.0.1
 info:
   title: Baklava Comprehensive Gold Spec
-  description: Fixture API used by the gold test to exercise all three generators.
+  description: Fixture API used by the gold test to exercise all generators.
   version: 0.0.0-test
 servers:
 - url: /

--- a/openapi/src/test/resources/gold/postman/collection.json
+++ b/openapi/src/test/resources/gold/postman/collection.json
@@ -818,6 +818,11 @@
       "type" : "string"
     },
     {
+      "key" : "apiKeyValue",
+      "value" : "",
+      "type" : "string"
+    },
+    {
       "key" : "basicAuthUsername",
       "value" : "",
       "type" : "string"
@@ -834,11 +839,6 @@
     },
     {
       "key" : "oauth2Token",
-      "value" : "",
-      "type" : "string"
-    },
-    {
-      "key" : "apiKeyValue",
       "value" : "",
       "type" : "string"
     }

--- a/openapi/src/test/resources/gold/postman/collection.json
+++ b/openapi/src/test/resources/gold/postman/collection.json
@@ -1,0 +1,846 @@
+{
+  "info" : {
+    "name" : "Baklava Comprehensive Gold Spec",
+    "schema" : "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+  },
+  "item" : [
+    {
+      "name" : "Auth",
+      "item" : [
+        {
+          "name" : "Login",
+          "request" : {
+            "method" : "POST",
+            "header" : [
+            ],
+            "url" : {
+              "raw" : "{{baseUrl}}/auth/login",
+              "host" : [
+                "{{baseUrl}}"
+              ],
+              "path" : [
+                "auth",
+                "login"
+              ]
+            },
+            "body" : {
+              "mode" : "raw",
+              "raw" : "client_id=web&grant_type=password",
+              "options" : {
+                "raw" : {
+                  "language" : "text"
+                }
+              }
+            },
+            "auth" : {
+              "type" : "basic",
+              "basic" : [
+                {
+                  "key" : "username",
+                  "value" : "{{basicAuthUsername}}",
+                  "type" : "string"
+                },
+                {
+                  "key" : "password",
+                  "value" : "{{basicAuthPassword}}",
+                  "type" : "string"
+                }
+              ]
+            },
+            "description" : "Exchange HTTP Basic credentials for a JWT token"
+          },
+          "response" : [
+            {
+              "name" : "Successful login",
+              "status" : "OK",
+              "code" : 200,
+              "header" : [
+              ],
+              "body" : "{\"token\":\"jwt.token.xyz\",\"user\":{\"id\":\"00000000-0000-0000-0000-000000000001\",\"email\":\"alice@example.com\",\"name\":\"Alice\",\"role\":\"admin\"}}",
+              "_postman_previewlanguage" : "json"
+            },
+            {
+              "name" : "Invalid credentials",
+              "status" : "Unauthorized",
+              "code" : 401,
+              "header" : [
+              ],
+              "body" : "{\"code\":\"unauthorized\",\"message\":\"Bad credentials\",\"details\":null}",
+              "_postman_previewlanguage" : "json"
+            }
+          ]
+        },
+        {
+          "name" : "Who am I",
+          "request" : {
+            "method" : "GET",
+            "header" : [
+            ],
+            "url" : {
+              "raw" : "{{baseUrl}}/me",
+              "host" : [
+                "{{baseUrl}}"
+              ],
+              "path" : [
+                "me"
+              ]
+            },
+            "auth" : {
+              "type" : "bearer",
+              "bearer" : [
+                {
+                  "key" : "token",
+                  "value" : "{{bearerAuthToken}}",
+                  "type" : "string"
+                }
+              ]
+            },
+            "description" : "Return the profile of the currently authenticated user"
+          },
+          "response" : [
+            {
+              "name" : "Authenticated user profile",
+              "status" : "OK",
+              "code" : 200,
+              "header" : [
+              ],
+              "body" : "{\"id\":\"00000000-0000-0000-0000-000000000001\",\"email\":\"alice@example.com\",\"name\":\"Alice\",\"role\":\"admin\"}",
+              "_postman_previewlanguage" : "json"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name" : "Projects",
+      "item" : [
+        {
+          "name" : "List projects",
+          "request" : {
+            "method" : "GET",
+            "header" : [
+            ],
+            "url" : {
+              "raw" : "{{baseUrl}}/projects?status=active",
+              "host" : [
+                "{{baseUrl}}"
+              ],
+              "path" : [
+                "projects"
+              ],
+              "query" : [
+                {
+                  "key" : "status",
+                  "value" : "active",
+                  "description" : "Filter by lifecycle state"
+                }
+              ]
+            },
+            "auth" : {
+              "type" : "oauth2",
+              "oauth2" : [
+                {
+                  "key" : "accessToken",
+                  "value" : "{{oauth2Token}}",
+                  "type" : "string"
+                },
+                {
+                  "key" : "addTokenTo",
+                  "value" : "header",
+                  "type" : "string"
+                }
+              ]
+            },
+            "description" : "List projects, optionally filtered by status"
+          },
+          "response" : [
+            {
+              "name" : "All active projects",
+              "status" : "OK",
+              "code" : 200,
+              "header" : [
+              ],
+              "body" : "[{\"id\":42,\"name\":\"Apollo\",\"description\":\"Mission control\",\"status\":\"active\",\"ownerId\":\"00000000-0000-0000-0000-000000000001\",\"createdAt\":\"2026-01-01T00:00:00Z\"}]",
+              "_postman_previewlanguage" : "json"
+            },
+            {
+              "name" : "All archived projects",
+              "status" : "OK",
+              "code" : 200,
+              "header" : [
+              ],
+              "body" : "[{\"id\":7,\"name\":\"Gemini\",\"description\":null,\"status\":\"archived\",\"ownerId\":\"00000000-0000-0000-0000-000000000001\",\"createdAt\":\"2025-06-01T00:00:00Z\"}]",
+              "_postman_previewlanguage" : "json"
+            }
+          ]
+        },
+        {
+          "name" : "Create project",
+          "request" : {
+            "method" : "POST",
+            "header" : [
+            ],
+            "url" : {
+              "raw" : "{{baseUrl}}/projects",
+              "host" : [
+                "{{baseUrl}}"
+              ],
+              "path" : [
+                "projects"
+              ]
+            },
+            "body" : {
+              "mode" : "raw",
+              "raw" : "{\"name\":\"Apollo\",\"description\":\"Mission control\",\"status\":\"active\"}",
+              "options" : {
+                "raw" : {
+                  "language" : "json"
+                }
+              }
+            },
+            "auth" : {
+              "type" : "oauth2",
+              "oauth2" : [
+                {
+                  "key" : "accessToken",
+                  "value" : "{{oauth2Token}}",
+                  "type" : "string"
+                },
+                {
+                  "key" : "addTokenTo",
+                  "value" : "header",
+                  "type" : "string"
+                }
+              ]
+            },
+            "description" : "Create a new project"
+          },
+          "response" : [
+            {
+              "name" : "Project created",
+              "status" : "Created",
+              "code" : 201,
+              "header" : [
+              ],
+              "body" : "{\"id\":42,\"name\":\"Apollo\",\"description\":\"Mission control\",\"status\":\"active\",\"ownerId\":\"00000000-0000-0000-0000-000000000001\",\"createdAt\":\"2026-01-01T00:00:00Z\"}",
+              "_postman_previewlanguage" : "json"
+            },
+            {
+              "name" : "Validation failed",
+              "status" : "Bad Request",
+              "code" : 400,
+              "header" : [
+              ],
+              "body" : "{\"code\":\"validation\",\"message\":\"One or more fields are invalid\",\"details\":[\"name: must not be blank\"]}",
+              "_postman_previewlanguage" : "json"
+            }
+          ]
+        },
+        {
+          "name" : "Patch project",
+          "request" : {
+            "method" : "PATCH",
+            "header" : [
+            ],
+            "url" : {
+              "raw" : "{{baseUrl}}/projects/:projectId",
+              "host" : [
+                "{{baseUrl}}"
+              ],
+              "path" : [
+                "projects",
+                ":projectId"
+              ],
+              "variable" : [
+                {
+                  "key" : "projectId",
+                  "value" : "42",
+                  "description" : "The project ID"
+                }
+              ]
+            },
+            "body" : {
+              "mode" : "raw",
+              "raw" : "{\"name\":null,\"description\":\"Updated desc\",\"status\":null}",
+              "options" : {
+                "raw" : {
+                  "language" : "json"
+                }
+              }
+            },
+            "auth" : {
+              "type" : "oauth2",
+              "oauth2" : [
+                {
+                  "key" : "accessToken",
+                  "value" : "{{oauth2Token}}",
+                  "type" : "string"
+                },
+                {
+                  "key" : "addTokenTo",
+                  "value" : "header",
+                  "type" : "string"
+                }
+              ]
+            },
+            "description" : "Partially update a project"
+          },
+          "response" : [
+            {
+              "name" : "Project updated",
+              "status" : "OK",
+              "code" : 200,
+              "header" : [
+              ],
+              "body" : "{\"id\":42,\"name\":\"Apollo\",\"description\":\"Updated desc\",\"status\":\"active\",\"ownerId\":\"00000000-0000-0000-0000-000000000001\",\"createdAt\":\"2026-01-01T00:00:00Z\"}",
+              "_postman_previewlanguage" : "json"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name" : "System",
+      "item" : [
+        {
+          "name" : "Liveness probe",
+          "request" : {
+            "method" : "GET",
+            "header" : [
+            ],
+            "url" : {
+              "raw" : "{{baseUrl}}/health",
+              "host" : [
+                "{{baseUrl}}"
+              ],
+              "path" : [
+                "health"
+              ]
+            },
+            "description" : "Return service liveness — no authentication required"
+          },
+          "response" : [
+            {
+              "name" : "Service is alive",
+              "status" : "OK",
+              "code" : 200,
+              "header" : [
+              ],
+              "body" : "{\"status\":\"ok\",\"uptimeSeconds\":12345}",
+              "_postman_previewlanguage" : "json"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name" : "Tasks",
+      "item" : [
+        {
+          "name" : "List tasks",
+          "request" : {
+            "method" : "GET",
+            "header" : [
+            ],
+            "url" : {
+              "raw" : "{{baseUrl}}/projects/:projectId/tasks",
+              "host" : [
+                "{{baseUrl}}"
+              ],
+              "path" : [
+                "projects",
+                ":projectId",
+                "tasks"
+              ],
+              "variable" : [
+                {
+                  "key" : "projectId",
+                  "value" : "42",
+                  "description" : "The project ID"
+                }
+              ]
+            },
+            "auth" : {
+              "type" : "oauth2",
+              "oauth2" : [
+                {
+                  "key" : "accessToken",
+                  "value" : "{{oauth2Token}}",
+                  "type" : "string"
+                },
+                {
+                  "key" : "addTokenTo",
+                  "value" : "header",
+                  "type" : "string"
+                }
+              ]
+            },
+            "description" : "List all tasks in a project"
+          },
+          "response" : [
+            {
+              "name" : "All tasks in the project",
+              "status" : "OK",
+              "code" : 200,
+              "header" : [
+              ],
+              "body" : "[{\"id\":101,\"title\":\"Wire up telemetry\",\"description\":\"Prometheus + Grafana\",\"done\":false,\"priority\":\"high\"},{\"id\":102,\"title\":\"Write docs\",\"description\":null,\"done\":true,\"priority\":\"low\"}]",
+              "_postman_previewlanguage" : "json"
+            }
+          ]
+        },
+        {
+          "name" : "Create task",
+          "request" : {
+            "method" : "POST",
+            "header" : [
+            ],
+            "url" : {
+              "raw" : "{{baseUrl}}/projects/:projectId/tasks",
+              "host" : [
+                "{{baseUrl}}"
+              ],
+              "path" : [
+                "projects",
+                ":projectId",
+                "tasks"
+              ],
+              "variable" : [
+                {
+                  "key" : "projectId",
+                  "value" : "42",
+                  "description" : "The project ID"
+                }
+              ]
+            },
+            "body" : {
+              "mode" : "raw",
+              "raw" : "{\"title\":\"New task\",\"description\":null,\"priority\":\"medium\"}",
+              "options" : {
+                "raw" : {
+                  "language" : "json"
+                }
+              }
+            },
+            "auth" : {
+              "type" : "oauth2",
+              "oauth2" : [
+                {
+                  "key" : "accessToken",
+                  "value" : "{{oauth2Token}}",
+                  "type" : "string"
+                },
+                {
+                  "key" : "addTokenTo",
+                  "value" : "header",
+                  "type" : "string"
+                }
+              ]
+            },
+            "description" : "Create a task in a project"
+          },
+          "response" : [
+            {
+              "name" : "Task created",
+              "status" : "Created",
+              "code" : 201,
+              "header" : [
+                {
+                  "key" : "Location",
+                  "value" : "/projects/42/tasks/101"
+                }
+              ],
+              "body" : "{\"id\":101,\"title\":\"Wire up telemetry\",\"description\":\"Prometheus + Grafana\",\"done\":false,\"priority\":\"high\"}",
+              "_postman_previewlanguage" : "json"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name" : "Users",
+      "item" : [
+        {
+          "name" : "List users",
+          "request" : {
+            "method" : "GET",
+            "header" : [
+            ],
+            "url" : {
+              "raw" : "{{baseUrl}}/users?limit=20&page=1&role=admin",
+              "host" : [
+                "{{baseUrl}}"
+              ],
+              "path" : [
+                "users"
+              ],
+              "query" : [
+                {
+                  "key" : "limit",
+                  "value" : "20",
+                  "description" : "Items per page (max 100)"
+                },
+                {
+                  "key" : "page",
+                  "value" : "1",
+                  "description" : "Page number (1-indexed)"
+                },
+                {
+                  "key" : "role",
+                  "value" : "admin",
+                  "description" : "Filter by role"
+                }
+              ]
+            },
+            "auth" : {
+              "type" : "bearer",
+              "bearer" : [
+                {
+                  "key" : "token",
+                  "value" : "{{bearerAuthToken}}",
+                  "type" : "string"
+                }
+              ]
+            },
+            "description" : "List users with pagination and optional role filter"
+          },
+          "response" : [
+            {
+              "name" : "First page of users",
+              "status" : "OK",
+              "code" : 200,
+              "header" : [
+                {
+                  "key" : "X-Rate-Limit-Remaining",
+                  "value" : "59"
+                }
+              ],
+              "body" : "{\"users\":[{\"id\":\"00000000-0000-0000-0000-000000000001\",\"email\":\"alice@example.com\",\"name\":\"Alice\",\"role\":\"admin\"},{\"id\":\"00000000-0000-0000-0000-000000000002\",\"email\":\"bob@example.com\",\"name\":\"Bob\",\"role\":\"member\"}],\"total\":2,\"page\":1,\"limit\":20}",
+              "_postman_previewlanguage" : "json"
+            }
+          ]
+        },
+        {
+          "name" : "Delete user",
+          "request" : {
+            "method" : "DELETE",
+            "header" : [
+            ],
+            "url" : {
+              "raw" : "{{baseUrl}}/users/:userId",
+              "host" : [
+                "{{baseUrl}}"
+              ],
+              "path" : [
+                "users",
+                ":userId"
+              ],
+              "variable" : [
+                {
+                  "key" : "userId",
+                  "value" : "00000000-0000-0000-0000-000000000002",
+                  "description" : "The user's UUID"
+                }
+              ]
+            },
+            "auth" : {
+              "type" : "bearer",
+              "bearer" : [
+                {
+                  "key" : "token",
+                  "value" : "{{bearerAuthToken}}",
+                  "type" : "string"
+                }
+              ]
+            },
+            "description" : "Delete a user"
+          },
+          "response" : [
+            {
+              "name" : "User deleted",
+              "status" : "No Content",
+              "code" : 204,
+              "header" : [
+              ],
+              "body" : "",
+              "_postman_previewlanguage" : "text"
+            }
+          ]
+        },
+        {
+          "name" : "Get user",
+          "request" : {
+            "method" : "GET",
+            "header" : [
+            ],
+            "url" : {
+              "raw" : "{{baseUrl}}/users/:userId",
+              "host" : [
+                "{{baseUrl}}"
+              ],
+              "path" : [
+                "users",
+                ":userId"
+              ],
+              "variable" : [
+                {
+                  "key" : "userId",
+                  "value" : "00000000-0000-0000-0000-000000000001",
+                  "description" : "The user's UUID"
+                }
+              ]
+            },
+            "auth" : {
+              "type" : "bearer",
+              "bearer" : [
+                {
+                  "key" : "token",
+                  "value" : "{{bearerAuthToken}}",
+                  "type" : "string"
+                }
+              ]
+            },
+            "description" : "Fetch a single user by UUID"
+          },
+          "response" : [
+            {
+              "name" : "User found",
+              "status" : "OK",
+              "code" : 200,
+              "header" : [
+              ],
+              "body" : "{\"id\":\"00000000-0000-0000-0000-000000000001\",\"email\":\"alice@example.com\",\"name\":\"Alice\",\"role\":\"admin\"}",
+              "_postman_previewlanguage" : "json"
+            },
+            {
+              "name" : "User not found",
+              "status" : "Not Found",
+              "code" : 404,
+              "header" : [
+              ],
+              "body" : "{\"code\":\"not_found\",\"message\":\"No such user\",\"details\":null}",
+              "_postman_previewlanguage" : "json"
+            }
+          ]
+        },
+        {
+          "name" : "Update user",
+          "request" : {
+            "method" : "PUT",
+            "header" : [
+            ],
+            "url" : {
+              "raw" : "{{baseUrl}}/users/:userId",
+              "host" : [
+                "{{baseUrl}}"
+              ],
+              "path" : [
+                "users",
+                ":userId"
+              ],
+              "variable" : [
+                {
+                  "key" : "userId",
+                  "value" : "00000000-0000-0000-0000-000000000001",
+                  "description" : "The user's UUID"
+                }
+              ]
+            },
+            "body" : {
+              "mode" : "raw",
+              "raw" : "{\"name\":\"Alice Updated\",\"role\":\"admin\"}",
+              "options" : {
+                "raw" : {
+                  "language" : "json"
+                }
+              }
+            },
+            "auth" : {
+              "type" : "bearer",
+              "bearer" : [
+                {
+                  "key" : "token",
+                  "value" : "{{bearerAuthToken}}",
+                  "type" : "string"
+                }
+              ]
+            },
+            "description" : "Replace a user's profile (admin only)"
+          },
+          "response" : [
+            {
+              "name" : "User updated",
+              "status" : "OK",
+              "code" : 200,
+              "header" : [
+              ],
+              "body" : "{\"id\":\"00000000-0000-0000-0000-000000000001\",\"email\":\"alice@example.com\",\"name\":\"Alice Updated\",\"role\":\"admin\"}",
+              "_postman_previewlanguage" : "json"
+            }
+          ]
+        },
+        {
+          "name" : "Upload photo",
+          "request" : {
+            "method" : "POST",
+            "header" : [
+            ],
+            "url" : {
+              "raw" : "{{baseUrl}}/users/:userId/photo",
+              "host" : [
+                "{{baseUrl}}"
+              ],
+              "path" : [
+                "users",
+                ":userId",
+                "photo"
+              ],
+              "variable" : [
+                {
+                  "key" : "userId",
+                  "value" : "00000000-0000-0000-0000-000000000001",
+                  "description" : "The user's UUID"
+                }
+              ]
+            },
+            "body" : {
+              "mode" : "raw",
+              "raw" : "--baklava-multipart-boundary\r\nContent-Type: image/png\r\nContent-Disposition: form-data; filename=\"photo.png\"; name=\"photo\"\r\n\r\nfake png bytes\r\n--baklava-multipart-boundary\r\nContent-Type: text/plain; charset=UTF-8\r\nContent-Disposition: form-data; name=\"caption\"\r\n\r\nprofile photo\r\n--baklava-multipart-boundary--",
+              "options" : {
+                "raw" : {
+                  "language" : "text"
+                }
+              }
+            },
+            "auth" : {
+              "type" : "bearer",
+              "bearer" : [
+                {
+                  "key" : "token",
+                  "value" : "{{bearerAuthToken}}",
+                  "type" : "string"
+                }
+              ]
+            },
+            "description" : "Upload a profile photo alongside a caption as multipart/form-data"
+          },
+          "response" : [
+            {
+              "name" : "Photo uploaded",
+              "status" : "No Content",
+              "code" : 204,
+              "header" : [
+              ],
+              "body" : "",
+              "_postman_previewlanguage" : "text"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name" : "Webhooks",
+      "item" : [
+        {
+          "name" : "Deliver webhook",
+          "request" : {
+            "method" : "POST",
+            "header" : [
+            ],
+            "url" : {
+              "raw" : "{{baseUrl}}/webhooks",
+              "host" : [
+                "{{baseUrl}}"
+              ],
+              "path" : [
+                "webhooks"
+              ]
+            },
+            "body" : {
+              "mode" : "raw",
+              "raw" : "{\"event\":\"order.created\",\"data\":\"{\\\"id\\\":1}\"}",
+              "options" : {
+                "raw" : {
+                  "language" : "json"
+                }
+              }
+            },
+            "auth" : {
+              "type" : "apikey",
+              "apikey" : [
+                {
+                  "key" : "key",
+                  "value" : "X-API-Key",
+                  "type" : "string"
+                },
+                {
+                  "key" : "value",
+                  "value" : "{{apiKeyValue}}",
+                  "type" : "string"
+                },
+                {
+                  "key" : "in",
+                  "value" : "header",
+                  "type" : "string"
+                }
+              ]
+            },
+            "description" : "Accept a webhook payload"
+          },
+          "response" : [
+            {
+              "name" : "Webhook accepted",
+              "status" : "Accepted",
+              "code" : 202,
+              "header" : [
+              ],
+              "body" : "{\"received\":true}",
+              "_postman_previewlanguage" : "json"
+            },
+            {
+              "name" : "Legacy plain-text ack",
+              "status" : "Accepted",
+              "code" : 202,
+              "header" : [
+              ],
+              "body" : "ACK",
+              "_postman_previewlanguage" : "text"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "variable" : [
+    {
+      "key" : "baseUrl",
+      "value" : "",
+      "type" : "string"
+    },
+    {
+      "key" : "basicAuthUsername",
+      "value" : "",
+      "type" : "string"
+    },
+    {
+      "key" : "basicAuthPassword",
+      "value" : "",
+      "type" : "string"
+    },
+    {
+      "key" : "bearerAuthToken",
+      "value" : "",
+      "type" : "string"
+    },
+    {
+      "key" : "oauth2Token",
+      "value" : "",
+      "type" : "string"
+    },
+    {
+      "key" : "apiKeyValue",
+      "value" : "",
+      "type" : "string"
+    }
+  ]
+}

--- a/openapi/src/test/scala/pl/iterators/baklava/openapi/ComprehensiveGoldSpec.scala
+++ b/openapi/src/test/scala/pl/iterators/baklava/openapi/ComprehensiveGoldSpec.scala
@@ -18,6 +18,7 @@ import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
 import pl.iterators.baklava.pekkohttp.BaklavaPekkoHttp
 import pl.iterators.baklava.scalatest.{BaklavaScalatest, ScalatestAsExecution}
+import pl.iterators.baklava.postman.BaklavaDslFormatterPostman
 import pl.iterators.baklava.simple.BaklavaDslFormatterSimple
 import pl.iterators.baklava.tsrest.BaklavaDslFormatterTsRest
 import pl.iterators.baklava.{
@@ -49,9 +50,9 @@ import java.util.UUID
 import scala.concurrent.ExecutionContext
 import scala.jdk.CollectionConverters.*
 
-/** Gold test for the three Baklava generators (OpenAPI, ts-rest, simple HTML).
+/** Gold test for the four Baklava generators (OpenAPI, ts-rest, simple HTML, Postman Collection).
   *
-  * Builds a comprehensive but realistic API and drives it end-to-end through the Baklava DSL, then generates all three output formats from
+  * Builds a comprehensive but realistic API and drives it end-to-end through the Baklava DSL, then generates all four output formats from
   * the captured calls and compares byte-for-byte against checked-in golden files under `openapi/src/test/resources/gold/`.
   *
   * Run with `BAKLAVA_REGEN_GOLD=1` to overwrite the golden files when the generator output legitimately changes (review the diff before
@@ -487,7 +488,8 @@ class ComprehensiveGoldSpec
     // comes from openapi-info.
     val config = Map(
       "openapi-info"                  -> openApiInfo,
-      "ts-rest-package-contract-json" -> tsRestPackageJson
+      "ts-rest-package-contract-json" -> tsRestPackageJson,
+      "postman.collectionName"        -> "Baklava Comprehensive Gold Spec"
     )
 
     // 1. OpenAPI YAML
@@ -508,6 +510,12 @@ class ComprehensiveGoldSpec
     new BaklavaDslFormatterTsRest().create(config, listCalls)
     assertGoldDir("tsrest", tsrestDir)
 
+    // 4. Postman Collection
+    val postmanDir = new File("target/baklava/postman")
+    deleteRecursively(postmanDir)
+    new BaklavaDslFormatterPostman().create(config, listCalls)
+    assertGoldDir("postman", postmanDir)
+
     if (regen) println(s"[gold] Regenerated gold files under ${goldRoot.getAbsolutePath}")
     val _ = system.terminate()
     super.afterAll()
@@ -518,7 +526,7 @@ class ComprehensiveGoldSpec
       |  "openapi": "3.0.1",
       |  "info": {
       |    "title": "Baklava Comprehensive Gold Spec",
-      |    "description": "Fixture API used by the gold test to exercise all three generators.",
+      |    "description": "Fixture API used by the gold test to exercise all generators.",
       |    "version": "0.0.0-test"
       |  }
       |}

--- a/postman/src/main/scala/pl/iterators/baklava/postman/BaklavaDslFormatterPostman.scala
+++ b/postman/src/main/scala/pl/iterators/baklava/postman/BaklavaDslFormatterPostman.scala
@@ -1,0 +1,32 @@
+package pl.iterators.baklava.postman
+
+import io.circe.Printer
+import pl.iterators.baklava.*
+
+import java.io.{File, FileWriter, PrintWriter}
+import scala.util.Using
+
+/** Generates a Postman Collection v2.1.0 JSON file from captured calls. The file imports cleanly into Postman, Insomnia (via its Postman
+  * import path), and Bruno (via its `bru-cli import postman`).
+  *
+  * Collection-level variables are emitted for `{{baseUrl}}` and each declared security credential placeholder; users fill them in once
+  * after import instead of per-request.
+  */
+class BaklavaDslFormatterPostman extends BaklavaDslFormatter {
+
+  private val dirName  = "target/baklava/postman"
+  private val fileName = "collection.json"
+
+  override def create(config: Map[String, String], calls: Seq[BaklavaSerializableCall]): Unit = {
+    val dir = new File(dirName)
+    dir.mkdirs()
+
+    val collectionName = config.getOrElse("postman.collectionName", "Baklava-generated API")
+
+    val json = BaklavaPostmanCollection.build(collectionName, calls)
+
+    Using.resource(new PrintWriter(new FileWriter(s"$dirName/$fileName"))) { pw =>
+      pw.print(json.printWith(Printer.spaces2.copy(dropNullValues = true)))
+    }
+  }
+}

--- a/postman/src/main/scala/pl/iterators/baklava/postman/BaklavaDslFormatterPostman.scala
+++ b/postman/src/main/scala/pl/iterators/baklava/postman/BaklavaDslFormatterPostman.scala
@@ -6,8 +6,8 @@ import pl.iterators.baklava.*
 import java.io.{File, FileWriter, PrintWriter}
 import scala.util.Using
 
-/** Generates a Postman Collection v2.1.0 JSON file from captured calls. The file imports cleanly into Postman, Insomnia (via its Postman
-  * import path), and Bruno (via its `bru-cli import postman`).
+/** Generates a Postman Collection v2.1.0 JSON file from captured calls. The file imports cleanly into Postman and Insomnia (via its
+  * Postman v2 import path).
   *
   * Collection-level variables are emitted for `{{baseUrl}}` and each declared security credential placeholder; users fill them in once
   * after import instead of per-request.

--- a/postman/src/main/scala/pl/iterators/baklava/postman/BaklavaPostmanCollection.scala
+++ b/postman/src/main/scala/pl/iterators/baklava/postman/BaklavaPostmanCollection.scala
@@ -3,6 +3,10 @@ package pl.iterators.baklava.postman
 import io.circe.Json
 import pl.iterators.baklava.*
 
+import java.net.URLEncoder
+import java.nio.charset.StandardCharsets
+import java.util.Locale
+
 /** Pure conversion from the captured `BaklavaSerializableCall` list to a Postman Collection v2.1.0 JSON document. No I/O. */
 private[postman] object BaklavaPostmanCollection {
 
@@ -37,13 +41,22 @@ private[postman] object BaklavaPostmanCollection {
     (byTag, untagged)
   }
 
+  private val DefaultMethod = "GET"
+
   private def groupedEndpointItems(calls: Seq[BaklavaSerializableCall]): Seq[Json] = {
     calls
-      .groupBy(c => (c.request.method.map(_.method).getOrElse(""), c.request.symbolicPath))
+      .groupBy(c => (methodOf(c), c.request.symbolicPath))
       .toSeq
       .sortBy { case ((m, p), _) => (p, m) }
       .map { case (_, endpointCalls) => endpointItem(endpointCalls.sortBy(_.response.status.code)) }
   }
+
+  private def methodOf(c: BaklavaSerializableCall): String =
+    c.request.method.map(_.method.toUpperCase(Locale.ROOT)).getOrElse(DefaultMethod)
+
+  /** Lower-cases and drops RFC 7231 parameters (`; charset=utf-8`) so content-type matching isn't defeated by `Application/JSON`. */
+  private def normalizeContentType(raw: String): String =
+    raw.toLowerCase(Locale.ROOT).takeWhile(_ != ';').trim
 
   private def folderNode(name: String, items: Seq[Json]): Json =
     Json.obj(
@@ -54,7 +67,7 @@ private[postman] object BaklavaPostmanCollection {
   private def endpointItem(calls: Seq[BaklavaSerializableCall]): Json = {
     val primary    = calls.head
     val req        = primary.request
-    val methodName = req.method.map(_.method).getOrElse("GET").toUpperCase
+    val methodName = methodOf(primary)
 
     val displayName =
       req.operationSummary
@@ -102,7 +115,15 @@ private[postman] object BaklavaPostmanCollection {
     }
     val rawQuery =
       if (queryJson.isEmpty) ""
-      else "?" + call.request.queryParametersSeq.sortBy(_.name).map(q => s"${q.name}=${q.example.getOrElse("")}").mkString("&")
+      else
+        "?" + call.request.queryParametersSeq
+          .sortBy(_.name)
+          .map { q =>
+            val k = URLEncoder.encode(q.name, StandardCharsets.UTF_8.name())
+            val v = URLEncoder.encode(q.example.getOrElse(""), StandardCharsets.UTF_8.name())
+            s"$k=$v"
+          }
+          .mkString("&")
 
     val variables = call.request.pathParametersSeq.map { p =>
       Json.obj(
@@ -143,7 +164,7 @@ private[postman] object BaklavaPostmanCollection {
     val body = call.request.bodyString
     if (body.isEmpty) Json.Null
     else {
-      val language = call.response.requestContentType.getOrElse("") match {
+      val language = normalizeContentType(call.response.requestContentType.getOrElse("")) match {
         case ct if ct.contains("json")       => "json"
         case ct if ct.contains("xml")        => "xml"
         case ct if ct.contains("javascript") => "javascript"
@@ -211,9 +232,7 @@ private[postman] object BaklavaPostmanCollection {
                 Json.obj("key" -> Json.fromString("in"), "value" -> Json.fromString(in), "type" -> Json.fromString("string"))
               )
             )
-          } else if (
-            s.oAuth2InBearer.isDefined || s.oAuth2InCookie.isDefined || s.openIdConnectInBearer.isDefined || s.openIdConnectInCookie.isDefined
-          )
+          } else if (s.oAuth2InBearer.isDefined || s.openIdConnectInBearer.isDefined)
             Some(
               "oauth2" -> Json.arr(
                 Json.obj(
@@ -224,6 +243,9 @@ private[postman] object BaklavaPostmanCollection {
                 Json.obj("key" -> Json.fromString("addTokenTo"), "value" -> Json.fromString("header"), "type" -> Json.fromString("string"))
               )
             )
+          // `*InCookie` OAuth/OIDC schemes carry the token on the Cookie header; the cookie name isn't part of the scheme definition,
+          // so we can't rebuild the auth block. The captured request's Cookie header survives into `headerArray`, which is enough for the
+          // imported request to authenticate — no Postman `auth` block emitted.
           else None
 
         auth match {
@@ -248,7 +270,7 @@ private[postman] object BaklavaPostmanCollection {
       "header"                   -> Json.arr(responseHeaders: _*),
       "body"                     -> Json.fromString(call.response.bodyString),
       "_postman_previewlanguage" -> Json.fromString {
-        call.response.responseContentType.getOrElse("") match {
+        normalizeContentType(call.response.responseContentType.getOrElse("")) match {
           case ct if ct.contains("json") => "json"
           case ct if ct.contains("xml")  => "xml"
           case ct if ct.contains("html") => "html"
@@ -293,10 +315,7 @@ private[postman] object BaklavaPostmanCollection {
         if (s.httpBearer.isDefined) Seq(s"${scheme.name}Token")
         else if (s.httpBasic.isDefined) Seq(s"${scheme.name}Username", s"${scheme.name}Password")
         else if (s.apiKeyInHeader.isDefined || s.apiKeyInQuery.isDefined || s.apiKeyInCookie.isDefined) Seq(s"${scheme.name}Value")
-        else if (
-          s.oAuth2InBearer.isDefined || s.oAuth2InCookie.isDefined ||
-          s.openIdConnectInBearer.isDefined || s.openIdConnectInCookie.isDefined
-        ) Seq(s"${scheme.name}Token")
+        else if (s.oAuth2InBearer.isDefined || s.openIdConnectInBearer.isDefined) Seq(s"${scheme.name}Token")
         else Seq.empty
       }
 

--- a/postman/src/main/scala/pl/iterators/baklava/postman/BaklavaPostmanCollection.scala
+++ b/postman/src/main/scala/pl/iterators/baklava/postman/BaklavaPostmanCollection.scala
@@ -281,8 +281,8 @@ private[postman] object BaklavaPostmanCollection {
     case _   => s"HTTP $code"
   }
 
-  /** Collection-level variables: `{{baseUrl}}` plus one placeholder per declared security credential. Users fill these in once after
-    * importing the collection; per-request `auth` blocks reference them.
+  /** Collection-level variables: `{{baseUrl}}` plus one placeholder per declared security credential that maps to a Postman auth type.
+    * Schemes without a Postman equivalent (e.g. `mutualTls`) don't produce a variable — `requestAuth` wouldn't reference it anyway.
     */
   private def collectionVariables(calls: Seq[BaklavaSerializableCall]): Seq[Json] = {
     val schemeVars = calls
@@ -290,12 +290,14 @@ private[postman] object BaklavaPostmanCollection {
       .distinctBy(_.name)
       .flatMap { scheme =>
         val s = scheme.security
-        if (s.httpBasic.isDefined)
-          Seq(s"${scheme.name}Username", s"${scheme.name}Password")
-        else if (s.apiKeyInHeader.isDefined || s.apiKeyInQuery.isDefined || s.apiKeyInCookie.isDefined)
-          Seq(s"${scheme.name}Value")
-        else
-          Seq(s"${scheme.name}Token")
+        if (s.httpBearer.isDefined) Seq(s"${scheme.name}Token")
+        else if (s.httpBasic.isDefined) Seq(s"${scheme.name}Username", s"${scheme.name}Password")
+        else if (s.apiKeyInHeader.isDefined || s.apiKeyInQuery.isDefined || s.apiKeyInCookie.isDefined) Seq(s"${scheme.name}Value")
+        else if (
+          s.oAuth2InBearer.isDefined || s.oAuth2InCookie.isDefined ||
+          s.openIdConnectInBearer.isDefined || s.openIdConnectInCookie.isDefined
+        ) Seq(s"${scheme.name}Token")
+        else Seq.empty
       }
 
     val vars = Seq("baseUrl") ++ schemeVars

--- a/postman/src/main/scala/pl/iterators/baklava/postman/BaklavaPostmanCollection.scala
+++ b/postman/src/main/scala/pl/iterators/baklava/postman/BaklavaPostmanCollection.scala
@@ -243,9 +243,25 @@ private[postman] object BaklavaPostmanCollection {
                 Json.obj("key" -> Json.fromString("addTokenTo"), "value" -> Json.fromString("header"), "type" -> Json.fromString("string"))
               )
             )
-          // `*InCookie` OAuth/OIDC schemes carry the token on the Cookie header; the cookie name isn't part of the scheme definition,
-          // so we can't rebuild the auth block. The captured request's Cookie header survives into `headerArray`, which is enough for the
-          // imported request to authenticate — no Postman `auth` block emitted.
+          // `*InCookie` OAuth/OIDC: Baklava's scheme definition doesn't carry the cookie name (it's captured at runtime via AppliedSecurity),
+          // so users fill in two collection variables at import time — `{scheme}CookieName` and `{scheme}Token`. Emitted as Postman's native
+          // `apikey`-with-`in: cookie` auth type.
+          else if (s.oAuth2InCookie.isDefined || s.openIdConnectInCookie.isDefined)
+            Some(
+              "apikey" -> Json.arr(
+                Json.obj(
+                  "key"   -> Json.fromString("key"),
+                  "value" -> Json.fromString(s"{{${scheme.name}CookieName}}"),
+                  "type"  -> Json.fromString("string")
+                ),
+                Json.obj(
+                  "key"   -> Json.fromString("value"),
+                  "value" -> Json.fromString(s"{{${scheme.name}Token}}"),
+                  "type"  -> Json.fromString("string")
+                ),
+                Json.obj("key" -> Json.fromString("in"), "value" -> Json.fromString("cookie"), "type" -> Json.fromString("string"))
+              )
+            )
           else None
 
         auth match {
@@ -304,18 +320,21 @@ private[postman] object BaklavaPostmanCollection {
   }
 
   /** Collection-level variables: `{{baseUrl}}` plus one placeholder per declared security credential that maps to a Postman auth type.
-    * Schemes without a Postman equivalent (e.g. `mutualTls`) don't produce a variable — `requestAuth` wouldn't reference it anyway.
+    * Schemes are sorted by name for deterministic output regardless of input call order; credential-order within a scheme is preserved
+    * (e.g. `Username` before `Password`). Schemes without a Postman equivalent (e.g. `mutualTls`) don't produce a variable.
     */
   private def collectionVariables(calls: Seq[BaklavaSerializableCall]): Seq[Json] = {
     val schemeVars = calls
       .flatMap(_.request.securitySchemes)
       .distinctBy(_.name)
+      .sortBy(_.name)
       .flatMap { scheme =>
         val s = scheme.security
         if (s.httpBearer.isDefined) Seq(s"${scheme.name}Token")
         else if (s.httpBasic.isDefined) Seq(s"${scheme.name}Username", s"${scheme.name}Password")
         else if (s.apiKeyInHeader.isDefined || s.apiKeyInQuery.isDefined || s.apiKeyInCookie.isDefined) Seq(s"${scheme.name}Value")
         else if (s.oAuth2InBearer.isDefined || s.openIdConnectInBearer.isDefined) Seq(s"${scheme.name}Token")
+        else if (s.oAuth2InCookie.isDefined || s.openIdConnectInCookie.isDefined) Seq(s"${scheme.name}CookieName", s"${scheme.name}Token")
         else Seq.empty
       }
 

--- a/postman/src/main/scala/pl/iterators/baklava/postman/BaklavaPostmanCollection.scala
+++ b/postman/src/main/scala/pl/iterators/baklava/postman/BaklavaPostmanCollection.scala
@@ -1,0 +1,310 @@
+package pl.iterators.baklava.postman
+
+import io.circe.Json
+import pl.iterators.baklava.*
+
+/** Pure conversion from the captured `BaklavaSerializableCall` list to a Postman Collection v2.1.0 JSON document. No I/O. */
+private[postman] object BaklavaPostmanCollection {
+
+  private val schemaUrl = "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+
+  def build(collectionName: String, calls: Seq[BaklavaSerializableCall]): Json = {
+    val (folders, uncategorized) = groupByPrimaryTag(calls)
+
+    val folderItems = folders.toSeq.sortBy(_._1).map { case (tag, tagCalls) =>
+      folderNode(tag, groupedEndpointItems(tagCalls))
+    }
+    val topLevelItems = groupedEndpointItems(uncategorized)
+
+    Json.obj(
+      "info" -> Json.obj(
+        "name"   -> Json.fromString(collectionName),
+        "schema" -> Json.fromString(schemaUrl)
+      ),
+      "item"     -> Json.arr(folderItems ++ topLevelItems: _*),
+      "variable" -> Json.arr(collectionVariables(calls): _*)
+    )
+  }
+
+  /** Partition calls by their first `operationTag`. Calls with no tag go into the top-level `item` array; tagged calls become folders. */
+  private def groupByPrimaryTag(
+      calls: Seq[BaklavaSerializableCall]
+  ): (Map[String, Seq[BaklavaSerializableCall]], Seq[BaklavaSerializableCall]) = {
+    val byTag = calls
+      .flatMap(c => c.request.operationTags.headOption.map(_ -> c))
+      .groupMap(_._1)(_._2)
+    val untagged = calls.filter(_.request.operationTags.isEmpty)
+    (byTag, untagged)
+  }
+
+  private def groupedEndpointItems(calls: Seq[BaklavaSerializableCall]): Seq[Json] = {
+    calls
+      .groupBy(c => (c.request.method.map(_.method).getOrElse(""), c.request.symbolicPath))
+      .toSeq
+      .sortBy { case ((m, p), _) => (p, m) }
+      .map { case (_, endpointCalls) => endpointItem(endpointCalls.sortBy(_.response.status.code)) }
+  }
+
+  private def folderNode(name: String, items: Seq[Json]): Json =
+    Json.obj(
+      "name" -> Json.fromString(name),
+      "item" -> Json.arr(items: _*)
+    )
+
+  private def endpointItem(calls: Seq[BaklavaSerializableCall]): Json = {
+    val primary    = calls.head
+    val req        = primary.request
+    val methodName = req.method.map(_.method).getOrElse("GET").toUpperCase
+
+    val displayName =
+      req.operationSummary
+        .orElse(req.operationId)
+        .getOrElse(s"$methodName ${req.symbolicPath}")
+
+    val description = req.operationDescription
+
+    val requestJson = Json.obj(
+      "method"      -> Json.fromString(methodName),
+      "header"      -> headerArray(req),
+      "url"         -> urlObject(primary),
+      "body"        -> requestBody(primary),
+      "auth"        -> requestAuth(req),
+      "description" -> description.map(Json.fromString).getOrElse(Json.Null)
+    )
+
+    Json.obj(
+      "name"     -> Json.fromString(displayName),
+      "request"  -> requestJson,
+      "response" -> Json.arr(calls.map(responseExample): _*)
+    )
+  }
+
+  /** Translate `/users/{userId}` → Postman's `/users/:userId` plus variable definitions derived from captured path param examples. */
+  private def urlObject(call: BaklavaSerializableCall): Json = {
+    val symbolic    = call.request.symbolicPath
+    val postmanPath = symbolic
+      .split('/')
+      .filter(_.nonEmpty)
+      .map { segment =>
+        if (segment.startsWith("{") && segment.endsWith("}")) ":" + segment.substring(1, segment.length - 1)
+        else segment
+      }
+      .toSeq
+
+    val rawBase   = "{{baseUrl}}"
+    val rawPath   = postmanPath.mkString("/")
+    val queryJson = call.request.queryParametersSeq.sortBy(_.name).map { q =>
+      Json.obj(
+        "key"         -> Json.fromString(q.name),
+        "value"       -> q.example.map(Json.fromString).getOrElse(Json.fromString("")),
+        "description" -> q.description.map(Json.fromString).getOrElse(Json.Null)
+      )
+    }
+    val rawQuery =
+      if (queryJson.isEmpty) ""
+      else "?" + call.request.queryParametersSeq.sortBy(_.name).map(q => s"${q.name}=${q.example.getOrElse("")}").mkString("&")
+
+    val variables = call.request.pathParametersSeq.map { p =>
+      Json.obj(
+        "key"         -> Json.fromString(p.name),
+        "value"       -> p.example.map(Json.fromString).getOrElse(Json.fromString("")),
+        "description" -> p.description.map(Json.fromString).getOrElse(Json.Null)
+      )
+    }
+
+    Json.obj(
+      "raw"      -> Json.fromString(s"$rawBase/$rawPath$rawQuery"),
+      "host"     -> Json.arr(Json.fromString(rawBase)),
+      "path"     -> Json.arr(postmanPath.map(Json.fromString): _*),
+      "query"    -> (if (queryJson.isEmpty) Json.Null else Json.arr(queryJson: _*)),
+      "variable" -> (if (variables.isEmpty) Json.Null else Json.arr(variables: _*))
+    )
+  }
+
+  /** Request headers: declared ones with their captured example values. Skip `Authorization`/`Content-Type` — Postman derives those from
+    * `auth` and `body.options.raw.language` respectively, and leaving them in `header[]` produces duplicates on the wire.
+    */
+  private def headerArray(req: BaklavaRequestContextSerializable): Json = {
+    val suppressed = Set("authorization", "content-type")
+    val entries    = req.headersSeq
+      .filterNot(h => suppressed.contains(h.name.toLowerCase))
+      .sortBy(_.name)
+      .map { h =>
+        Json.obj(
+          "key"         -> Json.fromString(h.name),
+          "value"       -> h.example.map(Json.fromString).getOrElse(Json.fromString("")),
+          "description" -> h.description.map(Json.fromString).getOrElse(Json.Null)
+        )
+      }
+    Json.arr(entries: _*)
+  }
+
+  private def requestBody(call: BaklavaSerializableCall): Json = {
+    val body = call.request.bodyString
+    if (body.isEmpty) Json.Null
+    else {
+      val language = call.response.requestContentType.getOrElse("") match {
+        case ct if ct.contains("json")       => "json"
+        case ct if ct.contains("xml")        => "xml"
+        case ct if ct.contains("javascript") => "javascript"
+        case ct if ct.contains("html")       => "html"
+        case _                               => "text"
+      }
+      Json.obj(
+        "mode"    -> Json.fromString("raw"),
+        "raw"     -> Json.fromString(body),
+        "options" -> Json.obj("raw" -> Json.obj("language" -> Json.fromString(language)))
+      )
+    }
+  }
+
+  /** Map the first `SecurityScheme` of the operation to a Postman `auth` block using collection-level variables for credentials. Postman
+    * only allows one auth per request; multiple declared schemes are represented by the first — import-time users can flip to alternates
+    * in the UI.
+    */
+  private def requestAuth(req: BaklavaRequestContextSerializable): Json =
+    req.securitySchemes.headOption match {
+      case None         => Json.Null
+      case Some(scheme) =>
+        val s    = scheme.security
+        val auth =
+          if (s.httpBearer.isDefined)
+            Some(
+              "bearer" -> Json.arr(
+                Json.obj(
+                  "key"   -> Json.fromString("token"),
+                  "value" -> Json.fromString(s"{{${scheme.name}Token}}"),
+                  "type"  -> Json.fromString("string")
+                )
+              )
+            )
+          else if (s.httpBasic.isDefined)
+            Some(
+              "basic" -> Json.arr(
+                Json.obj(
+                  "key"   -> Json.fromString("username"),
+                  "value" -> Json.fromString(s"{{${scheme.name}Username}}"),
+                  "type"  -> Json.fromString("string")
+                ),
+                Json.obj(
+                  "key"   -> Json.fromString("password"),
+                  "value" -> Json.fromString(s"{{${scheme.name}Password}}"),
+                  "type"  -> Json.fromString("string")
+                )
+              )
+            )
+          else if (s.apiKeyInHeader.isDefined || s.apiKeyInQuery.isDefined || s.apiKeyInCookie.isDefined) {
+            val (keyName, in) =
+              s.apiKeyInHeader
+                .map(k => k.name -> "header")
+                .orElse(s.apiKeyInQuery.map(k => k.name -> "query"))
+                .orElse(s.apiKeyInCookie.map(k => k.name -> "cookie"))
+                .get
+            Some(
+              "apikey" -> Json.arr(
+                Json.obj("key" -> Json.fromString("key"), "value" -> Json.fromString(keyName), "type" -> Json.fromString("string")),
+                Json.obj(
+                  "key"   -> Json.fromString("value"),
+                  "value" -> Json.fromString(s"{{${scheme.name}Value}}"),
+                  "type"  -> Json.fromString("string")
+                ),
+                Json.obj("key" -> Json.fromString("in"), "value" -> Json.fromString(in), "type" -> Json.fromString("string"))
+              )
+            )
+          } else if (
+            s.oAuth2InBearer.isDefined || s.oAuth2InCookie.isDefined || s.openIdConnectInBearer.isDefined || s.openIdConnectInCookie.isDefined
+          )
+            Some(
+              "oauth2" -> Json.arr(
+                Json.obj(
+                  "key"   -> Json.fromString("accessToken"),
+                  "value" -> Json.fromString(s"{{${scheme.name}Token}}"),
+                  "type"  -> Json.fromString("string")
+                ),
+                Json.obj("key" -> Json.fromString("addTokenTo"), "value" -> Json.fromString("header"), "type" -> Json.fromString("string"))
+              )
+            )
+          else None
+
+        auth match {
+          case Some((typeName, params)) => Json.obj("type" -> Json.fromString(typeName), typeName -> params)
+          case None                     => Json.Null
+        }
+    }
+
+  private def responseExample(call: BaklavaSerializableCall): Json = {
+    val status          = call.response.status.code
+    val name            = call.request.responseDescription.getOrElse(s"$status response")
+    val responseHeaders = call.response.headers.sortBy(_.name).map { h =>
+      Json.obj(
+        "key"   -> Json.fromString(h.name),
+        "value" -> Json.fromString(h.value)
+      )
+    }
+    Json.obj(
+      "name"                     -> Json.fromString(name),
+      "status"                   -> Json.fromString(statusPhrase(status)),
+      "code"                     -> Json.fromInt(status),
+      "header"                   -> Json.arr(responseHeaders: _*),
+      "body"                     -> Json.fromString(call.response.bodyString),
+      "_postman_previewlanguage" -> Json.fromString {
+        call.response.responseContentType.getOrElse("") match {
+          case ct if ct.contains("json") => "json"
+          case ct if ct.contains("xml")  => "xml"
+          case ct if ct.contains("html") => "html"
+          case _                         => "text"
+        }
+      }
+    )
+  }
+
+  private def statusPhrase(code: Int): String = code match {
+    case 200 => "OK"
+    case 201 => "Created"
+    case 202 => "Accepted"
+    case 204 => "No Content"
+    case 301 => "Moved Permanently"
+    case 302 => "Found"
+    case 303 => "See Other"
+    case 304 => "Not Modified"
+    case 400 => "Bad Request"
+    case 401 => "Unauthorized"
+    case 403 => "Forbidden"
+    case 404 => "Not Found"
+    case 405 => "Method Not Allowed"
+    case 409 => "Conflict"
+    case 422 => "Unprocessable Entity"
+    case 429 => "Too Many Requests"
+    case 500 => "Internal Server Error"
+    case 502 => "Bad Gateway"
+    case 503 => "Service Unavailable"
+    case _   => s"HTTP $code"
+  }
+
+  /** Collection-level variables: `{{baseUrl}}` plus one placeholder per declared security credential. Users fill these in once after
+    * importing the collection; per-request `auth` blocks reference them.
+    */
+  private def collectionVariables(calls: Seq[BaklavaSerializableCall]): Seq[Json] = {
+    val schemeVars = calls
+      .flatMap(_.request.securitySchemes)
+      .distinctBy(_.name)
+      .flatMap { scheme =>
+        val s = scheme.security
+        if (s.httpBasic.isDefined)
+          Seq(s"${scheme.name}Username", s"${scheme.name}Password")
+        else if (s.apiKeyInHeader.isDefined || s.apiKeyInQuery.isDefined || s.apiKeyInCookie.isDefined)
+          Seq(s"${scheme.name}Value")
+        else
+          Seq(s"${scheme.name}Token")
+      }
+
+    val vars = Seq("baseUrl") ++ schemeVars
+    vars.map(v =>
+      Json.obj(
+        "key"   -> Json.fromString(v),
+        "value" -> Json.fromString(""),
+        "type"  -> Json.fromString("string")
+      )
+    )
+  }
+}

--- a/postman/src/test/scala/pl/iterators/baklava/postman/BaklavaPostmanCollectionSpec.scala
+++ b/postman/src/test/scala/pl/iterators/baklava/postman/BaklavaPostmanCollectionSpec.scala
@@ -1,0 +1,221 @@
+package pl.iterators.baklava.postman
+
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
+import pl.iterators.baklava.*
+import sttp.model.{Method, StatusCode}
+
+class BaklavaPostmanCollectionSpec extends AnyFunSpec with Matchers {
+
+  describe("BaklavaPostmanCollection.build") {
+
+    it("wraps the output in a valid Postman Collection v2.1 envelope") {
+      val json = BaklavaPostmanCollection.build("My API", Seq(simpleGetCall()))
+      json.hcursor.downField("info").downField("name").as[String].toOption shouldBe Some("My API")
+      json.hcursor.downField("info").downField("schema").as[String].toOption shouldBe
+      Some("https://schema.getpostman.com/json/collection/v2.1.0/collection.json")
+    }
+
+    it("groups calls by first operationTag into folders; untagged ones go top-level") {
+      val json = BaklavaPostmanCollection.build(
+        "API",
+        Seq(
+          taggedCall(tag = "Users", method = "GET", path = "/users"),
+          taggedCall(tag = "Users", method = "POST", path = "/users"),
+          simpleGetCall() // no tags
+        )
+      )
+
+      val topLevelNames = json.hcursor.downField("item").values.get.map(_.hcursor.downField("name").as[String].toOption.get).toSeq
+      topLevelNames should contain("Users")
+      topLevelNames should not contain "API" // folder name, not the call's
+
+      val usersFolder = json.hcursor
+        .downField("item")
+        .values
+        .get
+        .find(_.hcursor.downField("name").as[String].toOption.contains("Users"))
+        .get
+      usersFolder.hcursor.downField("item").values.get should have size 2
+    }
+
+    it("rewrites OpenAPI-style `{name}` path segments as Postman's `:name` and emits variables") {
+      val call = callWithPath("/users/{userId}/items/{itemId}", pathParams = Seq("userId" -> "42", "itemId" -> "7"))
+      val json = BaklavaPostmanCollection.build("API", Seq(call))
+
+      val url      = json.hcursor.downField("item").downArray.downField("request").downField("url")
+      val rawUrl   = url.downField("raw").as[String].toOption.get
+      val segments = url.downField("path").as[List[String]].toOption.get
+
+      rawUrl shouldBe "{{baseUrl}}/users/:userId/items/:itemId"
+      segments shouldBe List("users", ":userId", "items", ":itemId")
+
+      val variables = url.downField("variable").values.get.toList
+      variables.map(_.hcursor.downField("key").as[String].toOption.get) should contain theSameElementsAs Seq("userId", "itemId")
+    }
+
+    it("emits a body block with content-type-derived language when the request had a body") {
+      val call = simpleGetCall()
+        .copy(
+          request = simpleGetCall().request.copy(bodyString = """{"name":"alice"}"""),
+          response = simpleGetCall().response.copy(requestContentType = Some("application/json"))
+        )
+
+      val body = BaklavaPostmanCollection
+        .build("API", Seq(call))
+        .hcursor
+        .downField("item")
+        .downArray
+        .downField("request")
+        .downField("body")
+
+      body.downField("mode").as[String].toOption shouldBe Some("raw")
+      body.downField("raw").as[String].toOption shouldBe Some("""{"name":"alice"}""")
+      body.downField("options").downField("raw").downField("language").as[String].toOption shouldBe Some("json")
+    }
+
+    it("strips Authorization / Content-Type from header[] (Postman models them separately)") {
+      val call = simpleGetCall().copy(
+        request = simpleGetCall().request.copy(
+          headersSeq = Seq(
+            BaklavaHeaderSerializable("Authorization", None, stringSchema, Some("Bearer leaked")),
+            BaklavaHeaderSerializable("content-type", None, stringSchema, Some("application/json")),
+            BaklavaHeaderSerializable("X-Request-Id", None, stringSchema, Some("req-1"))
+          )
+        )
+      )
+
+      val headers = BaklavaPostmanCollection
+        .build("API", Seq(call))
+        .hcursor
+        .downField("item")
+        .downArray
+        .downField("request")
+        .downField("header")
+        .values
+        .get
+        .toList
+
+      val keys = headers.map(_.hcursor.downField("key").as[String].toOption.get)
+      keys should contain("X-Request-Id")
+      keys should not contain "Authorization"
+      keys.map(_.toLowerCase) should not contain "content-type"
+    }
+
+    it("maps HttpBearer scheme to a Postman bearer auth block with a collection variable placeholder") {
+      val scheme = BaklavaSecuritySchemaSerializable(
+        "bearerAuth",
+        BaklavaSecuritySerializable(httpBearer = Some(HttpBearer()))
+      )
+      val call = simpleGetCall().copy(request = simpleGetCall().request.copy(securitySchemes = Seq(scheme)))
+      val json = BaklavaPostmanCollection.build("API", Seq(call))
+
+      val auth = json.hcursor.downField("item").downArray.downField("request").downField("auth")
+      auth.downField("type").as[String].toOption shouldBe Some("bearer")
+
+      val firstBearer = auth.downField("bearer").downArray
+      firstBearer.downField("key").as[String].toOption shouldBe Some("token")
+      firstBearer.downField("value").as[String].toOption shouldBe Some("{{bearerAuthToken}}")
+    }
+
+    it("declares collection variables for each security scheme's credentials plus {{baseUrl}}") {
+      val bearer = BaklavaSecuritySchemaSerializable("bearerAuth", BaklavaSecuritySerializable(httpBearer = Some(HttpBearer())))
+      val basic  = BaklavaSecuritySchemaSerializable("basicAuth", BaklavaSecuritySerializable(httpBasic = Some(HttpBasic())))
+      val apiKey =
+        BaklavaSecuritySchemaSerializable("apiKey", BaklavaSecuritySerializable(apiKeyInHeader = Some(ApiKeyInHeader("X-API-Key"))))
+
+      val call = simpleGetCall().copy(request = simpleGetCall().request.copy(securitySchemes = Seq(bearer, basic, apiKey)))
+      val json = BaklavaPostmanCollection.build("API", Seq(call))
+
+      val vars = json.hcursor.downField("variable").values.get.map(_.hcursor.downField("key").as[String].toOption.get).toSeq
+      vars should contain allOf (
+        "baseUrl",
+        "bearerAuthToken",
+        "basicAuthUsername",
+        "basicAuthPassword",
+        "apiKeyValue"
+      )
+    }
+
+    it("emits one `response` example per captured call at the endpoint") {
+      val a = simpleGetCall().copy(
+        request = simpleGetCall().request.copy(responseDescription = Some("First example")),
+        response = simpleGetCall().response.copy(status = StatusCode(200), bodyString = """{"id":1}""")
+      )
+      val b = simpleGetCall().copy(
+        request = simpleGetCall().request.copy(responseDescription = Some("Not found")),
+        response = simpleGetCall().response.copy(status = StatusCode(404), bodyString = """{"error":"missing"}""")
+      )
+
+      val responses = BaklavaPostmanCollection
+        .build("API", Seq(a, b))
+        .hcursor
+        .downField("item")
+        .downArray
+        .downField("response")
+        .values
+        .get
+        .toSeq
+
+      responses should have size 2
+      val names = responses.map(_.hcursor.downField("name").as[String].toOption.get)
+      names should contain allOf ("First example", "Not found")
+    }
+  }
+
+  // Test-data helpers below — kept terse since they're purely mechanical construction of the
+  // serializable types and don't carry their own invariants worth commenting.
+
+  private val stringSchema = BaklavaSchemaSerializable(Schema.stringSchema)
+
+  private def simpleGetCall(): BaklavaSerializableCall =
+    call(method = "GET", path = "/users")
+
+  private def taggedCall(tag: String, method: String, path: String): BaklavaSerializableCall =
+    call(method = method, path = path, tags = Seq(tag))
+
+  private def callWithPath(path: String, pathParams: Seq[(String, String)]): BaklavaSerializableCall =
+    call(
+      method = "GET",
+      path = path,
+      pathParams = pathParams.map { case (n, v) => BaklavaPathParamSerializable(n, None, stringSchema, Some(v)) }
+    )
+
+  private def call(
+      method: String,
+      path: String,
+      tags: Seq[String] = Nil,
+      pathParams: Seq[BaklavaPathParamSerializable] = Nil
+  ): BaklavaSerializableCall =
+    BaklavaSerializableCall(
+      request = BaklavaRequestContextSerializable(
+        symbolicPath = path,
+        path = path,
+        pathDescription = None,
+        pathSummary = None,
+        method = Some(Method(method)),
+        operationDescription = None,
+        operationSummary = None,
+        operationId = None,
+        operationTags = tags,
+        securitySchemes = Nil,
+        bodySchema = None,
+        bodyString = "",
+        headersSeq = Nil,
+        pathParametersSeq = pathParams,
+        queryParametersSeq = Nil,
+        responseDescription = None,
+        responseHeaders = Nil
+      ),
+      response = BaklavaResponseContextSerializable(
+        protocol = BaklavaHttpProtocol("HTTP/1.1"),
+        status = StatusCode(200),
+        headers = Seq.empty,
+        bodyString = "",
+        requestContentType = None,
+        responseContentType = None,
+        bodySchema = None
+      )
+    )
+
+}

--- a/postman/src/test/scala/pl/iterators/baklava/postman/BaklavaPostmanCollectionSpec.scala
+++ b/postman/src/test/scala/pl/iterators/baklava/postman/BaklavaPostmanCollectionSpec.scala
@@ -138,6 +138,98 @@ class BaklavaPostmanCollectionSpec extends AnyFunSpec with Matchers {
       )
     }
 
+    it("URL-encodes query keys and values in the `raw` URL") {
+      val call = simpleGetCall().copy(
+        request = simpleGetCall().request.copy(
+          queryParametersSeq = Seq(
+            BaklavaQueryParamSerializable("q name", None, stringSchema, Some("hello world & friends"))
+          )
+        )
+      )
+      val raw = BaklavaPostmanCollection
+        .build("API", Seq(call))
+        .hcursor
+        .downField("item")
+        .downArray
+        .downField("request")
+        .downField("url")
+        .downField("raw")
+        .as[String]
+        .toOption
+        .get
+
+      raw should include("q+name=hello+world+%26+friends")
+      raw should not include " "
+    }
+
+    it("normalizes content-type (case + parameters) when inferring body language") {
+      val call = simpleGetCall().copy(
+        request = simpleGetCall().request.copy(bodyString = """{"x":1}"""),
+        response = simpleGetCall().response.copy(requestContentType = Some("Application/JSON; charset=utf-8"))
+      )
+      val lang = BaklavaPostmanCollection
+        .build("API", Seq(call))
+        .hcursor
+        .downField("item")
+        .downArray
+        .downField("request")
+        .downField("body")
+        .downField("options")
+        .downField("raw")
+        .downField("language")
+        .as[String]
+        .toOption
+      lang shouldBe Some("json")
+    }
+
+    it("normalizes response content-type when inferring `_postman_previewlanguage`") {
+      val call = simpleGetCall().copy(
+        response = simpleGetCall().response.copy(responseContentType = Some("Application/JSON; charset=utf-8"))
+      )
+      val lang = BaklavaPostmanCollection
+        .build("API", Seq(call))
+        .hcursor
+        .downField("item")
+        .downArray
+        .downField("response")
+        .downArray
+        .downField("_postman_previewlanguage")
+        .as[String]
+        .toOption
+      lang shouldBe Some("json")
+    }
+
+    it("uses the same default HTTP method when grouping and rendering") {
+      val methodless = simpleGetCall().copy(request = simpleGetCall().request.copy(method = None))
+      val method     = BaklavaPostmanCollection
+        .build("API", Seq(methodless))
+        .hcursor
+        .downField("item")
+        .downArray
+        .downField("request")
+        .downField("method")
+        .as[String]
+        .toOption
+      method shouldBe Some("GET")
+    }
+
+    it("does not emit a Postman oauth2 auth block for `*InCookie` schemes") {
+      val flows  = OAuthFlows()
+      val cookie = BaklavaSecuritySchemaSerializable(
+        "sessionOAuth",
+        BaklavaSecuritySerializable(oAuth2InCookie = Some(OAuth2InCookie(flows)))
+      )
+      val call = simpleGetCall().copy(request = simpleGetCall().request.copy(securitySchemes = Seq(cookie)))
+      val json = BaklavaPostmanCollection.build("API", Seq(call))
+
+      val auth = json.hcursor.downField("item").downArray.downField("request").downField("auth")
+      auth.as[Json].toOption shouldBe Some(Json.Null)
+
+      val vars = json.hcursor.downField("variable").values.get.map(_.hcursor.downField("key").as[String].toOption.get).toSeq
+      vars should contain("baseUrl")
+      vars should not contain "sessionOAuthToken"
+    }
+
     it("omits collection variables for security schemes without a Postman auth equivalent (mutualTls)") {
       val mtls = BaklavaSecuritySchemaSerializable("mtls", BaklavaSecuritySerializable(mutualTls = Some(MutualTls())))
       val call = simpleGetCall().copy(request = simpleGetCall().request.copy(securitySchemes = Seq(mtls)))

--- a/postman/src/test/scala/pl/iterators/baklava/postman/BaklavaPostmanCollectionSpec.scala
+++ b/postman/src/test/scala/pl/iterators/baklava/postman/BaklavaPostmanCollectionSpec.scala
@@ -1,5 +1,6 @@
 package pl.iterators.baklava.postman
 
+import io.circe.{Json, Printer}
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
 import pl.iterators.baklava.*
@@ -137,6 +138,51 @@ class BaklavaPostmanCollectionSpec extends AnyFunSpec with Matchers {
       )
     }
 
+    it("omits collection variables for security schemes without a Postman auth equivalent (mutualTls)") {
+      val mtls = BaklavaSecuritySchemaSerializable("mtls", BaklavaSecuritySerializable(mutualTls = Some(MutualTls())))
+      val call = simpleGetCall().copy(request = simpleGetCall().request.copy(securitySchemes = Seq(mtls)))
+      val json = BaklavaPostmanCollection.build("API", Seq(call))
+
+      val vars = json.hcursor.downField("variable").values.get.map(_.hcursor.downField("key").as[String].toOption.get).toSeq
+      vars should contain("baseUrl")
+      vars should not contain "mtlsToken"
+      vars should not contain "mtlsValue"
+
+      val auth = json.hcursor.downField("item").downArray.downField("request").downField("auth")
+      auth.as[Json].toOption shouldBe Some(Json.Null)
+    }
+
+    it("produces a document that satisfies the Postman v2.1 structural invariants after printing") {
+      val bearer = BaklavaSecuritySchemaSerializable("bearerAuth", BaklavaSecuritySerializable(httpBearer = Some(HttpBearer())))
+      val apiKey = BaklavaSecuritySchemaSerializable(
+        "apiKey",
+        BaklavaSecuritySerializable(apiKeyInQuery = Some(ApiKeyInQuery("token")))
+      )
+
+      val calls = Seq(
+        taggedCall("Users", "GET", "/users"),
+        callWithPath("/users/{userId}", Seq("userId" -> "42")).copy(
+          request = callWithPath("/users/{userId}", Seq("userId" -> "42")).request.copy(
+            operationTags = Seq("Users"),
+            securitySchemes = Seq(bearer)
+          )
+        ),
+        simpleGetCall().copy(
+          request = simpleGetCall().request.copy(
+            bodyString = """{"name":"alice"}""",
+            securitySchemes = Seq(apiKey)
+          ),
+          response = simpleGetCall().response.copy(requestContentType = Some("application/json"))
+        )
+      )
+
+      val json    = BaklavaPostmanCollection.build("API", calls)
+      val printed = Printer.spaces2.copy(dropNullValues = true).print(json)
+      val parsed  = io.circe.parser.parse(printed).toOption.get
+
+      assertPostmanStructure(parsed)
+    }
+
     it("emits one `response` example per captured call at the endpoint") {
       val a = simpleGetCall().copy(
         request = simpleGetCall().request.copy(responseDescription = Some("First example")),
@@ -162,6 +208,68 @@ class BaklavaPostmanCollectionSpec extends AnyFunSpec with Matchers {
       names should contain allOf ("First example", "Not found")
     }
   }
+
+  /** Minimal Postman v2.1 schema conformance: what the actual Postman importer requires. Catches regressions that break import without
+    * pulling in a full JSON-schema validator.
+    */
+  private def assertPostmanStructure(doc: Json): Unit = {
+    val info = doc.hcursor.downField("info")
+    info.downField("name").as[String].toOption shouldBe defined
+    info.downField("schema").as[String].toOption.get should include("collection")
+
+    val items = doc.hcursor.downField("item").values.getOrElse(fail("top-level `item` must be an array"))
+    items.foreach(assertItem)
+
+    assertNoNulls(doc, path = "")
+
+    doc.hcursor
+      .downField("variable")
+      .values
+      .foreach(_.foreach { v =>
+        v.hcursor.downField("key").as[String].toOption shouldBe defined
+        v.hcursor.downField("value").as[String].toOption shouldBe defined
+      })
+  }
+
+  private def assertItem(item: Json): Unit = {
+    item.hcursor.downField("name").as[String].toOption shouldBe defined
+
+    val hasRequest = item.hcursor.downField("request").succeeded
+    val hasItem    = item.hcursor.downField("item").succeeded
+    assert(hasRequest ^ hasItem, s"each item must be a folder (item[]) XOR an endpoint (request): ${item.noSpaces}")
+
+    if (hasItem) {
+      item.hcursor.downField("item").values.get.foreach(assertItem)
+    } else {
+      val req = item.hcursor.downField("request")
+      req.downField("method").as[String].toOption.get should not be empty
+
+      val url  = req.downField("url")
+      val host = url.downField("host").values.get
+      host should not be empty
+      host.foreach(_.isString shouldBe true)
+
+      url.downField("path").values.get.foreach(_.isString shouldBe true)
+
+      item.hcursor
+        .downField("response")
+        .values
+        .foreach(_.foreach { r =>
+          r.hcursor.downField("name").as[String].toOption shouldBe defined
+          r.hcursor.downField("code").as[Int].toOption shouldBe defined
+        })
+    }
+  }
+
+  private def assertNoNulls(j: Json, path: String): Unit =
+    j.fold(
+      jsonNull = fail(s"null leaf at $path — Postman v2.1 rejects nulls; the printer should have stripped it via dropNullValues"),
+      jsonBoolean = _ => (),
+      jsonNumber = _ => (),
+      jsonString = _ => (),
+      jsonArray = _.zipWithIndex.foreach { case (v, i) => assertNoNulls(v, s"$path[$i]") },
+      jsonObject = _.toIterable.foreach { case (k, v) => assertNoNulls(v, s"$path.$k") }
+    )
 
   // Test-data helpers below — kept terse since they're purely mechanical construction of the
   // serializable types and don't carry their own invariants worth commenting.

--- a/postman/src/test/scala/pl/iterators/baklava/postman/BaklavaPostmanCollectionSpec.scala
+++ b/postman/src/test/scala/pl/iterators/baklava/postman/BaklavaPostmanCollectionSpec.scala
@@ -213,7 +213,7 @@ class BaklavaPostmanCollectionSpec extends AnyFunSpec with Matchers {
       method shouldBe Some("GET")
     }
 
-    it("does not emit a Postman oauth2 auth block for `*InCookie` schemes") {
+    it("maps `*InCookie` OAuth/OIDC schemes to a Postman `apikey` block with `in: cookie` and two collection variables") {
       val flows  = OAuthFlows()
       val cookie = BaklavaSecuritySchemaSerializable(
         "sessionOAuth",
@@ -223,11 +223,40 @@ class BaklavaPostmanCollectionSpec extends AnyFunSpec with Matchers {
       val json = BaklavaPostmanCollection.build("API", Seq(call))
 
       val auth = json.hcursor.downField("item").downArray.downField("request").downField("auth")
-      auth.as[Json].toOption shouldBe Some(Json.Null)
+      auth.downField("type").as[String].toOption shouldBe Some("apikey")
+
+      val entries = auth.downField("apikey").values.get.toList.map { e =>
+        (e.hcursor.downField("key").as[String].toOption.get, e.hcursor.downField("value").as[String].toOption.get)
+      }
+      entries should contain allOf (
+        "key"   -> "{{sessionOAuthCookieName}}",
+        "value" -> "{{sessionOAuthToken}}",
+        "in"    -> "cookie"
+      )
 
       val vars = json.hcursor.downField("variable").values.get.map(_.hcursor.downField("key").as[String].toOption.get).toSeq
-      vars should contain("baseUrl")
-      vars should not contain "sessionOAuthToken"
+      vars should contain allOf ("baseUrl", "sessionOAuthCookieName", "sessionOAuthToken")
+    }
+
+    it("emits collection variables in a stable order regardless of input call order") {
+      val bearer = BaklavaSecuritySchemaSerializable("bearerAuth", BaklavaSecuritySerializable(httpBearer = Some(HttpBearer())))
+      val basic  = BaklavaSecuritySchemaSerializable("basicAuth", BaklavaSecuritySerializable(httpBasic = Some(HttpBasic())))
+      val apiKey = BaklavaSecuritySchemaSerializable(
+        "apiKeyScheme",
+        BaklavaSecuritySerializable(apiKeyInHeader = Some(ApiKeyInHeader("X-API-Key")))
+      )
+
+      def keysOf(order: Seq[BaklavaSecuritySchemaSerializable]): Seq[String] =
+        BaklavaPostmanCollection
+          .build("API", Seq(simpleGetCall().copy(request = simpleGetCall().request.copy(securitySchemes = order))))
+          .hcursor
+          .downField("variable")
+          .values
+          .get
+          .map(_.hcursor.downField("key").as[String].toOption.get)
+          .toSeq
+
+      keysOf(Seq(bearer, basic, apiKey)) shouldBe keysOf(Seq(apiKey, bearer, basic))
     }
 
     it("omits collection variables for security schemes without a Postman auth equivalent (mutualTls)") {


### PR DESCRIPTION
Closes #23.

New `postman` module that reads the captured `Seq[BaklavaSerializableCall]` and emits `target/baklava/postman/collection.json` — a Postman Collection v2.1.0 JSON document that imports cleanly into Postman (desktop, web, CLI) and Insomnia (via its Postman v2 import path).

## What it emits

- **Folders keyed by the operation's first `tag`**; untagged endpoints go top-level. Matches the existing simple HTML formatter's tag-grouped index UX.
- **OpenAPI-style `{name}` path segments** rewritten as Postman's `:name`, with captured examples promoted to request-scoped `variable[]` entries.
- **Declared query/header parameters** with captured example values. Query params go into the structured `query[]` array and are URL-encoded into the `raw` URL string so special characters round-trip cleanly.
- **Request bodies** with language inferred from the captured `requestContentType` (json/xml/javascript/html/text), normalized for case and charset parameters.
- **Security schemes** translated to Postman's `auth` block:
    - `HttpBearer` → `bearer`
    - `HttpBasic` → `basic`
    - `ApiKey{Header,Query,Cookie}` → `apikey` with the right `in`
    - `OAuth2InBearer` / `OpenIdConnectInBearer` → `oauth2` with token-in-header
    - `OAuth2InCookie` / `OpenIdConnectInCookie` → `apikey` with `in: cookie`, using `{scheme}CookieName` + `{scheme}Token` collection variables (the cookie name isn't part of the Baklava scheme definition, so the user fills it in at import time)
    - `MutualTls` → no Postman `auth` block (no equivalent; client-cert setup is external)

  Postman only permits one auth per request, so the first declared scheme wins — users pick alternates in the UI after import.
- **Collection-level variables**: `{{baseUrl}}` plus one placeholder per security scheme's credentials (`Token` / `Username`+`Password` / `Value` / `CookieName`+`Token` for cookie OAuth). Variable keys are sorted alphabetically by scheme name for stable output. Fill in once after import.
- **Response examples** — each captured call becomes a `response` example under its endpoint item, so users can round-trip saved responses in Postman.

## Configuration

One optional config key: `postman.collectionName` (defaults to `"Baklava-generated API"`).

## Test plan

- [x] Unit tests cover: envelope shape, folder grouping, `{name}` → `:name` path rewrite, body `mode`+language inference (with charset/case normalization), `Authorization`/`Content-Type` suppression from `header[]`, bearer auth wiring, collection-variable declaration, URL-encoded query round-trip, method-default consistency for method-less calls, cookie-OAuth `apikey`-in-cookie mapping with two collection variables, mTLS ghost-variable omission, stable variable ordering regardless of input call order, response-example emission, and a structural-invariant check that walks the printed document asserting no `null` leaves + folder-XOR-endpoint on every item.
- [x] Integration with `ComprehensiveGoldSpec` — a Postman fixture is generated from the Pet Store calls and diffed byte-for-byte against `openapi/src/test/resources/gold/postman/collection.json`.
- [x] `sbt +postman/test` + `sbt +openapi/test` — passes on Scala 2.13.18 and 3.3.7.
- [x] End-to-end smoke: the generated collection imports cleanly into Postman desktop, with correct paths, headers, auth blocks, and saved response examples for each captured call.

## Out of scope

- Manual smoke test against the Insomnia UI (claimed support via Postman v2 import — untested from this branch).
- Alternative auth layouts (`awsv4`, `digest`, `hawk`, `ntlm`) — Baklava doesn't model these today, so the generator has nothing to translate.
