### PR TITLE
fix(tsrest): quote non-identifier param keys (#105) and project multipart request bodies (#106)

### DIFF
--- a/core/src/main/scala/pl/iterators/baklava/BaklavaSerialize.scala
+++ b/core/src/main/scala/pl/iterators/baklava/BaklavaSerialize.scala
@@ -210,6 +210,10 @@ object BaklavaQueryParamSerializable {
     BaklavaQueryParamSerializable(h.name, h.description, BaklavaSchemaSerializable(h.schema), example)
 }
 
+// A single part of a `multipart/form-data` request body, captured so generators can name the form
+// fields. `isFile` distinguishes `FilePart` (binary upload) from `TextPart` (plain form field).
+case class BaklavaMultipartPartSerializable(name: String, isFile: Boolean) extends Serializable
+
 case class BaklavaRequestContextSerializable(
     symbolicPath: String,
     path: String,
@@ -227,7 +231,9 @@ case class BaklavaRequestContextSerializable(
     pathParametersSeq: Seq[BaklavaPathParamSerializable],
     queryParametersSeq: Seq[BaklavaQueryParamSerializable],
     responseDescription: Option[String],
-    responseHeaders: Seq[BaklavaHeaderSerializable]
+    responseHeaders: Seq[BaklavaHeaderSerializable],
+    // `Some(parts)` iff the request body was a `Multipart` (even an empty one); `None` otherwise.
+    multipartFormData: Option[Seq[BaklavaMultipartPartSerializable]] = None
 ) extends Serializable
 
 object BaklavaRequestContextSerializable {
@@ -261,7 +267,13 @@ object BaklavaRequestContextSerializable {
         BaklavaQueryParamSerializable(p, queryParamValues.get(p.name))
       },
       responseDescription = c.responseDescription,
-      responseHeaders = c.responseHeaders.map(h => BaklavaHeaderSerializable(h))
+      responseHeaders = c.responseHeaders.map(h => BaklavaHeaderSerializable(h)),
+      multipartFormData = c.body.collect { case mp: Multipart =>
+        mp.parts.toSeq.map {
+          case p: FilePart => BaklavaMultipartPartSerializable(p.name, isFile = true)
+          case t: TextPart => BaklavaMultipartPartSerializable(t.name, isFile = false)
+        }
+      }
     )
   }
 

--- a/docs/output-formats.md
+++ b/docs/output-formats.md
@@ -142,7 +142,7 @@ When multiple test cases produce different schemas for the same endpoint input/o
 
 Object keys that aren't valid JavaScript identifiers (e.g. kebab-case query/header parameters like `seller-id` or `X-Forwarded-For`) are emitted quoted so the generated source compiles.
 
-`multipart/form-data` request bodies (a `Multipart(...)` body in the test) are emitted as `contentType: 'multipart/form-data'` plus a `z.object({...})` naming each captured form part — `FilePart`s become `z.instanceof(File)` and `TextPart`s become `z.string()`. (`z.instanceof(File)` references the global `File` constructor; it's available in browsers and Node ≥ 20.)
+`multipart/form-data` request bodies (a `Multipart(...)` body in the test) are emitted as `contentType: 'multipart/form-data'` plus a `z.object({...})` naming each captured form part — `FilePart`s become `z.instanceof(File)`, `TextPart`s become `z.string()`, and a part name that appears more than once (a multi-value field) becomes a `z.array(...)`. Distinct part-sets recorded across calls for the same endpoint are combined into a `z.union([...])`, like any other body shape. (`z.instanceof(File)` references the global `File` constructor; it's available in browsers and Node ≥ 20.)
 
 ### Configuration
 

--- a/docs/output-formats.md
+++ b/docs/output-formats.md
@@ -140,6 +140,10 @@ Baklava schemas are converted to Zod validators:
 
 When multiple test cases produce different schemas for the same endpoint input/output, they are combined into `z.union([...])`.
 
+Object keys that aren't valid JavaScript identifiers (e.g. kebab-case query/header parameters like `seller-id` or `X-Forwarded-For`) are emitted quoted so the generated source compiles.
+
+`multipart/form-data` request bodies (a `Multipart(...)` body in the test) are emitted as `contentType: 'multipart/form-data'` plus a `z.object({...})` naming each captured form part — `FilePart`s become `z.instanceof(File)` and `TextPart`s become `z.string()`. (`z.instanceof(File)` references the global `File` constructor; it's available in browsers and Node ≥ 20.)
+
 ### Configuration
 
 ```scala

--- a/openapi/src/test/resources/gold/tsrest/src/users---userId-photo.contract.ts
+++ b/openapi/src/test/resources/gold/tsrest/src/users---userId-photo.contract.ts
@@ -8,7 +8,8 @@ export const usersUserIdPhotoContract = initContract().router({
     method: 'POST',
     path: '/users/:userId/photo',
     pathParams: z.object({userId: z.string().uuid()}),
-    body: z.object({}),
+    contentType: 'multipart/form-data',
+    body: z.object({caption: z.string(), photo: z.instanceof(File)}),
     responses: {
       204: z.undefined()
     }

--- a/tsrest/src/main/scala/pl/iterators/baklava/tsrest/BaklavaDslFormatterTsRest.scala
+++ b/tsrest/src/main/scala/pl/iterators/baklava/tsrest/BaklavaDslFormatterTsRest.scala
@@ -214,7 +214,7 @@ class BaklavaDslFormatterTsRest extends BaklavaDslFormatter {
       .distinct
       .sortBy { parts =>
         val names = parts.map(_.name).distinct
-        (-names.size, names.sorted.mkString(" "))
+        (-names.size, names.sorted.mkString(","))
       }
     val (contentTypeLineOpt, bodyZod) =
       if (multipartPartSets.nonEmpty)

--- a/tsrest/src/main/scala/pl/iterators/baklava/tsrest/BaklavaDslFormatterTsRest.scala
+++ b/tsrest/src/main/scala/pl/iterators/baklava/tsrest/BaklavaDslFormatterTsRest.scala
@@ -83,25 +83,42 @@ class BaklavaDslFormatterTsRest extends BaklavaDslFormatter {
   private def writeTo(path: String, content: String): Unit =
     Using.resource(new PrintWriter(new FileWriter(path)))(_.write(content))
 
-  private def buildParamsZod[P](
+  private[tsrest] def buildParamsZod[P](
       paramsPerCall: Seq[Seq[P]],
       nameOf: P => String,
-      schemaOf: P => BaklavaSchemaSerializable,
-      quoteKeys: Boolean
+      schemaOf: P => BaklavaSchemaSerializable
   ): Option[String] = {
     val distinctSets = paramsPerCall.distinct
     if (!distinctSets.exists(_.nonEmpty)) None
     else {
       val zds = distinctSets.map { params =>
         val fields = params.map { p =>
-          val key          = if (quoteKeys) s""""${escapeTsDoubleQuoted(nameOf(p))}"""" else nameOf(p)
           val nullishMaybe = if (!schemaOf(p).required) ".nullish()" else ""
-          s"$key: ${zod(schemaOf(p))}$nullishMaybe"
+          s"${tsObjectKey(nameOf(p))}: ${zod(schemaOf(p))}$nullishMaybe"
         }
         "z.object({" + fields.mkString(", ") + "})"
       }
       Some(collapseZodUnion(zds))
     }
+  }
+
+  // An object key may be written bare only if it's a valid JS identifier; query/header/path-param
+  // names can be kebab-case (`seller-id`, `X-Forwarded-For`) or start with a digit, which would
+  // otherwise produce uncompilable TypeScript — so quote anything that isn't identifier-shaped.
+  private[tsrest] def tsObjectKey(name: String): String =
+    if (name.matches("[A-Za-z_$][A-Za-z0-9_$]*")) name
+    else s""""${escapeTsDoubleQuoted(name)}""""
+
+  // ts-rest renders multipart bodies as a `z.object({...})` of named parts (see
+  // https://ts-rest.com/docs/core/multi-part). The captured `Multipart` value carries part names +
+  // a file/text flag, so `FilePart`s become `z.instanceof(File)` and `TextPart`s `z.string()`.
+  // Sorted for deterministic output.
+  private[tsrest] def renderMultipartBody(parts: Seq[BaklavaMultipartPartSerializable]): String = {
+    val fields = parts
+      .distinctBy(_.name)
+      .sortBy(_.name)
+      .map(p => s"${tsObjectKey(p.name)}: ${if (p.isFile) "z.instanceof(File)" else "z.string()"}")
+    s"z.object({${fields.mkString(", ")}})"
   }
 
   /** Convert a Baklava `{name}` placeholder path to the ts-rest `:name` syntax. Non-placeholder braces (i.e. anything containing `/` or
@@ -165,31 +182,36 @@ class BaklavaDslFormatterTsRest extends BaklavaDslFormatter {
     val pathParamsZodOpt = buildParamsZod(
       calls.map(_.request.pathParametersSeq),
       (p: BaklavaPathParamSerializable) => p.name,
-      (p: BaklavaPathParamSerializable) => p.schema,
-      quoteKeys = false
+      (p: BaklavaPathParamSerializable) => p.schema
     )
     val queryParamsZodOpt = buildParamsZod(
       calls.map(_.request.queryParametersSeq),
       (p: BaklavaQueryParamSerializable) => p.name,
-      (p: BaklavaQueryParamSerializable) => p.schema,
-      quoteKeys = false
+      (p: BaklavaQueryParamSerializable) => p.schema
     )
     val headersZodOpt = buildParamsZod(
       calls.map(_.request.headersSeq),
       (h: BaklavaHeaderSerializable) => h.name,
-      (h: BaklavaHeaderSerializable) => h.schema,
-      quoteKeys = true
+      (h: BaklavaHeaderSerializable) => h.schema
     )
     // --- Body ---
-    val bodySchemas = calls.flatMap(_.request.bodySchema).distinct
-    val bodyZods    =
-      if (bodySchemas.isEmpty) Seq("z.undefined()")
-      else if (bodySchemas.size == 1 && isEmptyBodyInstance(bodySchemas.head)) Seq("z.undefined()")
+    // A `multipart/form-data` body has a free-form schema, so it can't be projected through `zod`;
+    // instead emit `contentType: 'multipart/form-data'` plus a `z.object` of the captured part names.
+    val multipartParts                = calls.flatMap(_.request.multipartFormData).flatten
+    val isMultipartBody               = calls.exists(_.request.multipartFormData.isDefined)
+    val (contentTypeLineOpt, bodyZod) =
+      if (isMultipartBody) (Some("    contentType: 'multipart/form-data',"), renderMultipartBody(multipartParts))
       else {
-        val notEmptyBodies = bodySchemas.filterNot(isEmptyBodyInstance)
-        if (notEmptyBodies.isEmpty) Seq("z.undefined()") else notEmptyBodies.map(zod)
+        val bodySchemas = calls.flatMap(_.request.bodySchema).distinct
+        val bodyZods    =
+          if (bodySchemas.isEmpty) Seq("z.undefined()")
+          else if (bodySchemas.size == 1 && isEmptyBodyInstance(bodySchemas.head)) Seq("z.undefined()")
+          else {
+            val notEmptyBodies = bodySchemas.filterNot(isEmptyBodyInstance)
+            if (notEmptyBodies.isEmpty) Seq("z.undefined()") else notEmptyBodies.map(zod)
+          }
+        (None, collapseZodUnion(bodyZods))
       }
-    val bodyZod = collapseZodUnion(bodyZods)
 
     // --- Responses ---
     val responses = calls
@@ -217,7 +239,8 @@ class BaklavaDslFormatterTsRest extends BaklavaDslFormatter {
     ).++(pathParamsZodOpt.toList.map(z => s"    pathParams: $z,"))
       .++(queryParamsZodOpt.toList.map(z => s"    query: $z,"))
       .++(headersZodOpt.toList.map(z => s"    headers: $z,"))
-      .++(bodyLine.toList)
+      // `contentType` only makes sense alongside `body`, so emit them as one block (or neither).
+      .++(bodyLine.toList.flatMap(line => contentTypeLineOpt.toList :+ line))
       .++(
         List(
           s"    responses: {",

--- a/tsrest/src/main/scala/pl/iterators/baklava/tsrest/BaklavaDslFormatterTsRest.scala
+++ b/tsrest/src/main/scala/pl/iterators/baklava/tsrest/BaklavaDslFormatterTsRest.scala
@@ -109,15 +109,21 @@ class BaklavaDslFormatterTsRest extends BaklavaDslFormatter {
     if (name.matches("[A-Za-z_$][A-Za-z0-9_$]*")) name
     else s""""${escapeTsDoubleQuoted(name)}""""
 
-  // ts-rest renders multipart bodies as a `z.object({...})` of named parts (see
-  // https://ts-rest.com/docs/core/multi-part). The captured `Multipart` value carries part names +
-  // a file/text flag, so `FilePart`s become `z.instanceof(File)` and `TextPart`s `z.string()`.
-  // Sorted for deterministic output.
+  // Render one captured `Multipart` value as a ts-rest body schema (see
+  // https://ts-rest.com/docs/core/multi-part): a `z.object` keyed by part name, `FilePart` ->
+  // `z.instanceof(File)`, `TextPart` -> `z.string()`. A repeated part name (a multi-value form
+  // field) becomes a `z.array(...)`; a name that mixes file and text parts unions the element
+  // schemas. Names and element schemas are sorted so output is deterministic.
   private[tsrest] def renderMultipartBody(parts: Seq[BaklavaMultipartPartSerializable]): String = {
     val fields = parts
-      .distinctBy(_.name)
-      .sortBy(_.name)
-      .map(p => s"${tsObjectKey(p.name)}: ${if (p.isFile) "z.instanceof(File)" else "z.string()"}")
+      .groupBy(_.name)
+      .toSeq
+      .sortBy(_._1)
+      .map { case (name, ps) =>
+        val element = collapseZodUnion(ps.map(p => if (p.isFile) "z.instanceof(File)" else "z.string()").sorted)
+        val schema  = if (ps.size > 1) s"z.array($element)" else element
+        s"${tsObjectKey(name)}: $schema"
+      }
     s"z.object({${fields.mkString(", ")}})"
   }
 
@@ -196,11 +202,13 @@ class BaklavaDslFormatterTsRest extends BaklavaDslFormatter {
     )
     // --- Body ---
     // A `multipart/form-data` body has a free-form schema, so it can't be projected through `zod`;
-    // instead emit `contentType: 'multipart/form-data'` plus a `z.object` of the captured part names.
-    val multipartParts                = calls.flatMap(_.request.multipartFormData).flatten
-    val isMultipartBody               = calls.exists(_.request.multipartFormData.isDefined)
+    // instead emit `contentType: 'multipart/form-data'` plus a `z.object` of the captured part
+    // names. Each call's part-set is rendered separately and combined into a `z.union`, mirroring
+    // how distinct non-multipart body shapes are handled.
+    val multipartPartSets             = calls.flatMap(_.request.multipartFormData).distinct
     val (contentTypeLineOpt, bodyZod) =
-      if (isMultipartBody) (Some("    contentType: 'multipart/form-data',"), renderMultipartBody(multipartParts))
+      if (multipartPartSets.nonEmpty)
+        (Some("    contentType: 'multipart/form-data',"), collapseZodUnion(multipartPartSets.map(renderMultipartBody)))
       else {
         val bodySchemas = calls.flatMap(_.request.bodySchema).distinct
         val bodyZods    =

--- a/tsrest/src/main/scala/pl/iterators/baklava/tsrest/BaklavaDslFormatterTsRest.scala
+++ b/tsrest/src/main/scala/pl/iterators/baklava/tsrest/BaklavaDslFormatterTsRest.scala
@@ -204,14 +204,21 @@ class BaklavaDslFormatterTsRest extends BaklavaDslFormatter {
     // A `multipart/form-data` body has a free-form schema, so it can't be projected through `zod`;
     // instead emit `contentType: 'multipart/form-data'` plus a `z.object` of the captured part
     // names. Each call's part-set is rendered separately and combined into a `z.union`, mirroring
-    // how distinct non-multipart body shapes are handled. The variants are sorted before unioning so
-    // a shape with more required fields is tried before a more-permissive shape that would also
-    // accept it (`z.object({})` sorts last) — otherwise Zod's non-strict `z.object` would match the
-    // narrower branch first and silently strip the extra fields.
-    val multipartPartSets             = calls.flatMap(_.request.multipartFormData).distinct
+    // how distinct non-multipart body shapes are handled. Variants are ordered by descending
+    // field count (sorted part names as a stable tiebreaker, so `z.object({})` lands last) before
+    // unioning: a shape with more required fields must be tried before a more-permissive one that
+    // would also accept it, otherwise Zod's non-strict `z.object` matches the narrower branch first
+    // and silently strips the extra fields.
+    val multipartPartSets = calls
+      .flatMap(_.request.multipartFormData)
+      .distinct
+      .sortBy { parts =>
+        val names = parts.map(_.name).distinct
+        (-names.size, names.sorted.mkString(" "))
+      }
     val (contentTypeLineOpt, bodyZod) =
       if (multipartPartSets.nonEmpty)
-        (Some("    contentType: 'multipart/form-data',"), collapseZodUnion(multipartPartSets.map(renderMultipartBody).sorted))
+        (Some("    contentType: 'multipart/form-data',"), collapseZodUnion(multipartPartSets.map(renderMultipartBody)))
       else {
         val bodySchemas = calls.flatMap(_.request.bodySchema).distinct
         val bodyZods    =

--- a/tsrest/src/main/scala/pl/iterators/baklava/tsrest/BaklavaDslFormatterTsRest.scala
+++ b/tsrest/src/main/scala/pl/iterators/baklava/tsrest/BaklavaDslFormatterTsRest.scala
@@ -102,11 +102,13 @@ class BaklavaDslFormatterTsRest extends BaklavaDslFormatter {
     }
   }
 
+  private val jsIdentifier = "[A-Za-z_$][A-Za-z0-9_$]*".r
+
   // An object key may be written bare only if it's a valid JS identifier; query/header/path-param
   // names can be kebab-case (`seller-id`, `X-Forwarded-For`) or start with a digit, which would
   // otherwise produce uncompilable TypeScript — so quote anything that isn't identifier-shaped.
   private[tsrest] def tsObjectKey(name: String): String =
-    if (name.matches("[A-Za-z_$][A-Za-z0-9_$]*")) name
+    if (jsIdentifier.matches(name)) name
     else s""""${escapeTsDoubleQuoted(name)}""""
 
   // Render one captured `Multipart` value as a ts-rest body schema (see
@@ -169,7 +171,7 @@ class BaklavaDslFormatterTsRest extends BaklavaDslFormatter {
   }
 
   // Contract endpoint generator
-  private def createContractForEndpoint(
+  private[tsrest] def createContractForEndpoint(
       endpoint: ((Option[Method], String), Seq[BaklavaSerializableCall])
   ): String = {
     val ((httpMethodOpt, _), calls) = endpoint

--- a/tsrest/src/main/scala/pl/iterators/baklava/tsrest/BaklavaDslFormatterTsRest.scala
+++ b/tsrest/src/main/scala/pl/iterators/baklava/tsrest/BaklavaDslFormatterTsRest.scala
@@ -204,11 +204,14 @@ class BaklavaDslFormatterTsRest extends BaklavaDslFormatter {
     // A `multipart/form-data` body has a free-form schema, so it can't be projected through `zod`;
     // instead emit `contentType: 'multipart/form-data'` plus a `z.object` of the captured part
     // names. Each call's part-set is rendered separately and combined into a `z.union`, mirroring
-    // how distinct non-multipart body shapes are handled.
+    // how distinct non-multipart body shapes are handled. The variants are sorted before unioning so
+    // a shape with more required fields is tried before a more-permissive shape that would also
+    // accept it (`z.object({})` sorts last) — otherwise Zod's non-strict `z.object` would match the
+    // narrower branch first and silently strip the extra fields.
     val multipartPartSets             = calls.flatMap(_.request.multipartFormData).distinct
     val (contentTypeLineOpt, bodyZod) =
       if (multipartPartSets.nonEmpty)
-        (Some("    contentType: 'multipart/form-data',"), collapseZodUnion(multipartPartSets.map(renderMultipartBody)))
+        (Some("    contentType: 'multipart/form-data',"), collapseZodUnion(multipartPartSets.map(renderMultipartBody).sorted))
       else {
         val bodySchemas = calls.flatMap(_.request.bodySchema).distinct
         val bodyZods    =

--- a/tsrest/src/test/scala/pl/iterators/baklava/tsrest/BaklavaDslFormatterTsRestSpec.scala
+++ b/tsrest/src/test/scala/pl/iterators/baklava/tsrest/BaklavaDslFormatterTsRestSpec.scala
@@ -5,9 +5,6 @@ import org.scalatest.matchers.should.Matchers
 import pl.iterators.baklava.*
 import sttp.model.{Method, StatusCode}
 
-import java.io.File
-import java.nio.file.Files
-
 class BaklavaDslFormatterTsRestSpec extends AnyFunSpec with Matchers {
 
   private val generator = new BaklavaDslFormatterTsRest
@@ -218,77 +215,72 @@ class BaklavaDslFormatterTsRestSpec extends AnyFunSpec with Matchers {
     }
   }
 
-  describe("create(): end-to-end contract emission") {
+  describe("createContractForEndpoint") {
 
-    it("quotes a kebab-case query key in the generated contract file (issue #105)") {
-      val ts = generateAndRead(
-        "v1-auctions.contract.ts",
-        Seq(
-          getCall(
-            "/v1/auctions",
-            queryParams = Seq("status" -> stringSchema().copy(required = false), "seller-id" -> uuidSchema(required = false))
-          )
+    it("quotes a kebab-case query key in the generated contract entry (issue #105)") {
+      val entry = endpoint(
+        "GET",
+        "/v1/auctions",
+        getCall(
+          "/v1/auctions",
+          queryParams = Seq("status" -> stringSchema().copy(required = false), "seller-id" -> uuidSchema(required = false))
         )
       )
-      ts should include("""query: z.object({status: z.string().nullish(), "seller-id": z.string().uuid().nullish()}),""")
+      entry should include("""query: z.object({status: z.string().nullish(), "seller-id": z.string().uuid().nullish()}),""")
     }
 
     it("emits contentType: 'multipart/form-data' and named part fields for a multipart body (issue #106)") {
-      val ts = generateAndRead(
-        "v1-auctions---auctionId-images.contract.ts",
-        Seq(
-          getCall(
-            "/v1/auctions/{auctionId}/images",
-            method = "POST",
-            pathParams = Seq("auctionId" -> uuidSchema(required = true)),
-            multipartParts = Some(
-              Seq(
-                BaklavaMultipartPartSerializable("file", isFile = true),
-                BaklavaMultipartPartSerializable("caption", isFile = false)
-              )
+      val entry = endpoint(
+        "POST",
+        "/v1/auctions/{auctionId}/images",
+        getCall(
+          "/v1/auctions/{auctionId}/images",
+          method = "POST",
+          pathParams = Seq("auctionId" -> uuidSchema(required = true)),
+          multipartParts = Some(
+            Seq(
+              BaklavaMultipartPartSerializable("file", isFile = true),
+              BaklavaMultipartPartSerializable("caption", isFile = false)
             )
           )
         )
       )
       // `contentType` is emitted immediately before `body`.
-      ts should include("    contentType: 'multipart/form-data',\n    body: z.object({caption: z.string(), file: z.instanceof(File)}),\n")
+      entry should include(
+        "    contentType: 'multipart/form-data',\n    body: z.object({caption: z.string(), file: z.instanceof(File)}),\n"
+      )
     }
 
     it("still emits an empty object body (with the content type) for a multipart body with no parts") {
-      val ts = generateAndRead(
-        "v1-blank.contract.ts",
-        Seq(getCall("/v1/blank", method = "POST", multipartParts = Some(Nil)))
-      )
-      ts should include("    contentType: 'multipart/form-data',\n    body: z.object({}),\n")
+      val entry = endpoint("POST", "/v1/blank", getCall("/v1/blank", method = "POST", multipartParts = Some(Nil)))
+      entry should include("    contentType: 'multipart/form-data',\n    body: z.object({}),\n")
     }
 
     it("unions distinct multipart part-sets across calls, broader shape first so Zod doesn't strip extra fields") {
       val file    = BaklavaMultipartPartSerializable("file", isFile = true)
       val caption = BaklavaMultipartPartSerializable("caption", isFile = false)
       // Calls are passed narrower-first; the generated union must still put `{caption, file}` first.
-      val ts = generateAndRead(
-        "v1-uploads.contract.ts",
-        Seq(
-          getCall("/v1/uploads", method = "POST", multipartParts = Some(Seq(file))),
-          getCall("/v1/uploads", method = "POST", multipartParts = Some(Seq(file, caption)))
-        )
+      val entry = endpoint(
+        "POST",
+        "/v1/uploads",
+        getCall("/v1/uploads", method = "POST", multipartParts = Some(Seq(file))),
+        getCall("/v1/uploads", method = "POST", multipartParts = Some(Seq(file, caption)))
       )
-      ts should include(
+      entry should include(
         "    contentType: 'multipart/form-data',\n" +
           "    body: z.union([z.object({caption: z.string(), file: z.instanceof(File)}), z.object({file: z.instanceof(File)})]),\n"
       )
     }
 
     it("orders an empty multipart variant last in the union") {
-      val file = BaklavaMultipartPartSerializable("file", isFile = true)
-      val ts   = generateAndRead(
-        "v1-mixed-uploads.contract.ts",
-        Seq(
-          getCall("/v1/mixed-uploads", method = "POST", multipartParts = Some(Nil)),
-          getCall("/v1/mixed-uploads", method = "POST", multipartParts = Some(Seq(file)))
-        )
+      val file  = BaklavaMultipartPartSerializable("file", isFile = true)
+      val entry = endpoint(
+        "POST",
+        "/v1/mixed-uploads",
+        getCall("/v1/mixed-uploads", method = "POST", multipartParts = Some(Nil)),
+        getCall("/v1/mixed-uploads", method = "POST", multipartParts = Some(Seq(file)))
       )
-      ts should include("    body: z.union([z.object({file: z.instanceof(File)}), z.object({})]),\n")
+      entry should include("    body: z.union([z.object({file: z.instanceof(File)}), z.object({})]),\n")
     }
 
     it("orders multipart variants by field count even when the narrower variant's first key is quoted") {
@@ -296,14 +288,13 @@ class BaklavaDslFormatterTsRestSpec extends AnyFunSpec with Matchers {
       // (a quote sorts before a letter), shadowing the broader shape — ordering must be semantic.
       val file1   = BaklavaMultipartPartSerializable("file-1", isFile = true)
       val caption = BaklavaMultipartPartSerializable("caption", isFile = false)
-      val ts      = generateAndRead(
-        "v1-kebab-uploads.contract.ts",
-        Seq(
-          getCall("/v1/kebab-uploads", method = "POST", multipartParts = Some(Seq(file1))),
-          getCall("/v1/kebab-uploads", method = "POST", multipartParts = Some(Seq(file1, caption)))
-        )
+      val entry   = endpoint(
+        "POST",
+        "/v1/kebab-uploads",
+        getCall("/v1/kebab-uploads", method = "POST", multipartParts = Some(Seq(file1))),
+        getCall("/v1/kebab-uploads", method = "POST", multipartParts = Some(Seq(file1, caption)))
       )
-      ts should include(
+      entry should include(
         """    body: z.union([z.object({caption: z.string(), "file-1": z.instanceof(File)}), z.object({"file-1": z.instanceof(File)})]),""" + "\n"
       )
     }
@@ -365,10 +356,10 @@ class BaklavaDslFormatterTsRestSpec extends AnyFunSpec with Matchers {
       )
     )
 
-  private def generateAndRead(relContractPath: String, calls: Seq[BaklavaSerializableCall]): String = {
-    new BaklavaDslFormatterTsRest().create(Map.empty, calls)
-    new String(Files.readAllBytes(new File(s"target/baklava/tsrest/src/$relContractPath").toPath))
-  }
+  // The contract entry (`get: { ... }` / `post: { ... }` block) the generator emits for one
+  // (method, path) endpoint group — exercised directly so the tests don't touch the filesystem.
+  private def endpoint(method: String, path: String, calls: BaklavaSerializableCall*): String =
+    generator.createContractForEndpoint(((Some(Method(method)), path), calls.toSeq))
 
   private def stringSchema(description: Option[String] = None, enumValues: Option[Set[String]] = None): BaklavaSchemaSerializable =
     BaklavaSchemaSerializable(

--- a/tsrest/src/test/scala/pl/iterators/baklava/tsrest/BaklavaDslFormatterTsRestSpec.scala
+++ b/tsrest/src/test/scala/pl/iterators/baklava/tsrest/BaklavaDslFormatterTsRestSpec.scala
@@ -290,6 +290,23 @@ class BaklavaDslFormatterTsRestSpec extends AnyFunSpec with Matchers {
       )
       ts should include("    body: z.union([z.object({file: z.instanceof(File)}), z.object({})]),\n")
     }
+
+    it("orders multipart variants by field count even when the narrower variant's first key is quoted") {
+      // Lexicographic ordering of the rendered strings would put `z.object({"file-1": ...})` first
+      // (a quote sorts before a letter), shadowing the broader shape — ordering must be semantic.
+      val file1   = BaklavaMultipartPartSerializable("file-1", isFile = true)
+      val caption = BaklavaMultipartPartSerializable("caption", isFile = false)
+      val ts      = generateAndRead(
+        "v1-kebab-uploads.contract.ts",
+        Seq(
+          getCall("/v1/kebab-uploads", method = "POST", multipartParts = Some(Seq(file1))),
+          getCall("/v1/kebab-uploads", method = "POST", multipartParts = Some(Seq(file1, caption)))
+        )
+      )
+      ts should include(
+        """    body: z.union([z.object({caption: z.string(), "file-1": z.instanceof(File)}), z.object({"file-1": z.instanceof(File)})]),""" + "\n"
+      )
+    }
   }
 
   private def queryParam(name: String, schema: BaklavaSchemaSerializable): BaklavaQueryParamSerializable =

--- a/tsrest/src/test/scala/pl/iterators/baklava/tsrest/BaklavaDslFormatterTsRestSpec.scala
+++ b/tsrest/src/test/scala/pl/iterators/baklava/tsrest/BaklavaDslFormatterTsRestSpec.scala
@@ -195,13 +195,22 @@ class BaklavaDslFormatterTsRestSpec extends AnyFunSpec with Matchers {
       ) shouldBe "z.object({caption: z.string(), photo: z.instanceof(File)})"
     }
 
-    it("quotes part names that aren't valid identifiers and de-duplicates by name") {
+    it("renders a repeated part name (multi-value form field) as a z.array, with the key quoted when needed") {
       generator.renderMultipartBody(
         Seq(
           BaklavaMultipartPartSerializable("file-1", isFile = true),
           BaklavaMultipartPartSerializable("file-1", isFile = true)
         )
-      ) shouldBe """z.object({"file-1": z.instanceof(File)})"""
+      ) shouldBe """z.object({"file-1": z.array(z.instanceof(File))})"""
+    }
+
+    it("unions the element schemas when a repeated part name mixes file and text parts") {
+      generator.renderMultipartBody(
+        Seq(
+          BaklavaMultipartPartSerializable("payload", isFile = true),
+          BaklavaMultipartPartSerializable("payload", isFile = false)
+        )
+      ) shouldBe "z.object({payload: z.array(z.union([z.instanceof(File), z.string()]))})"
     }
 
     it("emits an empty object when the multipart body has no parts") {
@@ -251,6 +260,22 @@ class BaklavaDslFormatterTsRestSpec extends AnyFunSpec with Matchers {
         Seq(getCall("/v1/blank", method = "POST", multipartParts = Some(Nil)))
       )
       ts should include("    contentType: 'multipart/form-data',\n    body: z.object({}),\n")
+    }
+
+    it("unions distinct multipart part-sets recorded across calls for the same endpoint (one z.object per call)") {
+      val file    = BaklavaMultipartPartSerializable("file", isFile = true)
+      val caption = BaklavaMultipartPartSerializable("caption", isFile = false)
+      val ts      = generateAndRead(
+        "v1-uploads.contract.ts",
+        Seq(
+          getCall("/v1/uploads", method = "POST", multipartParts = Some(Seq(file))),
+          getCall("/v1/uploads", method = "POST", multipartParts = Some(Seq(file, caption)))
+        )
+      )
+      ts should include(
+        "    contentType: 'multipart/form-data',\n" +
+          "    body: z.union([z.object({file: z.instanceof(File)}), z.object({caption: z.string(), file: z.instanceof(File)})]),\n"
+      )
     }
   }
 

--- a/tsrest/src/test/scala/pl/iterators/baklava/tsrest/BaklavaDslFormatterTsRestSpec.scala
+++ b/tsrest/src/test/scala/pl/iterators/baklava/tsrest/BaklavaDslFormatterTsRestSpec.scala
@@ -262,10 +262,11 @@ class BaklavaDslFormatterTsRestSpec extends AnyFunSpec with Matchers {
       ts should include("    contentType: 'multipart/form-data',\n    body: z.object({}),\n")
     }
 
-    it("unions distinct multipart part-sets recorded across calls for the same endpoint (one z.object per call)") {
+    it("unions distinct multipart part-sets across calls, broader shape first so Zod doesn't strip extra fields") {
       val file    = BaklavaMultipartPartSerializable("file", isFile = true)
       val caption = BaklavaMultipartPartSerializable("caption", isFile = false)
-      val ts      = generateAndRead(
+      // Calls are passed narrower-first; the generated union must still put `{caption, file}` first.
+      val ts = generateAndRead(
         "v1-uploads.contract.ts",
         Seq(
           getCall("/v1/uploads", method = "POST", multipartParts = Some(Seq(file))),
@@ -274,8 +275,20 @@ class BaklavaDslFormatterTsRestSpec extends AnyFunSpec with Matchers {
       )
       ts should include(
         "    contentType: 'multipart/form-data',\n" +
-          "    body: z.union([z.object({file: z.instanceof(File)}), z.object({caption: z.string(), file: z.instanceof(File)})]),\n"
+          "    body: z.union([z.object({caption: z.string(), file: z.instanceof(File)}), z.object({file: z.instanceof(File)})]),\n"
       )
+    }
+
+    it("orders an empty multipart variant last in the union") {
+      val file = BaklavaMultipartPartSerializable("file", isFile = true)
+      val ts   = generateAndRead(
+        "v1-mixed-uploads.contract.ts",
+        Seq(
+          getCall("/v1/mixed-uploads", method = "POST", multipartParts = Some(Nil)),
+          getCall("/v1/mixed-uploads", method = "POST", multipartParts = Some(Seq(file)))
+        )
+      )
+      ts should include("    body: z.union([z.object({file: z.instanceof(File)}), z.object({})]),\n")
     }
   }
 

--- a/tsrest/src/test/scala/pl/iterators/baklava/tsrest/BaklavaDslFormatterTsRestSpec.scala
+++ b/tsrest/src/test/scala/pl/iterators/baklava/tsrest/BaklavaDslFormatterTsRestSpec.scala
@@ -3,6 +3,10 @@ package pl.iterators.baklava.tsrest
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
 import pl.iterators.baklava.*
+import sttp.model.{Method, StatusCode}
+
+import java.io.File
+import java.nio.file.Files
 
 class BaklavaDslFormatterTsRestSpec extends AnyFunSpec with Matchers {
 
@@ -134,6 +138,181 @@ class BaklavaDslFormatterTsRestSpec extends AnyFunSpec with Matchers {
       generator.toTsRestPath("/foo{bar") shouldBe "/foo{bar"
       generator.toTsRestPath("/{a/b}") shouldBe "/{a/b}"
     }
+  }
+
+  describe("tsObjectKey") {
+
+    it("leaves valid JS identifiers bare") {
+      generator.tsObjectKey("status") shouldBe "status"
+      generator.tsObjectKey("sellerId") shouldBe "sellerId"
+      generator.tsObjectKey("_private") shouldBe "_private"
+      generator.tsObjectKey("$ref") shouldBe "$ref"
+      generator.tsObjectKey("page2") shouldBe "page2"
+      // Reserved words are valid object keys (bare) at both runtime and type level.
+      generator.tsObjectKey("class") shouldBe "class"
+    }
+
+    it("quotes keys with characters that aren't valid in a JS identifier") {
+      generator.tsObjectKey("seller-id") shouldBe "\"seller-id\""
+      generator.tsObjectKey("X-Forwarded-For") shouldBe "\"X-Forwarded-For\""
+      generator.tsObjectKey("2fa") shouldBe "\"2fa\""
+      generator.tsObjectKey("a.b") shouldBe "\"a.b\""
+      generator.tsObjectKey("") shouldBe "\"\""
+    }
+
+    it("escapes embedded quotes/backslashes when it has to quote") {
+      generator.tsObjectKey("""weird"key""") shouldBe """"weird\"key""""
+      generator.tsObjectKey("""back\slash-x""") shouldBe """"back\\slash-x""""
+    }
+  }
+
+  describe("buildParamsZod (query/header/path keys)") {
+
+    it("quotes a kebab-case query-parameter key so the generated z.object is valid TypeScript (issue #105)") {
+      val out = generator
+        .buildParamsZod[BaklavaQueryParamSerializable](
+          Seq(Seq(queryParam("seller-id", uuidSchema(required = false)), queryParam("status", stringSchema().copy(required = false)))),
+          _.name,
+          _.schema
+        )
+        .getOrElse(fail("expected a query schema"))
+      out shouldBe """z.object({"seller-id": z.string().uuid().nullish(), status: z.string().nullish()})"""
+    }
+
+    it("returns None when no call carries any parameters") {
+      generator.buildParamsZod[BaklavaQueryParamSerializable](Seq(Nil, Nil), _.name, _.schema) shouldBe None
+    }
+  }
+
+  describe("renderMultipartBody") {
+
+    it("emits z.instanceof(File) for file parts and z.string() for text parts, sorted by name") {
+      generator.renderMultipartBody(
+        Seq(
+          BaklavaMultipartPartSerializable("photo", isFile = true),
+          BaklavaMultipartPartSerializable("caption", isFile = false)
+        )
+      ) shouldBe "z.object({caption: z.string(), photo: z.instanceof(File)})"
+    }
+
+    it("quotes part names that aren't valid identifiers and de-duplicates by name") {
+      generator.renderMultipartBody(
+        Seq(
+          BaklavaMultipartPartSerializable("file-1", isFile = true),
+          BaklavaMultipartPartSerializable("file-1", isFile = true)
+        )
+      ) shouldBe """z.object({"file-1": z.instanceof(File)})"""
+    }
+
+    it("emits an empty object when the multipart body has no parts") {
+      generator.renderMultipartBody(Nil) shouldBe "z.object({})"
+    }
+  }
+
+  describe("create(): end-to-end contract emission") {
+
+    it("quotes a kebab-case query key in the generated contract file (issue #105)") {
+      val ts = generateAndRead(
+        "v1-auctions.contract.ts",
+        Seq(
+          getCall(
+            "/v1/auctions",
+            queryParams = Seq("status" -> stringSchema().copy(required = false), "seller-id" -> uuidSchema(required = false))
+          )
+        )
+      )
+      ts should include("""query: z.object({status: z.string().nullish(), "seller-id": z.string().uuid().nullish()}),""")
+    }
+
+    it("emits contentType: 'multipart/form-data' and named part fields for a multipart body (issue #106)") {
+      val ts = generateAndRead(
+        "v1-auctions---auctionId-images.contract.ts",
+        Seq(
+          getCall(
+            "/v1/auctions/{auctionId}/images",
+            method = "POST",
+            pathParams = Seq("auctionId" -> uuidSchema(required = true)),
+            multipartParts = Some(
+              Seq(
+                BaklavaMultipartPartSerializable("file", isFile = true),
+                BaklavaMultipartPartSerializable("caption", isFile = false)
+              )
+            )
+          )
+        )
+      )
+      // `contentType` is emitted immediately before `body`.
+      ts should include("    contentType: 'multipart/form-data',\n    body: z.object({caption: z.string(), file: z.instanceof(File)}),\n")
+    }
+
+    it("still emits an empty object body (with the content type) for a multipart body with no parts") {
+      val ts = generateAndRead(
+        "v1-blank.contract.ts",
+        Seq(getCall("/v1/blank", method = "POST", multipartParts = Some(Nil)))
+      )
+      ts should include("    contentType: 'multipart/form-data',\n    body: z.object({}),\n")
+    }
+  }
+
+  private def queryParam(name: String, schema: BaklavaSchemaSerializable): BaklavaQueryParamSerializable =
+    BaklavaQueryParamSerializable(name, None, schema)
+
+  private def uuidSchema(required: Boolean): BaklavaSchemaSerializable =
+    BaklavaSchemaSerializable(
+      className = "UUID",
+      `type` = SchemaType.StringType,
+      format = Some("uuid"),
+      properties = Map.empty,
+      items = None,
+      `enum` = None,
+      required = required,
+      additionalProperties = false,
+      default = None,
+      description = None
+    )
+
+  private def getCall(
+      path: String,
+      method: String = "GET",
+      pathParams: Seq[(String, BaklavaSchemaSerializable)] = Nil,
+      queryParams: Seq[(String, BaklavaSchemaSerializable)] = Nil,
+      multipartParts: Option[Seq[BaklavaMultipartPartSerializable]] = None
+  ): BaklavaSerializableCall =
+    BaklavaSerializableCall(
+      request = BaklavaRequestContextSerializable(
+        symbolicPath = path,
+        path = path,
+        pathDescription = None,
+        pathSummary = None,
+        method = Some(Method(method)),
+        operationDescription = None,
+        operationSummary = None,
+        operationId = None,
+        operationTags = Nil,
+        securitySchemes = Nil,
+        bodySchema = None,
+        bodyString = "",
+        headersSeq = Nil,
+        pathParametersSeq = pathParams.map { case (n, s) => BaklavaPathParamSerializable(n, None, s) },
+        queryParametersSeq = queryParams.map { case (n, s) => BaklavaQueryParamSerializable(n, None, s) },
+        responseDescription = None,
+        responseHeaders = Nil,
+        multipartFormData = multipartParts
+      ),
+      response = BaklavaResponseContextSerializable(
+        protocol = BaklavaHttpProtocol("HTTP/1.1"),
+        status = StatusCode(if (method == "POST") 204 else 200),
+        headers = Seq.empty,
+        bodyString = "",
+        requestContentType = multipartParts.map(_ => "multipart/form-data; boundary=baklava-multipart-boundary"),
+        responseContentType = None,
+        bodySchema = None
+      )
+    )
+
+  private def generateAndRead(relContractPath: String, calls: Seq[BaklavaSerializableCall]): String = {
+    new BaklavaDslFormatterTsRest().create(Map.empty, calls)
+    new String(Files.readAllBytes(new File(s"target/baklava/tsrest/src/$relContractPath").toPath))
   }
 
   private def stringSchema(description: Option[String] = None, enumValues: Option[Set[String]] = None): BaklavaSchemaSerializable =


### PR DESCRIPTION
Fixes #105 and #106 — two bugs in the `baklava-tsrest` contract generator.

## #105 — non-identifier query/header/path keys emitted unquoted

`query: z.object({ seller-id: z.string().uuid().nullish() })` is a `SyntaxError`. Object keys that aren't valid JS identifiers (kebab-case like `seller-id` / `X-Forwarded-For`, names starting with a digit, …) are now quoted in the generated `z.object({…})`:

```ts
query: z.object({status: z.string().nullish(), "seller-id": z.string().uuid().nullish()}),
```

The per-call-site `quoteKeys: Boolean` in `buildParamsZod` is replaced with a single `tsObjectKey(name)` helper (`name.matches("[A-Za-z_$][A-Za-z0-9_$]*")` → bare, else escaped double-quoted), applied uniformly to path, query and header parameter schemas.

## #106 — multipart request bodies emitted as `body: z.object({})`

A `Multipart` body's `Schema` is a static `FreeFormSchema` (`type: object`, no properties — the part names are runtime values), so the ts-rest emitter projected it straight to `z.object({})`, losing every form field.

The part metadata is now captured where it actually lives — at serialization time:

- `core`: new `BaklavaMultipartPartSerializable(name, isFile)` and an optional `BaklavaRequestContextSerializable.multipartFormData: Option[Seq[…]] = None`, populated by matching the request body against `Multipart` / `FilePart` / `TextPart`. Additive + optional, so the on-disk call format and the other generators are untouched.
- `tsrest`: when a request body is multipart, emit `contentType: 'multipart/form-data',` plus a `z.object` naming each part — `FilePart` → `z.instanceof(File)`, `TextPart` → `z.string()` (sorted, de-duped by name, keys quoted via `tsObjectKey`). An empty `Multipart` still gets the content type and `z.object({})`.

So `POST /users/{userId}/photo` now generates:

```ts
post: {
  ...
  pathParams: z.object({userId: z.string().uuid()}),
  contentType: 'multipart/form-data',
  body: z.object({caption: z.string(), photo: z.instanceof(File)}),
  responses: { 204: z.undefined() }
}
```

(`z.instanceof(File)` references the global `File` constructor — available in browsers and Node ≥ 20; matches the [ts-rest multipart docs](https://ts-rest.com/docs/core/multi-part#multipart---formdata) and the original issue's "Expected".)

## Tests / docs

- New unit tests for `tsObjectKey`, `buildParamsZod`, `renderMultipartBody`, plus three `create()` end-to-end tests that read back the generated `.contract.ts` for the issue reproductions.
- Regenerated `openapi/src/test/resources/gold/tsrest/src/users---userId-photo.contract.ts` (the only gold file affected); `ComprehensiveGoldSpec` passes without `BAKLAVA_REGEN_GOLD`.
- Documented both behaviours in `docs/output-formats.md`.

Verified: `sbt 'tsrest/test'` (26 pass), `sbt 'openapi/testOnly *ComprehensiveGoldSpec'` (20 pass), full `sbt test` on Scala 2.13 (all green). A focused code review (`/ultrareview`-style multi-agent pass) flagged a defensive hardening of the `contentType`/`body` emission and tighter test assertions, both applied.