### PR TITLE
ci: point Release Drafter at main instead of master

### DIFF
--- a/.github/workflows/draft.yml
+++ b/.github/workflows/draft.yml
@@ -3,7 +3,7 @@ name: Release Drafter
 on:
   push:
     branches:
-      - master
+      - main
 jobs:
   update_release_draft:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

`.github/workflows/draft.yml` listens for pushes on `master`, but this repo's default branch is `main` — so the [Release Drafter](https://github.com/release-drafter/release-drafter) workflow has been silently never running since the repo was created. Every GitHub Release page on this repo (v0.x → v1.3.0) was written by hand.

Switching the trigger to `main` lets release-drafter accumulate PR titles between releases into a draft body, so the next time a tag goes out the maintainer just has to publish the draft instead of writing the body from scratch.

## Test plan

- [x] yaml is well-formed (single key change, no other edits)
- [x] After merge: Release Drafter run shows up under Actions on the next push to main
- [x] After the next release tag: a draft release exists with the merged-PR titles since v1.3.0

## Notes

This only affects Release Drafter (the *draft* body generator). The actual artifact publishing to Maven Central runs from the typelevel CI workflow on tag push and is unaffected.