### PR TITLE
release: bump tlBaseVersion to 1.3 ahead of v1.3.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,4 @@
-ThisBuild / tlBaseVersion          := "1.2"
+ThisBuild / tlBaseVersion          := "1.3"
 ThisBuild / tlCiHeaderCheck        := false
 ThisBuild / tlUntaggedAreSnapshots := true
 ThisBuild / versionScheme          := Some("early-semver")


### PR DESCRIPTION
## Summary

Bumps `tlBaseVersion` from `1.2` to `1.3` ahead of cutting `v1.3.0`.

`baklava-http4s-routes` drops its `com.typesafe:config` dependency in #97 and removes the `routes(com.typesafe.config.Config)` overload — source-breaking. Under early-semver (`1.x.y`), the minor number is the breaking-change channel, so the bump is required even though `v1.2.0` only shipped five days ago.

`baklava-pekko-http-routes` is unaffected — both the new case-class API and the existing Typesafe-Config overload coexist there.

## Migration (http4s callers)

Either drop the HOCON entirely (defaults + `BAKLAVA_ROUTES_*` env vars cover most setups) or build the case class from your `Config`:

```scala
val c = config.getConfig("baklava-routes")
BaklavaRoutes.routes(BaklavaRoutesConfig(
  enabled = c.getBoolean("enabled"),
  basicAuthUser = Try(c.getString("basic-auth-user")).toOption,
  basicAuthPassword = Try(c.getString("basic-auth-password")).toOption,
  fileSystemPath = c.getString("filesystem-path"),
  publicPathPrefix = c.getString("public-path-prefix"),
  apiPublicPathPrefix = c.getString("api-public-path-prefix")
))
```

Full snippet also lives in `docs/installation.md`.

## Release flow

Same as #94 → `v1.2.0`:

1. Merge this PR.
2. Tag `v1.3.0` on `main` — typelevel publish workflow picks it up.
3. Follow-up PR (matching #95) bumps README install snippets and `docs/dsl-reference.md` `/v1.2.0/` deep-link URLs to `/v1.3.0/` after the tag exists.

## Test plan

- [x] scalafmt clean (`scalafmtSbtCheck`)
- [x] CI green on this PR