### PR TITLE
docs: bump version references to 1.3.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Baklava is a Scala library that turns your HTTP routing tests into API documenta
 **1. Add the SBT plugin** to `project/plugins.sbt`:
 
 ```scala
-addSbtPlugin("pl.iterators" % "baklava-sbt-plugin" % "1.3.0")
+addSbtPlugin("pl.iterators" % "baklava-sbt-plugin" % "1.3.1")
 ```
 
 **2. Enable the plugin** in `build.sbt`:
@@ -37,21 +37,21 @@ enablePlugins(BaklavaSbtPlugin)
 ```scala
 libraryDependencies ++= Seq(
   // HTTP server — choose one
-  "pl.iterators" %% "baklava-pekko-http" % "1.3.0" % Test,
-  // "pl.iterators" %% "baklava-http4s" % "1.3.0" % Test,
+  "pl.iterators" %% "baklava-pekko-http" % "1.3.1" % Test,
+  // "pl.iterators" %% "baklava-http4s" % "1.3.1" % Test,
 
   // Test framework — choose one
-  "pl.iterators" %% "baklava-scalatest"  % "1.3.0" % Test,
-  // "pl.iterators" %% "baklava-specs2"  % "1.3.0" % Test,
-  // "pl.iterators" %% "baklava-munit"   % "1.3.0" % Test,
+  "pl.iterators" %% "baklava-scalatest"  % "1.3.1" % Test,
+  // "pl.iterators" %% "baklava-specs2"  % "1.3.1" % Test,
+  // "pl.iterators" %% "baklava-munit"   % "1.3.1" % Test,
 
   // Output format — one or more
-  "pl.iterators" %% "baklava-openapi"    % "1.3.0" % Test,
-  "pl.iterators" %% "baklava-simple"     % "1.3.0" % Test,
-  // "pl.iterators" %% "baklava-tsrest"    % "1.3.0" % Test,
-  // "pl.iterators" %% "baklava-tsfetch"   % "1.3.0" % Test,
-  // "pl.iterators" %% "baklava-postman"   % "1.3.0" % Test,
-  // "pl.iterators" %% "baklava-sttpclient" % "1.3.0" % Test,
+  "pl.iterators" %% "baklava-openapi"    % "1.3.1" % Test,
+  "pl.iterators" %% "baklava-simple"     % "1.3.1" % Test,
+  // "pl.iterators" %% "baklava-tsrest"    % "1.3.1" % Test,
+  // "pl.iterators" %% "baklava-tsfetch"   % "1.3.1" % Test,
+  // "pl.iterators" %% "baklava-postman"   % "1.3.1" % Test,
+  // "pl.iterators" %% "baklava-sttpclient" % "1.3.1" % Test,
 )
 ```
 

