### PR TITLE
fix(http4s): propagate multipart Content-Type/boundary to outgoing requests

### DIFF
--- a/http4s/src/main/scala/pl/iterators/baklava/http4s/BaklavaHttp4s.scala
+++ b/http4s/src/main/scala/pl/iterators/baklava/http4s/BaklavaHttp4s.scala
@@ -112,6 +112,11 @@ trait BaklavaHttp4s[TestFrameworkFragmentType, TestFrameworkFragmentsType, TestF
     org.http4s.multipart.Multipart[IO](parts, Boundary("baklava-multipart-boundary"))
   }
 
+  /** This implicit satisfies the `BaklavaHttpDsl` API and is what type-class derivation resolves for `RequestBody = BaklavaMultipart`, but
+    * `baklavaContextToHttpRequest` does NOT use it for request building — it goes through `toHttp4sMultipart` directly so the encoded body
+    * and the advertised `Content-Type` boundary stay in sync (issue #102). To customize the wire format (parts layout, headers, boundary),
+    * override `toHttp4sMultipart` rather than this implicit; an override here alone will not affect outgoing multipart requests.
+    */
   override implicit protected def multipartToRequestBodyType: BaklavaHttp4s.ToEntityMarshaller[BaklavaMultipart] =
     implicitly[EntityEncoder[IO, org.http4s.multipart.Multipart[IO]]].contramap(toHttp4sMultipart)
 