--- a/docs/dsl-reference.md
+++ b/docs/dsl-reference.md
@@ -108,7 +108,7 @@ path(
 
 ## Root Element: `path`
 
-The [`path()`](https://github.com/theiterators/baklava/blob/v1.3.0/core/src/main/scala/pl/iterators/baklava/BaklavaTestFrameworkDsl.scala#L21) function is the root element of the DSL tree. It defines an API endpoint path and contains one or more HTTP method definitions.
+The [`path()`](https://github.com/theiterators/baklava/blob/v1.3.1/core/src/main/scala/pl/iterators/baklava/BaklavaTestFrameworkDsl.scala#L21) function is the root element of the DSL tree. It defines an API endpoint path and contains one or more HTTP method definitions.
 
 ### Signature
 
@@ -129,7 +129,7 @@ def path(
 | `path` | `String` | Yes | The URL path pattern, supporting path parameters in `{paramName}` format (e.g., `/users/{userId}`) |
 | `description` | `String` | No | Detailed description of the path and its purpose |
 | `summary` | `String` | No | Brief summary of the path |
-| `steps` | `BaklavaMethodDefinition*` | Yes | One or more [`supports()`](https://github.com/theiterators/baklava/blob/v1.3.0/core/src/main/scala/pl/iterators/baklava/BaklavaTestFrameworkDsl.scala#L63) definitions for HTTP methods |
+| `steps` | `BaklavaMethodDefinition*` | Yes | One or more [`supports()`](https://github.com/theiterators/baklava/blob/v1.3.1/core/src/main/scala/pl/iterators/baklava/BaklavaTestFrameworkDsl.scala#L63) definitions for HTTP methods |
 
 ### Example
 
@@ -147,7 +147,7 @@ path(
 
 ## HTTP Method Element: `supports`
 
-The [`supports()`](https://github.com/theiterators/baklava/blob/v1.3.0/core/src/main/scala/pl/iterators/baklava/BaklavaTestFrameworkDsl.scala#L63) function defines an HTTP method operation on a path. It specifies the method, parameters, security, and contains test cases.
+The [`supports()`](https://github.com/theiterators/baklava/blob/v1.3.1/core/src/main/scala/pl/iterators/baklava/BaklavaTestFrameworkDsl.scala#L63) function defines an HTTP method operation on a path. It specifies the method, parameters, security, and contains test cases.
 
 ### Signature
 
@@ -207,7 +207,7 @@ supports(
 
 ## Test Case Element: `onRequest`
 
-The [`onRequest()`](https://github.com/theiterators/baklava/blob/v1.3.0/core/src/main/scala/pl/iterators/baklava/BaklavaTestFrameworkDsl.scala#L377) function defines a specific test case for an HTTP operation. It specifies the request parameters and must be followed by [`respondsWith()`](#response-definition-respondswith) and [`assert()`](#assertion-block-assert).
+The [`onRequest()`](https://github.com/theiterators/baklava/blob/v1.3.1/core/src/main/scala/pl/iterators/baklava/BaklavaTestFrameworkDsl.scala#L377) function defines a specific test case for an HTTP operation. It specifies the request parameters and must be followed by [`respondsWith()`](#response-definition-respondswith) and [`assert()`](#assertion-block-assert).
 
 ### Signature
 
@@ -245,7 +245,7 @@ onRequest(
 
 ## Response Definition: `respondsWith`
 
-The [`respondsWith()`](https://github.com/theiterators/baklava/blob/v1.3.0/core/src/main/scala/pl/iterators/baklava/BaklavaTestFrameworkDsl.scala#L152) method defines the expected HTTP response for a test case.
+The [`respondsWith()`](https://github.com/theiterators/baklava/blob/v1.3.1/core/src/main/scala/pl/iterators/baklava/BaklavaTestFrameworkDsl.scala#L152) method defines the expected HTTP response for a test case.
 
 ### Signature
 
@@ -287,7 +287,7 @@ def respondsWith[ResponseBody](
 
 ## Assertion Block: `assert`
 
-The [`assert()`](https://github.com/theiterators/baklava/blob/v1.3.0/core/src/main/scala/pl/iterators/baklava/BaklavaTestFrameworkDsl.scala#L123) method contains the test framework-specific assertions. It receives a context object that provides access to the request/response.
+The [`assert()`](https://github.com/theiterators/baklava/blob/v1.3.1/core/src/main/scala/pl/iterators/baklava/BaklavaTestFrameworkDsl.scala#L123) method contains the test framework-specific assertions. It receives a context object that provides access to the request/response.
 
 ### Signature
 
@@ -299,7 +299,7 @@ def assert[R](
 
 ### Context Object
 
-The assertion block receives a [`BaklavaCaseContext`](https://github.com/theiterators/baklava/blob/v1.3.0/core/src/main/scala/pl/iterators/baklava/BaklavaHttpDsl.scala#L110) with:
+The assertion block receives a [`BaklavaCaseContext`](https://github.com/theiterators/baklava/blob/v1.3.1/core/src/main/scala/pl/iterators/baklava/BaklavaHttpDsl.scala#L110) with:
 
 - `ctx`: The request context containing all request parameters
 - `performRequest(route)`: Method to execute the HTTP request against your routes
@@ -403,7 +403,7 @@ withSetup {
 
 ### Path Parameters
 
-Path parameters are defined using the [`p[T]()`](https://github.com/theiterators/baklava/blob/v1.3.0/core/src/main/scala/pl/iterators/baklava/BaklavaPathParams.scala#L27) function and represent dynamic segments in the URL path.
+Path parameters are defined using the [`p[T]()`](https://github.com/theiterators/baklava/blob/v1.3.1/core/src/main/scala/pl/iterators/baklava/BaklavaPathParams.scala#L27) function and represent dynamic segments in the URL path.
 
 #### Signature
 
@@ -439,7 +439,7 @@ onRequest(pathParameters = ("org-123", 456L))
 
 ### Query Parameters
 
-Query parameters are defined using the [`q[T]()`](https://github.com/theiterators/baklava/blob/v1.3.0/core/src/main/scala/pl/iterators/baklava/BaklavaQueryParams.scala#L24) function and represent URL query string parameters.
+Query parameters are defined using the [`q[T]()`](https://github.com/theiterators/baklava/blob/v1.3.1/core/src/main/scala/pl/iterators/baklava/BaklavaQueryParams.scala#L24) function and represent URL query string parameters.
 
 #### Signature
 
@@ -480,7 +480,7 @@ onRequest(queryParameters = (Seq("scala", "api")))
 
 ### Headers
 
-Headers are defined using the [`h[T]()`](https://github.com/theiterators/baklava/blob/v1.3.0/core/src/main/scala/pl/iterators/baklava/BaklavaHeaders.scala#L26) function and represent HTTP headers.
+Headers are defined using the [`h[T]()`](https://github.com/theiterators/baklava/blob/v1.3.1/core/src/main/scala/pl/iterators/baklava/BaklavaHeaders.scala#L26) function and represent HTTP headers.
 
 #### Signature
 
@@ -530,7 +530,7 @@ onRequest(
 
 ### Form Data
 
-Use [`FormOf[T]`](https://github.com/theiterators/baklava/blob/v1.3.0/core/src/main/scala/pl/iterators/baklava/BaklavaHttpDsl.scala#L17) for `application/x-www-form-urlencoded` data:
+Use [`FormOf[T]`](https://github.com/theiterators/baklava/blob/v1.3.1/core/src/main/scala/pl/iterators/baklava/BaklavaHttpDsl.scala#L17) for `application/x-www-form-urlencoded` data:
 
 ```scala
 case class LoginForm(username: String, password: String)
@@ -618,18 +618,18 @@ onRequest(
 
 ### Available Security Types
 
-All security types are defined in [`Security.scala`](https://github.com/theiterators/baklava/blob/v1.3.0/core/src/main/scala/pl/iterators/baklava/Security.scala#L1):
+All security types are defined in [`Security.scala`](https://github.com/theiterators/baklava/blob/v1.3.1/core/src/main/scala/pl/iterators/baklava/Security.scala#L1):
 
-- [`HttpBearer`](https://github.com/theiterators/baklava/blob/v1.3.0/core/src/main/scala/pl/iterators/baklava/Security.scala#L20): Bearer token authentication
-- [`HttpBasic`](https://github.com/theiterators/baklava/blob/v1.3.0/core/src/main/scala/pl/iterators/baklava/Security.scala#L27): Basic authentication
-- [`ApiKeyInHeader`](https://github.com/theiterators/baklava/blob/v1.3.0/core/src/main/scala/pl/iterators/baklava/Security.scala#L36): API key in header
-- [`ApiKeyInQuery`](https://github.com/theiterators/baklava/blob/v1.3.0/core/src/main/scala/pl/iterators/baklava/Security.scala#L42): API key in query parameter
-- [`ApiKeyInCookie`](https://github.com/theiterators/baklava/blob/v1.3.0/core/src/main/scala/pl/iterators/baklava/Security.scala#L48): API key in cookie
-- [`MutualTls`](https://github.com/theiterators/baklava/blob/v1.3.0/core/src/main/scala/pl/iterators/baklava/Security.scala#L54): Mutual TLS authentication
-- [`OpenIdConnectInBearer`](https://github.com/theiterators/baklava/blob/v1.3.0/core/src/main/scala/pl/iterators/baklava/Security.scala#L60): OpenID Connect in bearer token
-- [`OpenIdConnectInCookie`](https://github.com/theiterators/baklava/blob/v1.3.0/core/src/main/scala/pl/iterators/baklava/Security.scala#L66): OpenID Connect in cookie
-- [`OAuth2InBearer`](https://github.com/theiterators/baklava/blob/v1.3.0/core/src/main/scala/pl/iterators/baklava/Security.scala#L72): OAuth2 in bearer token
-- [`OAuth2InCookie`](https://github.com/theiterators/baklava/blob/v1.3.0/core/src/main/scala/pl/iterators/baklava/Security.scala#L78): OAuth2 in cookie
+- [`HttpBearer`](https://github.com/theiterators/baklava/blob/v1.3.1/core/src/main/scala/pl/iterators/baklava/Security.scala#L20): Bearer token authentication
+- [`HttpBasic`](https://github.com/theiterators/baklava/blob/v1.3.1/core/src/main/scala/pl/iterators/baklava/Security.scala#L27): Basic authentication
+- [`ApiKeyInHeader`](https://github.com/theiterators/baklava/blob/v1.3.1/core/src/main/scala/pl/iterators/baklava/Security.scala#L36): API key in header
+- [`ApiKeyInQuery`](https://github.com/theiterators/baklava/blob/v1.3.1/core/src/main/scala/pl/iterators/baklava/Security.scala#L42): API key in query parameter
+- [`ApiKeyInCookie`](https://github.com/theiterators/baklava/blob/v1.3.1/core/src/main/scala/pl/iterators/baklava/Security.scala#L48): API key in cookie
+- [`MutualTls`](https://github.com/theiterators/baklava/blob/v1.3.1/core/src/main/scala/pl/iterators/baklava/Security.scala#L54): Mutual TLS authentication
+- [`OpenIdConnectInBearer`](https://github.com/theiterators/baklava/blob/v1.3.1/core/src/main/scala/pl/iterators/baklava/Security.scala#L60): OpenID Connect in bearer token
+- [`OpenIdConnectInCookie`](https://github.com/theiterators/baklava/blob/v1.3.1/core/src/main/scala/pl/iterators/baklava/Security.scala#L66): OpenID Connect in cookie
+- [`OAuth2InBearer`](https://github.com/theiterators/baklava/blob/v1.3.1/core/src/main/scala/pl/iterators/baklava/Security.scala#L72): OAuth2 in bearer token
+- [`OAuth2InCookie`](https://github.com/theiterators/baklava/blob/v1.3.1/core/src/main/scala/pl/iterators/baklava/Security.scala#L78): OAuth2 in cookie
 
 #### OAuth2 Flows
 
@@ -687,7 +687,7 @@ Common status codes available:
 
 ## Schema System
 
-Baklava uses a [`Schema[T]`](https://github.com/theiterators/baklava/blob/v1.3.0/core/src/main/scala/pl/iterators/baklava/Schema.scala#L20) type class to describe data types for documentation generation. Schemas are automatically derived via [Magnolia](https://github.com/softwaremill/magnolia) for:
+Baklava uses a [`Schema[T]`](https://github.com/theiterators/baklava/blob/v1.3.1/core/src/main/scala/pl/iterators/baklava/Schema.scala#L20) type class to describe data types for documentation generation. Schemas are automatically derived via [Magnolia](https://github.com/softwaremill/magnolia) for:
 
 - Primitive types (`String`, `Int`, `Long`, `Double`, `Boolean`, `UUID`, `BigDecimal`, etc.)
 - Collections (`Seq`, `List`, `Set`, `Map`)


### PR DESCRIPTION
## Summary
- Bump baklava version references in README.md (12 occurrences) and docs/dsl-reference.md (23 GitHub blob URLs) from 1.3.0 → 1.3.1, now that v1.3.1 is published to Maven Central.
- \`build.sbt\`'s \`pekkoHttpV = "1.3.0"\` is unrelated (pekko-http library version) and intentionally left alone.

Follows the convention from #95 and #100.

## Test plan
- [x] \`grep -rn '1\.3\.0\|v1\.3\.0'\` repo-wide returns no remaining baklava-version refs in docs.