--- a/http4s/src/main/scala/pl/iterators/baklava/http4s/BaklavaHttp4s.scala
+++ b/http4s/src/main/scala/pl/iterators/baklava/http4s/BaklavaHttp4s.scala
@@ -79,11 +79,13 @@ trait BaklavaHttp4s[TestFrameworkFragmentType, TestFrameworkFragmentsType, TestF
 
   implicit val urlFormSchema: Schema[UrlForm] = FreeFormSchema("UrlForm")
 
-  /** Build the http4s `Multipart` from the user-facing baklava `Multipart`. Extracted from the encoder so `baklavaContextToHttpRequest`
-    * can reuse it to recover the `Content-Type: multipart/form-data; boundary=…` header that http4s' `MultipartEncoder` leaves at
-    * `Headers.empty` (issue #102).
+  /** Build the http4s `Multipart` from the user-facing baklava `Multipart`. `baklavaContextToHttpRequest` builds the value once and uses
+    * it for both the entity body and to recover the `Content-Type: multipart/form-data; boundary=…` header that http4s' `MultipartEncoder`
+    * leaves at `Headers.empty` (issue #102) — keeping the boundary on the encoded body and the boundary on the advertised `Content-Type`
+    * impossible to diverge. Override this (rather than `multipartToRequestBodyType`) to customize the wire format; the request-building
+    * path uses this method directly so the override is honored everywhere.
     */
-  private def toHttp4sMultipart(baklavaMultipart: BaklavaMultipart): org.http4s.multipart.Multipart[IO] = {
+  protected def toHttp4sMultipart(baklavaMultipart: BaklavaMultipart): org.http4s.multipart.Multipart[IO] = {
     // `Vector[Http4sPart[IO]]` annotation: Scala 2.13 otherwise widens the match to `Part[Pure] | Part[IO]`.
     val parts: Vector[Http4sPart[IO]] = baklavaMultipart.parts.toVector.map {
       case FilePart(name, contentType, filename, bytes) =>
@@ -212,21 +214,20 @@ trait BaklavaHttp4s[TestFrameworkFragmentType, TestFrameworkFragmentsType, TestF
       uri = Uri.fromString(ctx.path).fold(throw _, identity),
       headers = baklavaHeadersToHttpHeaders(otherHeaders)
     )
+    // http4s' `MultipartEncoder` ships `headers = Headers.empty` (long-standing TODO upstream),
+    // so `withEntity(multipart)` alone produces a request without the
+    // `Content-Type: multipart/form-data; boundary=…` header — the header lives on the http4s
+    // `Multipart` value itself, not the encoder. We build the http4s `Multipart` once and use it
+    // both for the entity body and to recover those headers, so the boundary on the encoded body
+    // and the boundary on the advertised `Content-Type` are guaranteed to match (issue #102).
     val withBody = ctx.body match {
+      case Some(mp: BaklavaMultipart) =>
+        val http4sMp = toHttp4sMultipart(mp)
+        base.withEntity(http4sMp).putHeaders(http4sMp.headers)
       case Some(body) => base.withEntity(body)
       case None       => base
     }
-    // http4s' `MultipartEncoder` ships `headers = Headers.empty` (long-standing TODO upstream),
-    // so `withEntity` for a multipart body produces a request without the
-    // `Content-Type: multipart/form-data; boundary=…` header. The header lives on the http4s
-    // `Multipart` value itself. Recover it here so http4s routes that decode `Multipart[IO]`
-    // accept the request (issue #102).
-    val withMultipartHeaders = ctx.body match {
-      case Some(mp: BaklavaMultipart) =>
-        withBody.putHeaders(toHttp4sMultipart(mp).headers)
-      case _ => withBody
-    }
-    parsedOverride.fold(withMultipartHeaders)(ct => withMultipartHeaders.withContentType(ct))
+    parsedOverride.fold(withBody)(ct => withBody.withContentType(ct))
   }
 
   /** Find a `Content-Type` in the declared headers (case-insensitive) and return the parsed http4s `Content-Type`. Throws on either

--- a/http4s/src/main/scala/pl/iterators/baklava/http4s/BaklavaHttp4s.scala
+++ b/http4s/src/main/scala/pl/iterators/baklava/http4s/BaklavaHttp4s.scala
@@ -79,12 +79,9 @@ trait BaklavaHttp4s[TestFrameworkFragmentType, TestFrameworkFragmentsType, TestF
 
   implicit val urlFormSchema: Schema[UrlForm] = FreeFormSchema("UrlForm")
 
-  /** Build the http4s `Multipart` from the user-facing baklava `Multipart`. `baklavaContextToHttpRequest` builds the value once and uses
-    * it for both the entity body and to recover the `Content-Type: multipart/form-data; boundary=…` header that http4s' `MultipartEncoder`
-    * leaves at `Headers.empty` (issue #102) — keeping the boundary on the encoded body and the boundary on the advertised `Content-Type`
-    * impossible to diverge. Override this (rather than `multipartToRequestBodyType`) to customize the wire format; the request-building
-    * path uses this method directly so the override is honored everywhere.
-    */
+  // Override here (not `multipartToRequestBodyType`) to customize the wire format —
+  // `baklavaContextToHttpRequest` calls this directly so the body boundary and the Content-Type
+  // boundary can't diverge (issue #102).
   protected def toHttp4sMultipart(baklavaMultipart: BaklavaMultipart): org.http4s.multipart.Multipart[IO] = {
     // `Vector[Http4sPart[IO]]` annotation: Scala 2.13 otherwise widens the match to `Part[Pure] | Part[IO]`.
     val parts: Vector[Http4sPart[IO]] = baklavaMultipart.parts.toVector.map {
@@ -112,11 +109,7 @@ trait BaklavaHttp4s[TestFrameworkFragmentType, TestFrameworkFragmentsType, TestF
     org.http4s.multipart.Multipart[IO](parts, Boundary("baklava-multipart-boundary"))
   }
 
-  /** This implicit satisfies the `BaklavaHttpDsl` API and is what type-class derivation resolves for `RequestBody = BaklavaMultipart`, but
-    * `baklavaContextToHttpRequest` does NOT use it for request building — it goes through `toHttp4sMultipart` directly so the encoded body
-    * and the advertised `Content-Type` boundary stay in sync (issue #102). To customize the wire format (parts layout, headers, boundary),
-    * override `toHttp4sMultipart` rather than this implicit; an override here alone will not affect outgoing multipart requests.
-    */
+  // Required by the abstract API; not used by `baklavaContextToHttpRequest` — override `toHttp4sMultipart` instead.
   override implicit protected def multipartToRequestBodyType: BaklavaHttp4s.ToEntityMarshaller[BaklavaMultipart] =
     implicitly[EntityEncoder[IO, org.http4s.multipart.Multipart[IO]]].contramap(toHttp4sMultipart)
 
@@ -219,12 +212,9 @@ trait BaklavaHttp4s[TestFrameworkFragmentType, TestFrameworkFragmentsType, TestF
       uri = Uri.fromString(ctx.path).fold(throw _, identity),
       headers = baklavaHeadersToHttpHeaders(otherHeaders)
     )
-    // http4s' `MultipartEncoder` ships `headers = Headers.empty` (long-standing TODO upstream),
-    // so `withEntity(multipart)` alone produces a request without the
-    // `Content-Type: multipart/form-data; boundary=…` header — the header lives on the http4s
-    // `Multipart` value itself, not the encoder. We build the http4s `Multipart` once and use it
-    // both for the entity body and to recover those headers, so the boundary on the encoded body
-    // and the boundary on the advertised `Content-Type` are guaranteed to match (issue #102).
+    // http4s' MultipartEncoder ships Headers.empty; the Content-Type/boundary live on the
+    // Multipart value itself. Build it once and use it for both `withEntity` and `putHeaders`
+    // so the body boundary and the advertised boundary can't diverge (issue #102).
     val withBody = ctx.body match {
       case Some(mp: BaklavaMultipart) =>
         val http4sMp = toHttp4sMultipart(mp)

--- a/http4s/src/main/scala/pl/iterators/baklava/http4s/BaklavaHttp4s.scala
+++ b/http4s/src/main/scala/pl/iterators/baklava/http4s/BaklavaHttp4s.scala
@@ -79,33 +79,39 @@ trait BaklavaHttp4s[TestFrameworkFragmentType, TestFrameworkFragmentsType, TestF
 
   implicit val urlFormSchema: Schema[UrlForm] = FreeFormSchema("UrlForm")
 
-  override implicit protected def multipartToRequestBodyType: BaklavaHttp4s.ToEntityMarshaller[BaklavaMultipart] =
-    implicitly[EntityEncoder[IO, org.http4s.multipart.Multipart[IO]]].contramap { baklavaMultipart =>
-      // `Vector[Http4sPart[IO]]` annotation: Scala 2.13 otherwise widens the match to `Part[Pure] | Part[IO]`.
-      val parts: Vector[Http4sPart[IO]] = baklavaMultipart.parts.toVector.map {
-        case FilePart(name, contentType, filename, bytes) =>
-          val ct = headers.`Content-Type`
-            .parse(contentType)
-            .toOption
-            .getOrElse(headers.`Content-Type`(MediaType.application.`octet-stream`))
-          val body = Stream.chunk(fs2.Chunk.array(bytes))
-          if (filename.isEmpty)
-            Http4sPart[IO](
-              Headers(
-                headers.`Content-Disposition`("form-data", Map(CIString("name") -> name)),
-                (headers.`Content-Transfer-Encoding`.Binary: headers.`Content-Transfer-Encoding`),
-                ct
-              ),
-              body
-            )
-          else
-            Http4sPart.fileData[IO](name, filename, body, ct)
-        case TextPart(name, value) =>
-          Http4sPart.formData[IO](name, value)
-      }
-      // Fixed boundary keeps the captured request body byte-stable across gold-test runs.
-      org.http4s.multipart.Multipart[IO](parts, Boundary("baklava-multipart-boundary"))
+  /** Build the http4s `Multipart` from the user-facing baklava `Multipart`. Extracted from the encoder so `baklavaContextToHttpRequest`
+    * can reuse it to recover the `Content-Type: multipart/form-data; boundary=…` header that http4s' `MultipartEncoder` leaves at
+    * `Headers.empty` (issue #102).
+    */
+  private def toHttp4sMultipart(baklavaMultipart: BaklavaMultipart): org.http4s.multipart.Multipart[IO] = {
+    // `Vector[Http4sPart[IO]]` annotation: Scala 2.13 otherwise widens the match to `Part[Pure] | Part[IO]`.
+    val parts: Vector[Http4sPart[IO]] = baklavaMultipart.parts.toVector.map {
+      case FilePart(name, contentType, filename, bytes) =>
+        val ct = headers.`Content-Type`
+          .parse(contentType)
+          .toOption
+          .getOrElse(headers.`Content-Type`(MediaType.application.`octet-stream`))
+        val body = Stream.chunk(fs2.Chunk.array(bytes))
+        if (filename.isEmpty)
+          Http4sPart[IO](
+            Headers(
+              headers.`Content-Disposition`("form-data", Map(CIString("name") -> name)),
+              (headers.`Content-Transfer-Encoding`.Binary: headers.`Content-Transfer-Encoding`),
+              ct
+            ),
+            body
+          )
+        else
+          Http4sPart.fileData[IO](name, filename, body, ct)
+      case TextPart(name, value) =>
+        Http4sPart.formData[IO](name, value)
     }
+    // Fixed boundary keeps the captured request body byte-stable across gold-test runs.
+    org.http4s.multipart.Multipart[IO](parts, Boundary("baklava-multipart-boundary"))
+  }
+
+  override implicit protected def multipartToRequestBodyType: BaklavaHttp4s.ToEntityMarshaller[BaklavaMultipart] =
+    implicitly[EntityEncoder[IO, org.http4s.multipart.Multipart[IO]]].contramap(toHttp4sMultipart)
 
   override implicit protected def emptyToResponseBodyType: BaklavaHttp4s.FromEntityUnmarshaller[EmptyBody] =
     EntityDecoder.void[IO].map(_ => EmptyBodyInstance)
@@ -210,7 +216,17 @@ trait BaklavaHttp4s[TestFrameworkFragmentType, TestFrameworkFragmentsType, TestF
       case Some(body) => base.withEntity(body)
       case None       => base
     }
-    parsedOverride.fold(withBody)(ct => withBody.withContentType(ct))
+    // http4s' `MultipartEncoder` ships `headers = Headers.empty` (long-standing TODO upstream),
+    // so `withEntity` for a multipart body produces a request without the
+    // `Content-Type: multipart/form-data; boundary=…` header. The header lives on the http4s
+    // `Multipart` value itself. Recover it here so http4s routes that decode `Multipart[IO]`
+    // accept the request (issue #102).
+    val withMultipartHeaders = ctx.body match {
+      case Some(mp: BaklavaMultipart) =>
+        withBody.putHeaders(toHttp4sMultipart(mp).headers)
+      case _ => withBody
+    }
+    parsedOverride.fold(withMultipartHeaders)(ct => withMultipartHeaders.withContentType(ct))
   }
 
   /** Find a `Content-Type` in the declared headers (case-insensitive) and return the parsed http4s `Content-Type`. Throws on either

--- a/openapi/src/test/scala/pl/iterators/baklava/openapi/Http4sMultipartContentTypeSpec.scala
+++ b/openapi/src/test/scala/pl/iterators/baklava/openapi/Http4sMultipartContentTypeSpec.scala
@@ -14,11 +14,8 @@ import sttp.model.{Header => SttpHeader, Method}
 
 import java.nio.charset.StandardCharsets
 
-/** Regression test for issue #102 on the http4s adapter. http4s' `MultipartEncoder` carries an empty header set, so a vanilla
-  * `withEntity(multipart)` produces a request with no `Content-Type: multipart/form-data; boundary=…`. The adapter has to recover those
-  * headers from the http4s `Multipart` value itself; otherwise routes decoding `Multipart[IO]` reject with
-  * `Missing boundary extension to Content-Type`.
-  */
+// Regression for issue #102: http4s' MultipartEncoder leaves Content-Type unset, so the adapter
+// has to recover it from the Multipart value itself.
 class Http4sMultipartContentTypeSpec
     extends AnyFunSpec
     with Matchers
@@ -45,8 +42,7 @@ class Http4sMultipartContentTypeSpec
     }
 
     it("still honors a declared Content-Type override") {
-      // If the user explicitly declares a Content-Type header, it wins over the encoder-derived
-      // one — preserving the existing override behavior from issue #52.
+      // Preserves issue #52 override behavior on top of the multipart fix.
       val ctx     = buildMultipartRequestContext(Seq(SttpHeader("Content-Type", "image/png")))
       val request = baklavaContextToHttpRequest(ctx)(multipartToRequestBodyType)
 
@@ -54,11 +50,7 @@ class Http4sMultipartContentTypeSpec
     }
 
     it("uses one Multipart value for both the body and the Content-Type so boundaries can't diverge") {
-      // Lock in the same-Multipart invariant: the boundary on the advertised Content-Type and
-      // the boundary marker inside the encoded body bytes must match. If a future refactor goes
-      // back to building the http4s Multipart twice (once for the entity, once for headers),
-      // a consumer override of `toHttp4sMultipart` could let the two diverge — this assertion
-      // catches that by reading the boundary parameter from the header and grepping the body.
+      // The boundary on the Content-Type and the boundary marker in the body bytes must match.
       val ctx     = buildMultipartRequestContext(Seq.empty)
       val request = baklavaContextToHttpRequest(ctx)(multipartToRequestBodyType)
 
@@ -72,9 +64,7 @@ class Http4sMultipartContentTypeSpec
     }
 
     it("produces a request that http4s' Multipart decoder accepts") {
-      // This is the exact failure mode reported in issue #102: an http4s route doing
-      // `entity(as[Multipart[IO]])` previously rejected the request with
-      // `Missing boundary extension to Content-Type`. After the fix, decoding succeeds.
+      // Reproduces the exact failure mode from issue #102.
       val ctx     = buildMultipartRequestContext(Seq.empty)
       val request = baklavaContextToHttpRequest(ctx)(multipartToRequestBodyType)
 
@@ -85,12 +75,10 @@ class Http4sMultipartContentTypeSpec
     }
 
     it("leaves the marshaller-provided Content-Type intact on non-multipart bodies") {
-      // Sanity check that the multipart-only branch does not affect ordinary bodies — they should
-      // get the Content-Type their EntityEncoder bakes in (here: text/plain from the String encoder).
       val ctx     = buildStringRequestContext(Seq.empty, "plain text")
       val request = baklavaContextToHttpRequest(ctx)(implicitly)
 
-      // Assert main type only — exact subtype/charset varies across http4s versions.
+      // Main type only — subtype/charset varies across http4s versions.
       request.contentType.map(_.mediaType.mainType) shouldBe Some("text")
     }
   }

--- a/openapi/src/test/scala/pl/iterators/baklava/openapi/Http4sMultipartContentTypeSpec.scala
+++ b/openapi/src/test/scala/pl/iterators/baklava/openapi/Http4sMultipartContentTypeSpec.scala
@@ -84,12 +84,13 @@ class Http4sMultipartContentTypeSpec
       decoded.parts.map(_.name).toList.flatten shouldBe List("photo", "caption")
     }
 
-    it("does not put a Content-Type on requests with a non-multipart body") {
-      // Sanity check that the multipart-only branch does not affect ordinary bodies.
+    it("leaves the marshaller-provided Content-Type intact on non-multipart bodies") {
+      // Sanity check that the multipart-only branch does not affect ordinary bodies — they should
+      // get the Content-Type their EntityEncoder bakes in (here: text/plain from the String encoder).
       val ctx     = buildStringRequestContext(Seq.empty, "plain text")
       val request = baklavaContextToHttpRequest(ctx)(implicitly)
 
-      // String EntityEncoder defaults to text/plain; assert main type, not exact subtype/charset.
+      // Assert main type only — exact subtype/charset varies across http4s versions.
       request.contentType.map(_.mediaType.mainType) shouldBe Some("text")
     }
   }

--- a/openapi/src/test/scala/pl/iterators/baklava/openapi/Http4sMultipartContentTypeSpec.scala
+++ b/openapi/src/test/scala/pl/iterators/baklava/openapi/Http4sMultipartContentTypeSpec.scala
@@ -1,0 +1,146 @@
+package pl.iterators.baklava.openapi
+
+import cats.effect.IO
+import cats.effect.unsafe.IORuntime
+import org.http4s.headers.`Content-Type`
+import org.http4s.multipart.{Multipart => Http4sMultipart}
+import org.http4s.{EntityDecoder, HttpRoutes, MediaType, Request, Response, Status}
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
+import pl.iterators.baklava.http4s.BaklavaHttp4s
+import pl.iterators.baklava.scalatest.{BaklavaScalatest, ScalatestAsExecution}
+import pl.iterators.baklava.{AppliedSecurity, BaklavaRequestContext, FilePart, Multipart => BaklavaMultipart, NoopSecurity, TextPart}
+import sttp.model.{Header => SttpHeader, Method}
+
+/** Regression test for issue #102 on the http4s adapter. http4s' `MultipartEncoder` carries an empty header set, so a vanilla
+  * `withEntity(multipart)` produces a request with no `Content-Type: multipart/form-data; boundary=…`. The adapter has to recover those
+  * headers from the http4s `Multipart` value itself; otherwise routes decoding `Multipart[IO]` reject with
+  * `Missing boundary extension to Content-Type`.
+  */
+class Http4sMultipartContentTypeSpec
+    extends AnyFunSpec
+    with Matchers
+    with BaklavaHttp4s[Unit, Unit, ScalatestAsExecution]
+    with BaklavaScalatest[HttpRoutes[IO], BaklavaHttp4s.ToEntityMarshaller, BaklavaHttp4s.FromEntityUnmarshaller] {
+
+  override implicit val runtime: IORuntime                                                = IORuntime.global
+  override def strictHeaderCheckDefault: Boolean                                          = false
+  override def performRequest(routes: HttpRoutes[IO], request: Request[IO]): Response[IO] =
+    Response[IO](status = Status.NoContent)
+
+  val routes: HttpRoutes[IO] = HttpRoutes.empty[IO]
+
+  describe("http4s adapter's baklavaContextToHttpRequest with a Multipart body (issue #102)") {
+
+    it("sets Content-Type: multipart/form-data with the boundary parameter") {
+      val ctx     = buildMultipartRequestContext(Seq.empty)
+      val request = baklavaContextToHttpRequest(ctx)(multipartToRequestBodyType)
+
+      val ct = request.contentType
+      ct.map(_.mediaType.mainType) shouldBe Some("multipart")
+      ct.map(_.mediaType.subType) shouldBe Some("form-data")
+      ct.flatMap(_.mediaType.extensions.get("boundary")) shouldBe Some("baklava-multipart-boundary")
+    }
+
+    it("still honors a declared Content-Type override") {
+      // If the user explicitly declares a Content-Type header, it wins over the encoder-derived
+      // one — preserving the existing override behavior from issue #52.
+      val ctx     = buildMultipartRequestContext(Seq(SttpHeader("Content-Type", "image/png")))
+      val request = baklavaContextToHttpRequest(ctx)(multipartToRequestBodyType)
+
+      request.contentType shouldBe Some(`Content-Type`(MediaType.image.png))
+    }
+
+    it("produces a request that http4s' Multipart decoder accepts") {
+      // This is the exact failure mode reported in issue #102: an http4s route doing
+      // `entity(as[Multipart[IO]])` previously rejected the request with
+      // `Missing boundary extension to Content-Type`. After the fix, decoding succeeds.
+      val ctx     = buildMultipartRequestContext(Seq.empty)
+      val request = baklavaContextToHttpRequest(ctx)(multipartToRequestBodyType)
+
+      val decoder: EntityDecoder[IO, Http4sMultipart[IO]] = EntityDecoder.multipart[IO]
+      val decoded                                         = request.as[Http4sMultipart[IO]](implicitly, decoder).unsafeRunSync()
+
+      decoded.parts.map(_.name).toList.flatten shouldBe List("photo", "caption")
+    }
+
+    it("does not put a Content-Type on requests with a non-multipart body") {
+      // Sanity check that the multipart-only branch does not affect ordinary bodies.
+      val ctx     = buildStringRequestContext(Seq.empty, "plain text")
+      val request = baklavaContextToHttpRequest(ctx)(implicitly)
+
+      // String EntityEncoder defaults to text/plain; assert main type, not exact subtype/charset.
+      request.contentType.map(_.mediaType.mainType) shouldBe Some("text")
+    }
+  }
+
+  private def buildMultipartRequestContext(
+      hs: Seq[SttpHeader]
+  ): BaklavaRequestContext[BaklavaMultipart, Unit, Unit, Unit, Unit, Unit, Unit] =
+    BaklavaRequestContext[BaklavaMultipart, Unit, Unit, Unit, Unit, Unit, Unit](
+      symbolicPath = "/upload",
+      path = "/upload",
+      pathDescription = None,
+      pathSummary = None,
+      method = Some(Method("POST")),
+      operationDescription = None,
+      operationSummary = None,
+      operationId = None,
+      operationTags = Seq.empty,
+      securitySchemes = Seq.empty,
+      body = Some(
+        BaklavaMultipart(
+          FilePart("photo", "image/png", "photo.png", "fake png bytes".getBytes("UTF-8")),
+          TextPart("caption", "profile photo")
+        )
+      ),
+      bodySchema = None,
+      headers = hs,
+      headersDefinition = (),
+      headersProvided = (),
+      headersSeq = Seq.empty,
+      security = AppliedSecurity(NoopSecurity, Map.empty),
+      pathParameters = (),
+      pathParametersProvided = (),
+      pathParametersSeq = Seq.empty,
+      queryParameters = (),
+      queryParametersProvided = (),
+      queryParametersSeq = Seq.empty,
+      responseDescription = None,
+      responseHeaders = Seq.empty
+    )
+
+  private def buildStringRequestContext(
+      hs: Seq[SttpHeader],
+      body: String
+  ): BaklavaRequestContext[String, Unit, Unit, Unit, Unit, Unit, Unit] =
+    BaklavaRequestContext[String, Unit, Unit, Unit, Unit, Unit, Unit](
+      symbolicPath = "/x",
+      path = "/x",
+      pathDescription = None,
+      pathSummary = None,
+      method = Some(Method("POST")),
+      operationDescription = None,
+      operationSummary = None,
+      operationId = None,
+      operationTags = Seq.empty,
+      securitySchemes = Seq.empty,
+      body = Some(body),
+      bodySchema = None,
+      headers = hs,
+      headersDefinition = (),
+      headersProvided = (),
+      headersSeq = Seq.empty,
+      security = AppliedSecurity(NoopSecurity, Map.empty),
+      pathParameters = (),
+      pathParametersProvided = (),
+      pathParametersSeq = Seq.empty,
+      queryParameters = (),
+      queryParametersProvided = (),
+      queryParametersSeq = Seq.empty,
+      responseDescription = None,
+      responseHeaders = Seq.empty
+    )
+
+  override def afterAll(): Unit = ()
+}

--- a/openapi/src/test/scala/pl/iterators/baklava/openapi/Http4sMultipartContentTypeSpec.scala
+++ b/openapi/src/test/scala/pl/iterators/baklava/openapi/Http4sMultipartContentTypeSpec.scala
@@ -12,6 +12,8 @@ import pl.iterators.baklava.scalatest.{BaklavaScalatest, ScalatestAsExecution}
 import pl.iterators.baklava.{AppliedSecurity, BaklavaRequestContext, FilePart, Multipart => BaklavaMultipart, NoopSecurity, TextPart}
 import sttp.model.{Header => SttpHeader, Method}
 
+import java.nio.charset.StandardCharsets
+
 /** Regression test for issue #102 on the http4s adapter. http4s' `MultipartEncoder` carries an empty header set, so a vanilla
   * `withEntity(multipart)` produces a request with no `Content-Type: multipart/form-data; boundary=…`. The adapter has to recover those
   * headers from the http4s `Multipart` value itself; otherwise routes decoding `Multipart[IO]` reject with
@@ -49,6 +51,24 @@ class Http4sMultipartContentTypeSpec
       val request = baklavaContextToHttpRequest(ctx)(multipartToRequestBodyType)
 
       request.contentType shouldBe Some(`Content-Type`(MediaType.image.png))
+    }
+
+    it("uses one Multipart value for both the body and the Content-Type so boundaries can't diverge") {
+      // Lock in the same-Multipart invariant: the boundary on the advertised Content-Type and
+      // the boundary marker inside the encoded body bytes must match. If a future refactor goes
+      // back to building the http4s Multipart twice (once for the entity, once for headers),
+      // a consumer override of `toHttp4sMultipart` could let the two diverge — this assertion
+      // catches that by reading the boundary parameter from the header and grepping the body.
+      val ctx     = buildMultipartRequestContext(Seq.empty)
+      val request = baklavaContextToHttpRequest(ctx)(multipartToRequestBodyType)
+
+      val advertisedBoundary = request.contentType
+        .flatMap(_.mediaType.extensions.get("boundary"))
+        .getOrElse(
+          fail("expected a boundary parameter on the Content-Type header")
+        )
+      val bodyString = new String(request.body.compile.toVector.unsafeRunSync().toArray, StandardCharsets.UTF_8)
+      bodyString should include(s"--$advertisedBoundary")
     }
 
     it("produces a request that http4s' Multipart decoder accepts") {
@@ -90,7 +110,7 @@ class Http4sMultipartContentTypeSpec
       securitySchemes = Seq.empty,
       body = Some(
         BaklavaMultipart(
-          FilePart("photo", "image/png", "photo.png", "fake png bytes".getBytes("UTF-8")),
+          FilePart("photo", "image/png", "photo.png", "fake png bytes".getBytes(StandardCharsets.UTF_8)),
           TextPart("caption", "profile photo")
         )
       ),

--- a/openapi/src/test/scala/pl/iterators/baklava/openapi/PekkoMultipartContentTypeSpec.scala
+++ b/openapi/src/test/scala/pl/iterators/baklava/openapi/PekkoMultipartContentTypeSpec.scala
@@ -18,11 +18,8 @@ import java.nio.charset.StandardCharsets
 import scala.concurrent.duration.Duration
 import scala.concurrent.{Await, ExecutionContext}
 
-/** Companion to `Http4sMultipartContentTypeSpec` (issue #102). Pekko's `Multipart.FormData.toEntity(boundary)` bakes
-  * `Content-Type: multipart/form-data; boundary=…` into the `MessageEntity` itself — unlike http4s, where the encoder leaves
-  * `Headers.empty` and the adapter has to recover the header. So pekko is NOT affected by #102. This spec locks that behavior in so a
-  * future marshaller change can't silently regress it.
-  */
+// Sibling to Http4sMultipartContentTypeSpec — pekko bakes Content-Type into the entity directly,
+// so it isn't affected by issue #102. This spec locks that in.
 class PekkoMultipartContentTypeSpec
     extends AnyFunSpec
     with Matchers
@@ -51,8 +48,6 @@ class PekkoMultipartContentTypeSpec
     }
 
     it("produces an entity that pekko's Multipart.FormData unmarshaller accepts") {
-      // Sibling to the http4s round-trip test — verifies that the resulting request can be parsed
-      // back into a multipart form by pekko's own unmarshaller.
       val ctx     = buildMultipartRequestContext(Seq.empty)
       val request = baklavaContextToHttpRequest(ctx)
 
@@ -68,7 +63,6 @@ class PekkoMultipartContentTypeSpec
     }
 
     it("still honors a declared Content-Type override") {
-      // Mirrors the http4s sibling: a declared Content-Type header on the test should win.
       val ctx     = buildMultipartRequestContext(Seq(SttpHeader("Content-Type", "image/png")))
       val request = baklavaContextToHttpRequest(ctx)
 

--- a/openapi/src/test/scala/pl/iterators/baklava/openapi/PekkoMultipartContentTypeSpec.scala
+++ b/openapi/src/test/scala/pl/iterators/baklava/openapi/PekkoMultipartContentTypeSpec.scala
@@ -1,0 +1,115 @@
+package pl.iterators.baklava.openapi
+
+import org.apache.pekko.actor.ActorSystem
+import org.apache.pekko.http.scaladsl.marshalling.ToEntityMarshaller
+import org.apache.pekko.http.scaladsl.model.MediaTypes
+import org.apache.pekko.http.scaladsl.model.{Multipart => PekkoMultipart}
+import org.apache.pekko.http.scaladsl.server.Route
+import org.apache.pekko.http.scaladsl.unmarshalling.{FromEntityUnmarshaller, Unmarshal}
+import org.apache.pekko.stream.Materializer
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
+import pl.iterators.baklava.pekkohttp.BaklavaPekkoHttp
+import pl.iterators.baklava.scalatest.{BaklavaScalatest, ScalatestAsExecution}
+import pl.iterators.baklava.{AppliedSecurity, BaklavaRequestContext, FilePart, Multipart => BaklavaMultipart, NoopSecurity, TextPart}
+import sttp.model.{Header => SttpHeader, Method}
+
+import scala.concurrent.duration.Duration
+import scala.concurrent.{Await, ExecutionContext}
+
+/** Companion to `Http4sMultipartContentTypeSpec` (issue #102). Pekko's `Multipart.FormData.toEntity(boundary)` bakes
+  * `Content-Type: multipart/form-data; boundary=…` into the `MessageEntity` itself — unlike http4s, where the encoder leaves
+  * `Headers.empty` and the adapter has to recover the header. So pekko is NOT affected by #102. This spec locks that behavior in so a
+  * future marshaller change can't silently regress it.
+  */
+class PekkoMultipartContentTypeSpec
+    extends AnyFunSpec
+    with Matchers
+    with BaklavaPekkoHttp[Unit, Unit, ScalatestAsExecution]
+    with BaklavaScalatest[Route, ToEntityMarshaller, FromEntityUnmarshaller] {
+
+  private implicit val system: ActorSystem        = ActorSystem("pekko-multipart-content-type")
+  implicit val executionContext: ExecutionContext = system.dispatcher
+  implicit val materializer: Materializer         = Materializer(system)
+
+  val routes: Route                                                              = Route.seal(_ => throw new UnsupportedOperationException)
+  override def strictHeaderCheckDefault: Boolean                                 = false
+  override def performRequest(routes: Route, request: HttpRequest): HttpResponse =
+    throw new UnsupportedOperationException("this spec only exercises request-building, not routing")
+
+  describe("pekko-http adapter's baklavaContextToHttpRequest with a Multipart body (issue #102 — sibling check)") {
+
+    it("sets Content-Type: multipart/form-data with the boundary parameter") {
+      val ctx     = buildMultipartRequestContext(Seq.empty)
+      val request = baklavaContextToHttpRequest(ctx)
+
+      val ct = request.entity.contentType
+      ct.mediaType.mainType shouldBe "multipart"
+      ct.mediaType.subType shouldBe "form-data"
+      ct.mediaType.params.get("boundary") shouldBe Some("baklava-multipart-boundary")
+    }
+
+    it("produces an entity that pekko's Multipart.FormData unmarshaller accepts") {
+      // Sibling to the http4s round-trip test — verifies that the resulting request can be parsed
+      // back into a multipart form by pekko's own unmarshaller.
+      val ctx     = buildMultipartRequestContext(Seq.empty)
+      val request = baklavaContextToHttpRequest(ctx)
+
+      val formData = Await.result(
+        Unmarshal(request.entity).to[PekkoMultipart.FormData],
+        Duration.Inf
+      )
+      val parts = Await.result(
+        formData.parts.runFold(List.empty[String])((acc, p) => acc :+ p.name),
+        Duration.Inf
+      )
+      parts shouldBe List("photo", "caption")
+    }
+
+    it("still honors a declared Content-Type override") {
+      // Mirrors the http4s sibling: a declared Content-Type header on the test should win.
+      val ctx     = buildMultipartRequestContext(Seq(SttpHeader("Content-Type", "image/png")))
+      val request = baklavaContextToHttpRequest(ctx)
+
+      request.entity.contentType.mediaType shouldBe MediaTypes.`image/png`
+    }
+  }
+
+  private def buildMultipartRequestContext(
+      hs: Seq[SttpHeader]
+  ): BaklavaRequestContext[BaklavaMultipart, Unit, Unit, Unit, Unit, Unit, Unit] =
+    BaklavaRequestContext[BaklavaMultipart, Unit, Unit, Unit, Unit, Unit, Unit](
+      symbolicPath = "/upload",
+      path = "/upload",
+      pathDescription = None,
+      pathSummary = None,
+      method = Some(Method("POST")),
+      operationDescription = None,
+      operationSummary = None,
+      operationId = None,
+      operationTags = Seq.empty,
+      securitySchemes = Seq.empty,
+      body = Some(
+        BaklavaMultipart(
+          FilePart("photo", "image/png", "photo.png", "fake png bytes".getBytes("UTF-8")),
+          TextPart("caption", "profile photo")
+        )
+      ),
+      bodySchema = None,
+      headers = hs,
+      headersDefinition = (),
+      headersProvided = (),
+      headersSeq = Seq.empty,
+      security = AppliedSecurity(NoopSecurity, Map.empty),
+      pathParameters = (),
+      pathParametersProvided = (),
+      pathParametersSeq = Seq.empty,
+      queryParameters = (),
+      queryParametersProvided = (),
+      queryParametersSeq = Seq.empty,
+      responseDescription = None,
+      responseHeaders = Seq.empty
+    )
+
+  override def afterAll(): Unit = { val _ = system.terminate() }
+}

--- a/openapi/src/test/scala/pl/iterators/baklava/openapi/PekkoMultipartContentTypeSpec.scala
+++ b/openapi/src/test/scala/pl/iterators/baklava/openapi/PekkoMultipartContentTypeSpec.scala
@@ -14,6 +14,7 @@ import pl.iterators.baklava.scalatest.{BaklavaScalatest, ScalatestAsExecution}
 import pl.iterators.baklava.{AppliedSecurity, BaklavaRequestContext, FilePart, Multipart => BaklavaMultipart, NoopSecurity, TextPart}
 import sttp.model.{Header => SttpHeader, Method}
 
+import java.nio.charset.StandardCharsets
 import scala.concurrent.duration.Duration
 import scala.concurrent.{Await, ExecutionContext}
 
@@ -91,7 +92,7 @@ class PekkoMultipartContentTypeSpec
       securitySchemes = Seq.empty,
       body = Some(
         BaklavaMultipart(
-          FilePart("photo", "image/png", "photo.png", "fake png bytes".getBytes("UTF-8")),
+          FilePart("photo", "image/png", "photo.png", "fake png bytes".getBytes(StandardCharsets.UTF_8)),
           TextPart("caption", "profile photo")
         )
       ),


### PR DESCRIPTION
Fixes #102.

## Summary
- http4s' `MultipartEncoder` ships `headers = Headers.empty` (long-standing upstream TODO), so `Request.withEntity(multipart)` produced a request without `Content-Type: multipart/form-data; boundary=…`. Routes decoding `Multipart[IO]` rejected with `Missing boundary extension to Content-Type`.
- Extract the baklava→http4s `Multipart` conversion into a `protected` `toHttp4sMultipart` helper, then in `baklavaContextToHttpRequest` build the http4s `Multipart` once for the multipart branch and use it for both `withEntity` and `putHeaders`. The boundary on the encoded body and the boundary on the advertised `Content-Type` are guaranteed to match. The existing declared-Content-Type override path (issue #52) still wins.
- Pekko-http is **not** affected — its `Multipart.FormData.toEntity(boundary)` bakes the Content-Type into the `MessageEntity` directly — but a sibling spec locks that behavior in.

## Behavior change for downstream customization
**`baklavaContextToHttpRequest` no longer uses the implicit `multipartToRequestBodyType` for request building** — it goes through `toHttp4sMultipart` directly, so the encoded body and the advertised `Content-Type` boundary stay in sync. To customize the multipart wire format (parts layout, headers, boundary), override `toHttp4sMultipart` (now `protected`) rather than `multipartToRequestBodyType` — overriding the implicit alone will not affect outgoing multipart requests. Both methods carry Scaladoc to this effect.

## Test plan
- [x] `Http4sMultipartContentTypeSpec` — Content-Type with boundary present, override still honored, non-multipart bodies untouched, plus a round-trip through `EntityDecoder.multipart[IO]` that reproduces the original failure mode.
- [x] Same-Multipart invariant: dedicated test reads the boundary off the Content-Type header and asserts it appears as a `--boundary` marker in the encoded body bytes — locks in the boundary-consistency invariant against future refactors.
- [x] `PekkoMultipartContentTypeSpec` — sibling check that pekko stays unaffected, including a `Multipart.FormData` unmarshal round-trip.
- [x] Full `openapi` suite passes on Scala 2.13 (112 tests, including `ComprehensiveGoldSpec` which exercises multipart end-to-end).
- [x] http4s + multipart specs pass on Scala 3 (3.3.7).

## Notes for downstream users
After this lands, the workaround from the issue (manually declaring `headers = "multipart/form-data; boundary=baklava-multipart-boundary"` on every multipart `onRequest`) can be removed.
