### PR TITLE
fix: render Map[K, V] schemas with additionalProperties (#108)

### DIFF
--- a/core/src/main/scala/pl/iterators/baklava/BaklavaHttpDsl.scala
+++ b/core/src/main/scala/pl/iterators/baklava/BaklavaHttpDsl.scala
@@ -15,16 +15,17 @@ case class FormOf[T](fields: (String, String)*)(implicit val schema: Schema[T])
 
 object FormOf {
   implicit def schema[T](implicit schema: Schema[T]): Schema[FormOf[T]] = new Schema[FormOf[T]] {
-    val `type`: SchemaType                 = schema.`type`
-    val className: String                  = schema.className
-    val format: Option[String]             = schema.format
-    val properties: Map[String, Schema[?]] = schema.properties
-    val items: Option[Schema[?]]           = schema.items
-    val `enum`: Option[Set[String]]        = schema.`enum`
-    val required: Boolean                  = schema.required
-    val additionalProperties: Boolean      = schema.additionalProperties
-    val default: Option[FormOf[T]]         = None
-    val description: Option[String]        = schema.description
+    val `type`: SchemaType                                     = schema.`type`
+    val className: String                                      = schema.className
+    val format: Option[String]                                 = schema.format
+    val properties: Map[String, Schema[?]]                     = schema.properties
+    val items: Option[Schema[?]]                               = schema.items
+    val `enum`: Option[Set[String]]                            = schema.`enum`
+    val required: Boolean                                      = schema.required
+    val additionalProperties: Boolean                          = schema.additionalProperties
+    override val additionalPropertiesSchema: Option[Schema[?]] = schema.additionalPropertiesSchema
+    val default: Option[FormOf[T]]                             = None
+    val description: Option[String]                            = schema.description
   }
 }
 

--- a/core/src/main/scala/pl/iterators/baklava/BaklavaSerialize.scala
+++ b/core/src/main/scala/pl/iterators/baklava/BaklavaSerialize.scala
@@ -97,7 +97,9 @@ case class BaklavaSchemaSerializable(
     required: Boolean,
     additionalProperties: Boolean,
     default: Option[Json],
-    description: Option[String]
+    description: Option[String],
+    // Value schema for a map-like object (`additionalProperties: <schema>`); `None` otherwise.
+    additionalPropertiesSchema: Option[BaklavaSchemaSerializable] = None
 ) extends Serializable
 
 object BaklavaSchemaSerializable {
@@ -112,7 +114,8 @@ object BaklavaSchemaSerializable {
       required = schema.required,
       additionalProperties = schema.additionalProperties,
       default = schema.default.flatMap(encodeDefault(schema.`type`)),
-      description = schema.description
+      description = schema.description,
+      additionalPropertiesSchema = schema.additionalPropertiesSchema.map(BaklavaSchemaSerializable(_))
     )
   }
 

--- a/core/src/main/scala/pl/iterators/baklava/Schema.scala
+++ b/core/src/main/scala/pl/iterators/baklava/Schema.scala
@@ -29,30 +29,36 @@ trait Schema[T] {
   val default: Option[T]
   val description: Option[String]
 
+  // For map-like object schemas: the schema all values conform to (renders as a JSON Schema /
+  // OpenAPI `additionalProperties: <schema>`). `None` for ordinary objects and primitives.
+  def additionalPropertiesSchema: Option[Schema[?]] = None
+
   def withDescription(_description: String): Schema[T] = new Schema[T] {
-    val className: String                  = Schema.this.className
-    val `type`: SchemaType                 = Schema.this.`type`
-    val format: Option[String]             = Schema.this.format
-    val properties: Map[String, Schema[?]] = Schema.this.properties
-    val items: Option[Schema[?]]           = Schema.this.items
-    val `enum`: Option[Set[String]]        = Schema.this.`enum`
-    val required: Boolean                  = Schema.this.required
-    val additionalProperties: Boolean      = Schema.this.additionalProperties
-    val default: Option[T]                 = Schema.this.default
-    val description: Option[String]        = Some(_description)
+    val className: String                                      = Schema.this.className
+    val `type`: SchemaType                                     = Schema.this.`type`
+    val format: Option[String]                                 = Schema.this.format
+    val properties: Map[String, Schema[?]]                     = Schema.this.properties
+    val items: Option[Schema[?]]                               = Schema.this.items
+    val `enum`: Option[Set[String]]                            = Schema.this.`enum`
+    val required: Boolean                                      = Schema.this.required
+    val additionalProperties: Boolean                          = Schema.this.additionalProperties
+    override val additionalPropertiesSchema: Option[Schema[?]] = Schema.this.additionalPropertiesSchema
+    val default: Option[T]                                     = Schema.this.default
+    val description: Option[String]                            = Some(_description)
   }
 
   def withDefault(_default: T): Schema[T] = new Schema[T] {
-    val className: String                  = Schema.this.className
-    val `type`: SchemaType                 = Schema.this.`type`
-    val format: Option[String]             = Schema.this.format
-    val properties: Map[String, Schema[?]] = Schema.this.properties
-    val items: Option[Schema[?]]           = Schema.this.items
-    val `enum`: Option[Set[String]]        = Schema.this.`enum`
-    val required: Boolean                  = Schema.this.required
-    val additionalProperties: Boolean      = Schema.this.additionalProperties
-    val default: Option[T]                 = Some(_default)
-    val description: Option[String]        = Schema.this.description
+    val className: String                                      = Schema.this.className
+    val `type`: SchemaType                                     = Schema.this.`type`
+    val format: Option[String]                                 = Schema.this.format
+    val properties: Map[String, Schema[?]]                     = Schema.this.properties
+    val items: Option[Schema[?]]                               = Schema.this.items
+    val `enum`: Option[Set[String]]                            = Schema.this.`enum`
+    val required: Boolean                                      = Schema.this.required
+    val additionalProperties: Boolean                          = Schema.this.additionalProperties
+    override val additionalPropertiesSchema: Option[Schema[?]] = Schema.this.additionalPropertiesSchema
+    val default: Option[T]                                     = Some(_default)
+    val description: Option[String]                            = Schema.this.description
   }
 
   override def toString: String = {
@@ -122,16 +128,17 @@ trait SchemaDefaults {
   implicit val unitSchema: PrimitiveSchema[Unit]             = PrimitiveSchema[Unit]("Unit", SchemaType.NullType, None)
   implicit val bigDecimalSchema: PrimitiveSchema[BigDecimal] = PrimitiveSchema[BigDecimal]("BigDecimal", SchemaType.NumberType, None)
   implicit def optionSchema[T](implicit schema: Schema[T]): Schema[Option[T]] = new Schema[Option[T]] {
-    val className: String                  = schema.className
-    val `type`: SchemaType                 = schema.`type`
-    val format: Option[String]             = schema.format
-    val properties: Map[String, Schema[?]] = schema.properties
-    val items: Option[Schema[?]]           = schema.items
-    val `enum`: Option[Set[String]]        = schema.`enum`
-    val required: Boolean                  = false
-    val additionalProperties: Boolean      = schema.additionalProperties
-    val default: Option[Option[T]]         = Some(None)
-    val description: Option[String]        = schema.description
+    val className: String                                      = schema.className
+    val `type`: SchemaType                                     = schema.`type`
+    val format: Option[String]                                 = schema.format
+    val properties: Map[String, Schema[?]]                     = schema.properties
+    val items: Option[Schema[?]]                               = schema.items
+    val `enum`: Option[Set[String]]                            = schema.`enum`
+    val required: Boolean                                      = false
+    val additionalProperties: Boolean                          = schema.additionalProperties
+    override val additionalPropertiesSchema: Option[Schema[?]] = schema.additionalPropertiesSchema
+    val default: Option[Option[T]]                             = Some(None)
+    val description: Option[String]                            = schema.description
   }
   implicit def seqSchema[T](implicit schema: Schema[T]): Schema[Seq[T]] = new Schema[Seq[T]] {
     val className: String                  = "Seq[" + schema.className + "]"
@@ -157,17 +164,21 @@ trait SchemaDefaults {
     val default: Option[List[T]]           = None
     val description: Option[String]        = None
   }
-  implicit def stringMapSchema[T](implicit schema: Schema[T]): Schema[Map[String, T]] = new Schema[Map[String, T]] {
-    val className: String                  = "Map[String, " + schema.className + "]"
-    val `type`: SchemaType                 = SchemaType.ObjectType
-    val format: Option[String]             = None
-    val properties: Map[String, Schema[?]] = Map.empty
-    val items: Option[Schema[?]]           = None
-    val `enum`: Option[Set[String]]        = None
-    val required: Boolean                  = true
-    val additionalProperties: Boolean      = true
-    val default: Option[Map[String, T]]    = None
-    val description: Option[String]        = None
+  // A JSON object whose keys are the (string-encoded) `K` values and whose values all conform to
+  // `V` — renders as `type: object` + `additionalProperties: <schema for V>`. The key constraint
+  // isn't expressible in OpenAPI 3.0, so it's dropped (JSON object keys are strings regardless).
+  implicit def mapSchema[K, V](implicit keySchema: Schema[K], valueSchema: Schema[V]): Schema[Map[K, V]] = new Schema[Map[K, V]] {
+    val className: String                                      = s"Map[${keySchema.className}, ${valueSchema.className}]"
+    val `type`: SchemaType                                     = SchemaType.ObjectType
+    val format: Option[String]                                 = None
+    val properties: Map[String, Schema[?]]                     = Map.empty
+    val items: Option[Schema[?]]                               = None
+    val `enum`: Option[Set[String]]                            = None
+    val required: Boolean                                      = true
+    val additionalProperties: Boolean                          = true
+    override val additionalPropertiesSchema: Option[Schema[?]] = Some(valueSchema)
+    val default: Option[Map[K, V]]                             = None
+    val description: Option[String]                            = None
   }
   implicit val uuidSchema: PrimitiveSchema[java.util.UUID] = PrimitiveSchema[java.util.UUID]("UUID", SchemaType.StringType, Some("uuid"))
 

--- a/core/src/test/scala/pl/iterators/baklava/SchemaCompare.scala
+++ b/core/src/test/scala/pl/iterators/baklava/SchemaCompare.scala
@@ -19,6 +19,8 @@ object SchemaCompare {
     a.`enum` shouldEqual b.`enum`
     a.required shouldEqual b.required
     a.additionalProperties shouldEqual b.additionalProperties
+    a.additionalPropertiesSchema.map(_.`type`) shouldEqual b.additionalPropertiesSchema.map(_.`type`)
+    a.additionalPropertiesSchema.flatMap(_.format) shouldEqual b.additionalPropertiesSchema.flatMap(_.format)
     a.description shouldEqual b.description
     a.default shouldEqual b.default
     ()

--- a/core/src/test/scala/pl/iterators/baklava/SchemaSpec.scala
+++ b/core/src/test/scala/pl/iterators/baklava/SchemaSpec.scala
@@ -70,5 +70,36 @@ class SchemaSpec extends AnyFunSpec with Matchers {
 
       SchemaCompare.assertSchemaFieldsEqual(derived, expected)
     }
+
+    it("for Map[String, Int] (object + additionalProperties value schema)") {
+      val derived = implicitly[Schema[Map[String, Int]]]
+      derived.`type` shouldBe SchemaType.ObjectType
+      derived.className shouldBe "Map[String, Int]"
+      derived.additionalProperties shouldBe true
+      derived.additionalPropertiesSchema.map(_.`type`) shouldBe Some(SchemaType.IntegerType)
+    }
+
+    it("for Map[UUID, String] (a non-string key drops the key constraint, keeps the value schema)") {
+      val derived = implicitly[Schema[Map[UUID, String]]]
+      derived.`type` shouldBe SchemaType.ObjectType
+      derived.additionalPropertiesSchema.map(_.`type`) shouldBe Some(SchemaType.StringType)
+    }
+
+    case class WithMap(id: Int, tags: Map[String, String])
+
+    it("for a case class with a Map[String, String] field") {
+      val derived = implicitly[Schema[WithMap]]
+      val tags    = derived.properties("tags")
+      tags.`type` shouldBe SchemaType.ObjectType
+      tags.additionalProperties shouldBe true
+      tags.additionalPropertiesSchema.map(_.`type`) shouldBe Some(SchemaType.StringType)
+    }
+
+    it("for Option[Map[String, Int]] (the value schema survives the Option wrapper)") {
+      val derived = implicitly[Schema[Option[Map[String, Int]]]]
+      derived.required shouldBe false
+      derived.`type` shouldBe SchemaType.ObjectType
+      derived.additionalPropertiesSchema.map(_.`type`) shouldBe Some(SchemaType.IntegerType)
+    }
   }
 }

--- a/docs/output-formats.md
+++ b/docs/output-formats.md
@@ -373,6 +373,7 @@ Endpoints with a request body emit `.contentType(...)` honoring the content-type
 | `Boolean` | `Boolean` |
 | `Seq/List/Vector/Set/Array[T]` | `Seq[T]` |
 | Named case class | Case class (emitted in the owning tag's `dtos.scala` or `common/dtos.scala`) |
+| `Map[K, V]` | `Map[String, V]` |
 | `Option[T]` | Field becomes `Option[T] = None` |
 
 ### Configuration
@@ -461,6 +462,7 @@ Endpoint files import types from the appropriate location (`./types`, `../common
 | `Null` | `null` |
 | `Seq[T]`, `List[T]`, `Vector[T]`, `Set[T]`, `Array[T]` | `InnerType[]` |
 | Case class with properties | Named `interface` (re-exported per-tag as `Users.ClassName` / shared as `Common.ClassName`) |
+| `Map[K, V]` | `Record<string, V>` |
 | `Option[T]` | Field becomes optional (`field?: T`) |
 
 ### Configuration

--- a/docs/output-formats.md
+++ b/docs/output-formats.md
@@ -136,6 +136,7 @@ Baklava schemas are converted to Zod validators:
 | `Boolean` | `z.boolean()` |
 | `Seq[T]`, `List[T]` | `z.array(innerSchema)` |
 | Case class | `z.object({ field: schema, ... })` |
+| `Map[K, V]` | `z.record(z.string(), innerSchema)` |
 | `Option[T]` | `schema.nullish()` |
 
 When multiple test cases produce different schemas for the same endpoint input/output, they are combined into `z.union([...])`.

--- a/openapi/src/main/scala/pl/iterators/baklava/openapi/BaklavaDslFormatterOpenAPIWorker.scala
+++ b/openapi/src/main/scala/pl/iterators/baklava/openapi/BaklavaDslFormatterOpenAPIWorker.scala
@@ -373,9 +373,11 @@ object BaklavaDslFormatterOpenAPIWorker {
   private def baklavaSchemaToOpenAPISchema(baklavaSchema: BaklavaSchemaSerializable): Schema[?] = {
     val schema = new Schema[String]()
     // A named object type carries an `x-class` extension so post-processors can lift it into
-    // components/schemas; a map-like object (`additionalProperties: <schema>`) is structural rather
-    // than a named class, so it's left untagged.
-    if (baklavaSchema.`type` == SchemaType.ObjectType && baklavaSchema.additionalPropertiesSchema.isEmpty) {
+    // components/schemas; a *pure* map (no declared properties, just `additionalProperties: <schema>`)
+    // is structural rather than a named class, so it's left untagged. An object that has both
+    // declared properties and a catch-all is still a named DTO and keeps its `x-class`.
+    val isPureMap = baklavaSchema.additionalPropertiesSchema.isDefined && baklavaSchema.properties.isEmpty
+    if (baklavaSchema.`type` == SchemaType.ObjectType && !isPureMap) {
       schema.extensions(
         Map
           .apply[String, AnyRef](

--- a/openapi/src/main/scala/pl/iterators/baklava/openapi/BaklavaDslFormatterOpenAPIWorker.scala
+++ b/openapi/src/main/scala/pl/iterators/baklava/openapi/BaklavaDslFormatterOpenAPIWorker.scala
@@ -372,7 +372,10 @@ object BaklavaDslFormatterOpenAPIWorker {
 
   private def baklavaSchemaToOpenAPISchema(baklavaSchema: BaklavaSchemaSerializable): Schema[?] = {
     val schema = new Schema[String]()
-    if (baklavaSchema.`type` == SchemaType.ObjectType) {
+    // A named object type carries an `x-class` extension so post-processors can lift it into
+    // components/schemas; a map-like object (`additionalProperties: <schema>`) is structural rather
+    // than a named class, so it's left untagged.
+    if (baklavaSchema.`type` == SchemaType.ObjectType && baklavaSchema.additionalPropertiesSchema.isEmpty) {
       schema.extensions(
         Map
           .apply[String, AnyRef](
@@ -400,7 +403,10 @@ object BaklavaDslFormatterOpenAPIWorker {
     baklavaSchema.`enum`.foreach(e => schema.setEnum(e.toList.asJava))
     baklavaSchema.default.flatMap(jsonToJavaDefault).foreach(schema.setDefault)
     schema.setRequired(baklavaSchema.properties.toList.filter(_._2.required).map(_._1).asJava)
-    if (baklavaSchema.additionalProperties) schema.setAdditionalProperties(baklavaSchema.additionalProperties)
+    baklavaSchema.additionalPropertiesSchema match {
+      case Some(bs) => schema.setAdditionalProperties(baklavaSchemaToOpenAPISchema(bs))
+      case None     => if (baklavaSchema.additionalProperties) schema.setAdditionalProperties(baklavaSchema.additionalProperties)
+    }
 
     schema
   }

--- a/openapi/src/test/resources/gold/openapi/openapi.yml
+++ b/openapi/src/test/resources/gold/openapi/openapi.yml
@@ -1010,15 +1010,68 @@ paths:
               additionalProperties: true
               x-class: Multipart
             examples:
-              Photo uploaded:
+              Photo uploaded; rendered variants returned keyed by name:
                 value: "--baklava-multipart-boundary\r\nContent-Type: image/png\r\n\
                   Content-Disposition: form-data; filename=\"photo.png\"; name=\"\
                   photo\"\r\n\r\nfake png bytes\r\n--baklava-multipart-boundary\r\n\
                   Content-Type: text/plain; charset=UTF-8\r\nContent-Disposition:\
                   \ form-data; name=\"caption\"\r\n\r\nprofile photo\r\n--baklava-multipart-boundary--"
       responses:
-        "204":
-          description: Photo uploaded
+        "201":
+          description: Photo uploaded; rendered variants returned keyed by name
+          content:
+            application/json:
+              schema:
+                required:
+                - id
+                - variants
+                type: object
+                properties:
+                  id:
+                    type: string
+                    format: uuid
+                  variants:
+                    type: object
+                    additionalProperties:
+                      required:
+                      - format
+                      - height
+                      - url
+                      - width
+                      type: object
+                      properties:
+                        url:
+                          type: string
+                        width:
+                          type: integer
+                          format: int32
+                        height:
+                          type: integer
+                          format: int32
+                        format:
+                          type: string
+                      x-class: PhotoVariant
+                x-class: PhotoUpload
+              examples:
+                Photo uploaded; rendered variants returned keyed by name:
+                  value: |-
+                    {
+                      "id" : "00000000-0000-0000-0000-000000000010",
+                      "variants" : {
+                        "thumbnail" : {
+                          "url" : "https://cdn.example.com/photo_thumb.png",
+                          "width" : 64,
+                          "height" : 64,
+                          "format" : "png"
+                        },
+                        "full" : {
+                          "url" : "https://cdn.example.com/photo.png",
+                          "width" : 1024,
+                          "height" : 768,
+                          "format" : "png"
+                        }
+                      }
+                    }
       security:
       - bearerAuth: []
   /webhooks:

--- a/openapi/src/test/resources/gold/postman/collection.json
+++ b/openapi/src/test/resources/gold/postman/collection.json
@@ -726,13 +726,13 @@
           },
           "response" : [
             {
-              "name" : "Photo uploaded",
-              "status" : "No Content",
-              "code" : 204,
+              "name" : "Photo uploaded; rendered variants returned keyed by name",
+              "status" : "Created",
+              "code" : 201,
               "header" : [
               ],
-              "body" : "",
-              "_postman_previewlanguage" : "text"
+              "body" : "{\"id\":\"00000000-0000-0000-0000-000000000010\",\"variants\":{\"thumbnail\":{\"url\":\"https://cdn.example.com/photo_thumb.png\",\"width\":64,\"height\":64,\"format\":\"png\"},\"full\":{\"url\":\"https://cdn.example.com/photo.png\",\"width\":1024,\"height\":768,\"format\":\"png\"}}}",
+              "_postman_previewlanguage" : "json"
             }
           ]
         }

--- a/openapi/src/test/resources/gold/simple/POST__users___userId___photo-a38a0a95.html
+++ b/openapi/src/test/resources/gold/simple/POST__users___userId___photo-a38a0a95.html
@@ -51,7 +51,7 @@
   ],
   "additionalProperties" : true
 }</pre></details></div></div>
-<div class="card"><div class="card-header"><span class="status-badge status-2xx">204</span> Response</div><div class="card-body"><p>Photo uploaded</p><h4>Curl</h4><div class="curl-block"><pre>curl -X POST '$BASE_URL/users/00000000-0000-0000-0000-000000000001/photo' \
+<div class="card"><div class="card-header"><span class="status-badge status-2xx">201</span> Response</div><div class="card-body"><p>Photo uploaded; rendered variants returned keyed by name</p><h4>Curl</h4><div class="curl-block"><pre>curl -X POST '$BASE_URL/users/00000000-0000-0000-0000-000000000001/photo' \
   -H 'Content-Type: multipart/form-data; boundary=baklava-multipart-boundary' \
   -H 'Authorization: Bearer &lt;TOKEN&gt;' \
   --data-raw '--baklava-multipart-boundary
@@ -74,7 +74,74 @@ Content-Type: text/plain; charset=UTF-8
 Content-Disposition: form-data; name="caption"
 
 profile photo
---baklava-multipart-boundary--</pre></div></div>
+--baklava-multipart-boundary--</pre><h4>Response body</h4><pre>{
+  "id" : "00000000-0000-0000-0000-000000000010",
+  "variants" : {
+    "thumbnail" : {
+      "url" : "https://cdn.example.com/photo_thumb.png",
+      "width" : 64,
+      "height" : 64,
+      "format" : "png"
+    },
+    "full" : {
+      "url" : "https://cdn.example.com/photo.png",
+      "width" : 1024,
+      "height" : 768,
+      "format" : "png"
+    }
+  }
+}</pre><details><summary>Response schema</summary><pre>{
+  "$schema" : "http://json-schema.org/draft-07/schema#",
+  "title" : "PhotoUpload",
+  "type" : "object",
+  "properties" : {
+    "id" : {
+      "type" : "string",
+      "format" : "uuid"
+    },
+    "variants" : {
+      "title" : "Map[String, PhotoVariant]",
+      "type" : "object",
+      "properties" : {
+        
+      },
+      "required" : [
+      ],
+      "additionalProperties" : {
+        "title" : "PhotoVariant",
+        "type" : "object",
+        "properties" : {
+          "url" : {
+            "type" : "string"
+          },
+          "width" : {
+            "type" : "integer",
+            "format" : "int32"
+          },
+          "height" : {
+            "type" : "integer",
+            "format" : "int32"
+          },
+          "format" : {
+            "type" : "string"
+          }
+        },
+        "required" : [
+          "format",
+          "height",
+          "url",
+          "width"
+        ],
+        "additionalProperties" : false
+      }
+    }
+  },
+  "required" : [
+    "id",
+    "variants"
+  ],
+  "additionalProperties" : false
+}</pre></details></div></div>
 <script>
 document.addEventListener('click', function (e) {
   var btn = e.target.closest('button.copy-btn');

--- a/openapi/src/test/resources/gold/sttpclient/src/main/scala/baklavaclient/users/UsersEndpoints.scala
+++ b/openapi/src/test/resources/gold/sttpclient/src/main/scala/baklavaclient/users/UsersEndpoints.scala
@@ -75,11 +75,12 @@ object UsersEndpoints {
   )(
       userId: java.util.UUID,
       bodyJson: String
-  ): Request[Either[String, String]] = {
+  ): Request[Either[ResponseException[String], PhotoUpload]] = {
     basicRequest
       .post(baseUri.addPath("users", s"$userId", "photo"))
       .header("Authorization", s"Bearer ${bearerAuthToken}")
       .body(bodyJson)
       .contentType("multipart/form-data; boundary=baklava-multipart-boundary")
+      .response(asJson[PhotoUpload])
   }
 }

--- a/openapi/src/test/resources/gold/sttpclient/src/main/scala/baklavaclient/users/dtos.scala
+++ b/openapi/src/test/resources/gold/sttpclient/src/main/scala/baklavaclient/users/dtos.scala
@@ -4,4 +4,8 @@ import baklavaclient.common.User
 
 final case class PaginatedUsers(limit: Int, page: Int, total: Int, users: Seq[User])
 
+final case class PhotoUpload(id: java.util.UUID, variants: Map[String, PhotoVariant])
+
+final case class PhotoVariant(format: String, height: Int, url: String, width: Int)
+
 final case class UpdateUserRequest(name: String, role: String)

--- a/openapi/src/test/resources/gold/tsfetch/src/users/endpoints.ts
+++ b/openapi/src/test/resources/gold/tsfetch/src/users/endpoints.ts
@@ -1,5 +1,5 @@
 import { BaklavaClient, BaklavaHttpError } from "../client";
-import type { PaginatedUsers, UpdateUserRequest } from "./types";
+import type { PaginatedUsers, PhotoUpload, PhotoVariant, UpdateUserRequest } from "./types";
 import type { ErrorResponse, User } from "../common/types";
 
 /** List users — List users with pagination and optional role filter */
@@ -91,8 +91,9 @@ export async function updateUser(client: BaklavaClient, params: {
 export async function uploadPhoto(client: BaklavaClient, params: {
   userId: string;
   body: Record<string, unknown>;
-}): Promise<void> {
+}): Promise<PhotoUpload> {
   const url = new URL(`${client.baseUrl}/users/${encodeURIComponent(String(params.userId))}/photo`);
+  let __ret!: PhotoUpload;
   const res = await client.fetch(url.toString(), {
     method: "POST",
     headers: {
@@ -101,5 +102,11 @@ export async function uploadPhoto(client: BaklavaClient, params: {
     },
     body: params.body as unknown as BodyInit,
   });
-  if (!res.ok) throw new BaklavaHttpError(res.status, await res.text());
+  const text = await res.text();
+  if (!res.ok) throw new BaklavaHttpError(res.status, text);
+  const ct = res.headers.get("content-type") ?? "";
+  if (ct.includes("application/json")) {
+    return (text ? JSON.parse(text) : undefined) as typeof __ret;
+  }
+  return text as unknown as typeof __ret;
 }

--- a/openapi/src/test/resources/gold/tsfetch/src/users/types.ts
+++ b/openapi/src/test/resources/gold/tsfetch/src/users/types.ts
@@ -7,6 +7,18 @@ export interface PaginatedUsers {
   users: User[];
 }
 
+export interface PhotoUpload {
+  id: string;
+  variants: Record<string, PhotoVariant>;
+}
+
+export interface PhotoVariant {
+  format: string;
+  height: number;
+  url: string;
+  width: number;
+}
+
 export interface UpdateUserRequest {
   name: string;
   role: "admin" | "guest" | "member";

--- a/openapi/src/test/resources/gold/tsrest/src/users---userId-photo.contract.ts
+++ b/openapi/src/test/resources/gold/tsrest/src/users---userId-photo.contract.ts
@@ -11,7 +11,13 @@ export const usersUserIdPhotoContract = initContract().router({
     contentType: 'multipart/form-data',
     body: z.object({caption: z.string(), photo: z.instanceof(File)}),
     responses: {
-      204: z.undefined()
+      201: z.object({
+        "id": z.string().uuid(),
+        "variants": z.record(z.string(), z.object({
+        "format": z.string(),
+        "height": z.number().int(),
+        "url": z.string(),
+        "width": z.number().int()}))})
     }
   }
 });

--- a/openapi/src/test/scala/pl/iterators/baklava/openapi/BaklavaDslFormatterOpenAPIWorkerSpec.scala
+++ b/openapi/src/test/scala/pl/iterators/baklava/openapi/BaklavaDslFormatterOpenAPIWorkerSpec.scala
@@ -281,6 +281,7 @@ class BaklavaDslFormatterOpenAPIWorkerSpec extends AnyFunSpec with Matchers {
         val bodySchema = openAPI.getPaths.get("/v1/variants").getPost.getRequestBody.getContent.get("application/json").getSchema
         bodySchema.getType shouldBe "object"
         bodySchema.getExtensions shouldBe null // a map is structural, not a named class — no x-class
+        bodySchema.getRequired shouldBe null   // no `required: []` noise for a propertyless object (swagger nulls an empty list)
         val valueSchema = bodySchema.getAdditionalProperties match {
           case s: io.swagger.v3.oas.models.media.Schema[?] => s
           case other                                       =>

--- a/openapi/src/test/scala/pl/iterators/baklava/openapi/BaklavaDslFormatterOpenAPIWorkerSpec.scala
+++ b/openapi/src/test/scala/pl/iterators/baklava/openapi/BaklavaDslFormatterOpenAPIWorkerSpec.scala
@@ -242,6 +242,56 @@ class BaklavaDslFormatterOpenAPIWorkerSpec extends AnyFunSpec with Matchers {
       }
     }
 
+    describe("map-typed schemas (additionalProperties: <schema>)") {
+      it("renders additionalProperties as the value schema and leaves the map itself untagged") {
+        val variantSchema = BaklavaSchemaSerializable(
+          className = "VariantDto",
+          `type` = SchemaType.ObjectType,
+          format = None,
+          properties = Map("url" -> BaklavaSchemaSerializable(Schema.stringSchema)),
+          items = None,
+          `enum` = None,
+          required = true,
+          additionalProperties = false,
+          default = None,
+          description = None
+        )
+        val mapBodySchema = BaklavaSchemaSerializable(
+          className = "Map[String, VariantDto]",
+          `type` = SchemaType.ObjectType,
+          format = None,
+          properties = Map.empty,
+          items = None,
+          `enum` = None,
+          required = true,
+          additionalProperties = true,
+          default = None,
+          description = None,
+          additionalPropertiesSchema = Some(variantSchema)
+        )
+        val base = call("POST", "/v1/variants", None, None, Nil, None, Nil)
+        val c    = base.copy(
+          response = base.response.copy(requestContentType = Some("application/json"), bodySchema = None),
+          request = base.request.copy(bodySchema = Some(mapBodySchema))
+        )
+
+        val openAPI = new OpenAPI()
+        BaklavaDslFormatterOpenAPIWorker.generateForCalls(openAPI, Seq(c))
+
+        val bodySchema = openAPI.getPaths.get("/v1/variants").getPost.getRequestBody.getContent.get("application/json").getSchema
+        bodySchema.getType shouldBe "object"
+        bodySchema.getExtensions shouldBe null // a map is structural, not a named class — no x-class
+        val valueSchema = bodySchema.getAdditionalProperties match {
+          case s: io.swagger.v3.oas.models.media.Schema[?] => s
+          case other                                       =>
+            fail(s"expected additionalProperties to be a Schema, got: ${Option(other).map(_.getClass.getName).getOrElse("null")}")
+        }
+        valueSchema.getType shouldBe "object"
+        valueSchema.getProperties.keySet.asScala should contain("url")
+        valueSchema.getExtensions.get("x-class") shouldBe "VariantDto" // the value type is still a named class
+      }
+    }
+
     describe("example key deduplication") {
       it("disambiguates duplicate response-example keys with numeric suffixes") {
         val sameDescription = "Some response"

--- a/openapi/src/test/scala/pl/iterators/baklava/openapi/ComprehensiveGoldSpec.scala
+++ b/openapi/src/test/scala/pl/iterators/baklava/openapi/ComprehensiveGoldSpec.scala
@@ -148,6 +148,14 @@ class ComprehensiveGoldSpec
   private val task1 = Task(101L, "Wire up telemetry", Some("Prometheus + Grafana"), done = false, Priority.High)
   private val task2 = Task(102L, "Write docs", None, done = true, Priority.Low)
 
+  private val samplePhotoUpload = PhotoUpload(
+    UUID.fromString("00000000-0000-0000-0000-000000000010"),
+    Map(
+      "thumbnail" -> PhotoVariant("https://cdn.example.com/photo_thumb.png", 64, 64, "png"),
+      "full"      -> PhotoVariant("https://cdn.example.com/photo.png", 1024, 768, "png")
+    )
+  )
+
   // ---------------------------------------------------------------------------
   // API surface
   // ---------------------------------------------------------------------------
@@ -467,12 +475,12 @@ class ComprehensiveGoldSpec
           TextPart("caption", "profile photo")
         ),
         security = bearerAuth("jwt.token.xyz")
-      ).respondsWith[EmptyBody](NoContent, description = "Photo uploaded")
+      ).respondsWith[PhotoUpload](Created, description = "Photo uploaded; rendered variants returned keyed by name")
         .assert { ctx =>
-          nextResponse = emptyResponse(NoContent)
+          nextResponse = jsonResponse(Created, samplePhotoUpload.asJson.noSpaces)
           val response = ctx.performRequest(routes)
           lastRequest.get().entity.contentType.mediaType.value should startWith("multipart/form-data")
-          response.status.intValue() shouldBe 204
+          response.status.intValue() shouldBe 201
         }
     )
   )
@@ -704,4 +712,7 @@ object ComprehensiveGoldSpec {
   case class WebhookPayload(event: String, data: String)
   case class WebhookAck(received: Boolean)
   case class HealthResponse(status: String, uptimeSeconds: Long)
+
+  case class PhotoVariant(url: String, width: Int, height: Int, format: String)
+  case class PhotoUpload(id: UUID, variants: Map[String, PhotoVariant])
 }

--- a/simple/src/main/scala/pl/iterators/baklava/simple/BaklavaDslFormatterSimple.scala
+++ b/simple/src/main/scala/pl/iterators/baklava/simple/BaklavaDslFormatterSimple.scala
@@ -435,8 +435,13 @@ class BaklavaDslFormatterSimple extends BaklavaDslFormatter {
                              .map(Json.fromString): _*
                          )
                        else Json.Null),
-        "additionalProperties" -> (if (baklavaSchema.`type` == SchemaType.ObjectType) Json.fromBoolean(baklavaSchema.additionalProperties)
-                                   else Json.Null),
+        "additionalProperties" -> (
+          if (baklavaSchema.`type` != SchemaType.ObjectType) Json.Null
+          else
+            baklavaSchema.additionalPropertiesSchema
+              .map(j => toJsonSchemaV7(j))
+              .getOrElse(Json.fromBoolean(baklavaSchema.additionalProperties))
+        ),
         "items" -> baklavaSchema.items.map(j => toJsonSchemaV7(j)).getOrElse(Json.Null)
       )
       .deepDropNullValues

--- a/simple/src/test/scala/pl/iterators/baklava/simple/BaklavaDslFormatterSimpleSpec.scala
+++ b/simple/src/test/scala/pl/iterators/baklava/simple/BaklavaDslFormatterSimpleSpec.scala
@@ -41,6 +41,40 @@ class BaklavaDslFormatterSimpleSpec extends AnyFunSpec with Matchers {
       requiredArray(generator.jsonSchemaV7(schemaB)) shouldBe requiredA
     }
 
+    it("renders additionalProperties as the value schema for a string-keyed map (issue #108)") {
+      val variant = BaklavaSchemaSerializable(
+        className = "Variant",
+        `type` = SchemaType.ObjectType,
+        format = None,
+        properties = Map("url" -> stringRequired),
+        items = None,
+        `enum` = None,
+        required = true,
+        additionalProperties = false,
+        default = None,
+        description = None
+      )
+      val mapSchema = BaklavaSchemaSerializable(
+        className = "Map[String, Variant]",
+        `type` = SchemaType.ObjectType,
+        format = None,
+        properties = Map.empty,
+        items = None,
+        `enum` = None,
+        required = true,
+        additionalProperties = true,
+        default = None,
+        description = None,
+        additionalPropertiesSchema = Some(variant)
+      )
+      val json = parser.parse(generator.jsonSchemaV7(mapSchema)).toTry.get.hcursor
+      json.downField("type").as[String].toTry.get shouldBe "object"
+      val ap = json.downField("additionalProperties")
+      ap.downField("type").as[String].toTry.get shouldBe "object"
+      ap.downField("title").as[String].toTry.get shouldBe "Variant"
+      ap.downField("properties").downField("url").downField("type").as[String].toTry.get shouldBe "string"
+    }
+
     it("omits the `required` keyword on non-object schemas (valid JSON Schema)") {
       val schema = objectSchema(Map("a" -> stringRequired, "b" -> stringRequired))
       val json   = parser.parse(generator.jsonSchemaV7(schema)).toTry.get.hcursor

--- a/sttpclient/src/main/scala/pl/iterators/baklava/sttpclient/BaklavaSttpClientGenerator.scala
+++ b/sttpclient/src/main/scala/pl/iterators/baklava/sttpclient/BaklavaSttpClientGenerator.scala
@@ -253,13 +253,15 @@ private[sttpclient] class BaklavaSttpClientGenerator(basePackage: String, calls:
     typedReq || uniformTypedResponseSchema(ec).isDefined
   }
 
-  /** A schema is "typed" (i.e. `asJson[T]`-able) when it resolves to a named case class or a collection of one. Primitive/form/empty
-    * schemas stay untyped so endpoints with non-JSON bodies keep working.
+  /** A schema is "typed" (i.e. `asJson[T]`-able) when it resolves to a named case class, a string-keyed map (`Map[String, V]` — circe has
+    * a built-in codec given one for `V`), or a collection of either. Primitive/form/empty/free-form schemas stay untyped so endpoints with
+    * non-JSON bodies keep working.
     */
   private def isTypedBodySchema(schema: BaklavaSchemaSerializable): Boolean = schema.`type` match {
-    case SchemaType.ObjectType if isNamedCaseClass(schema) => true
-    case SchemaType.ArrayType                              => schema.items.exists(isTypedBodySchema)
-    case _                                                 => false
+    case SchemaType.ObjectType if isNamedCaseClass(schema)                   => true
+    case SchemaType.ObjectType if schema.additionalPropertiesSchema.nonEmpty => true
+    case SchemaType.ArrayType                                                => schema.items.exists(isTypedBodySchema)
+    case _                                                                   => false
   }
 
   /** If *every* 2xx capture on this endpoint has a typed, non-empty body schema, all render to the same Scala type, AND all declare a

--- a/sttpclient/src/main/scala/pl/iterators/baklava/sttpclient/BaklavaSttpClientGenerator.scala
+++ b/sttpclient/src/main/scala/pl/iterators/baklava/sttpclient/BaklavaSttpClientGenerator.scala
@@ -400,8 +400,10 @@ private[sttpclient] class BaklavaSttpClientGenerator(basePackage: String, calls:
       case SchemaType.ObjectType if isNamedCaseClass(schema) =>
         if (!collected.contains(schema.className)) collected(schema.className) = renderCaseClassBody(schema)
         schema.properties.values.foreach(visit)
+        schema.additionalPropertiesSchema.foreach(visit)
       case SchemaType.ObjectType =>
         schema.properties.values.foreach(visit)
+        schema.additionalPropertiesSchema.foreach(visit)
       case SchemaType.ArrayType =>
         schema.items.foreach(visit)
       case _ => ()
@@ -420,16 +422,19 @@ private[sttpclient] class BaklavaSttpClientGenerator(basePackage: String, calls:
     val byClassName = scala.collection.mutable.Map.empty[String, Set[String]].withDefaultValue(Set.empty)
     def findTopLevelRef(s: BaklavaSchemaSerializable): Set[String] = s.`type` match {
       case SchemaType.ObjectType if isNamedCaseClass(s) => Set(s.className)
+      case SchemaType.ObjectType                        => s.additionalPropertiesSchema.toSet.flatMap(findTopLevelRef)
       case SchemaType.ArrayType                         => s.items.toSet.flatMap(findTopLevelRef)
       case _                                            => Set.empty
     }
     def collectFromSchema(schema: BaklavaSchemaSerializable): Unit = schema.`type` match {
       case SchemaType.ObjectType if isNamedCaseClass(schema) =>
-        val refs = schema.properties.values.flatMap(findTopLevelRef).toSet
+        val refs = (schema.properties.values ++ schema.additionalPropertiesSchema).flatMap(findTopLevelRef).toSet
         byClassName.update(schema.className, byClassName(schema.className) ++ refs)
         schema.properties.values.foreach(collectFromSchema)
+        schema.additionalPropertiesSchema.foreach(collectFromSchema)
       case SchemaType.ObjectType =>
         schema.properties.values.foreach(collectFromSchema)
+        schema.additionalPropertiesSchema.foreach(collectFromSchema)
       case SchemaType.ArrayType => schema.items.foreach(collectFromSchema)
       case _                    => ()
     }
@@ -470,10 +475,15 @@ private[sttpclient] class BaklavaSttpClientGenerator(basePackage: String, calls:
     val acc                                       = scala.collection.mutable.Set.empty[String]
     def visit(s: BaklavaSchemaSerializable): Unit = s.`type` match {
       case SchemaType.ObjectType if isNamedCaseClass(s) =>
-        if (acc.add(s.className)) s.properties.values.foreach(visit)
-      case SchemaType.ObjectType => s.properties.values.foreach(visit)
-      case SchemaType.ArrayType  => s.items.foreach(visit)
-      case _                     => ()
+        if (acc.add(s.className)) {
+          s.properties.values.foreach(visit)
+          s.additionalPropertiesSchema.foreach(visit)
+        }
+      case SchemaType.ObjectType =>
+        s.properties.values.foreach(visit)
+        s.additionalPropertiesSchema.foreach(visit)
+      case SchemaType.ArrayType => s.items.foreach(visit)
+      case _                    => ()
     }
     c.request.bodySchema.foreach(visit)
     c.response.bodySchema.foreach(visit)
@@ -529,10 +539,14 @@ private[sttpclient] class BaklavaSttpClientGenerator(basePackage: String, calls:
       val inner = schema.items.map(scalaType).getOrElse("Any")
       s"Seq[$inner]"
     case SchemaType.ObjectType =>
-      // Anonymous / `additionalProperties` objects render as `Map[String, io.circe.Json]` rather than `Map[String, Any]`. circe has
-      // built-in codecs for `Json`, so a typed case class that contains such a field still derives cleanly via `generic.auto._`.
       if (isNamedCaseClass(schema)) scalaSafeIdent(schema.className)
-      else "Map[String, io.circe.Json]"
+      else
+        schema.additionalPropertiesSchema match {
+          case Some(v) => s"Map[String, ${scalaType(v)}]"
+          // Anonymous / open objects render as `Map[String, io.circe.Json]` rather than `Map[String, Any]`. circe has
+          // built-in codecs for `Json`, so a typed case class that contains such a field still derives cleanly via `generic.auto._`.
+          case None => "Map[String, io.circe.Json]"
+        }
   }
 
   private def isSpecialHeader(name: String): Boolean =

--- a/sttpclient/src/test/scala/pl/iterators/baklava/sttpclient/BaklavaSttpClientGeneratorSpec.scala
+++ b/sttpclient/src/test/scala/pl/iterators/baklava/sttpclient/BaklavaSttpClientGeneratorSpec.scala
@@ -272,7 +272,21 @@ class BaklavaSttpClientGeneratorSpec extends AnyFunSpec with Matchers {
       content should include("""sttp.model.Method("PROPFIND")""")
       content should not include ".propfind("
     }
+
+    it("renders a Map[String, V] field as Map[String, V] and emits the value case class (#108)") {
+      cleanSrc()
+      val base = getCall("/images", tag = Some("Images"))
+      val call =
+        base.let(c => c.copy(response = c.response.copy(bodySchema = Some(BaklavaSchemaSerializable(implicitly[Schema[ImageDto]])))))
+      val dtos = generateAndRead("src/main/scala/baklavaclient/images/dtos.scala", Seq(call))
+      dtos should include("final case class ImageDto(")
+      dtos should include("variants: Map[String, Variant]")
+      dtos should include("final case class Variant(")
+    }
   }
+
+  case class Variant(url: String, width: Int)
+  case class ImageDto(id: String, variants: Map[String, Variant])
 
   private def namedObject(name: String, props: Map[String, PrimitiveSchema[?]]): BaklavaSchemaSerializable =
     BaklavaSchemaSerializable(

--- a/sttpclient/src/test/scala/pl/iterators/baklava/sttpclient/BaklavaSttpClientGeneratorSpec.scala
+++ b/sttpclient/src/test/scala/pl/iterators/baklava/sttpclient/BaklavaSttpClientGeneratorSpec.scala
@@ -283,6 +283,25 @@ class BaklavaSttpClientGeneratorSpec extends AnyFunSpec with Matchers {
       dtos should include("variants: Map[String, Variant]")
       dtos should include("final case class Variant(")
     }
+
+    it("treats a top-level Map[String, V] JSON body as a typed Map[String, V], not raw String (#108)") {
+      cleanSrc()
+      val base = getCall("/images", tag = Some("Images"))
+      val call = base.let(c =>
+        c.copy(response =
+          c.response.copy(
+            bodySchema = Some(BaklavaSchemaSerializable(implicitly[Schema[Map[String, Variant]]])),
+            responseContentType = Some("application/json")
+          )
+        )
+      )
+      val endpoints = generateAndRead("src/main/scala/baklavaclient/images/ImagesEndpoints.scala", Seq(call))
+      endpoints should include("Map[String, Variant]")
+      endpoints should not include "Either[String, String]"
+      val dtos =
+        new String(Files.readAllBytes(new File("target/baklava/sttpclient/src/main/scala/baklavaclient/images/dtos.scala").toPath))
+      dtos should include("final case class Variant(")
+    }
   }
 
   case class Variant(url: String, width: Int)

--- a/tsfetch/src/main/scala/pl/iterators/baklava/tsfetch/BaklavaTsFetchGenerator.scala
+++ b/tsfetch/src/main/scala/pl/iterators/baklava/tsfetch/BaklavaTsFetchGenerator.scala
@@ -305,8 +305,10 @@ private[tsfetch] class BaklavaTsFetchGenerator(calls: Seq[BaklavaSerializableCal
       case SchemaType.ObjectType if isNamedInterface(schema) =>
         if (!collected.contains(schema.className)) collected(schema.className) = renderInterfaceBody(schema)
         schema.properties.values.foreach(visit)
+        schema.additionalPropertiesSchema.foreach(visit)
       case SchemaType.ObjectType =>
         schema.properties.values.foreach(visit)
+        schema.additionalPropertiesSchema.foreach(visit)
       case SchemaType.ArrayType =>
         schema.items.foreach(visit)
       case _ => ()
@@ -325,11 +327,13 @@ private[tsfetch] class BaklavaTsFetchGenerator(calls: Seq[BaklavaSerializableCal
     val byClassName = scala.collection.mutable.Map.empty[String, Set[String]].withDefaultValue(Set.empty)
     def collectFromSchema(schema: BaklavaSchemaSerializable): Unit = schema.`type` match {
       case SchemaType.ObjectType if isNamedInterface(schema) =>
-        val refs = schema.properties.values.flatMap(directReferencesIn).toSet
+        val refs = (schema.properties.values ++ schema.additionalPropertiesSchema).flatMap(directReferencesIn).toSet
         byClassName.update(schema.className, byClassName(schema.className) ++ refs)
         schema.properties.values.foreach(collectFromSchema)
+        schema.additionalPropertiesSchema.foreach(collectFromSchema)
       case SchemaType.ObjectType =>
         schema.properties.values.foreach(collectFromSchema)
+        schema.additionalPropertiesSchema.foreach(collectFromSchema)
       case SchemaType.ArrayType => schema.items.foreach(collectFromSchema)
       case _                    => ()
     }
@@ -349,9 +353,9 @@ private[tsfetch] class BaklavaTsFetchGenerator(calls: Seq[BaklavaSerializableCal
     */
   private def directReferencesIn(schema: BaklavaSchemaSerializable): Set[String] = schema.`type` match {
     case SchemaType.ObjectType if isNamedInterface(schema) => Set(schema.className)
-    case SchemaType.ObjectType                             => schema.properties.values.flatMap(directReferencesIn).toSet
-    case SchemaType.ArrayType                              => schema.items.toSet.flatMap(directReferencesIn)
-    case _                                                 => Set.empty
+    case SchemaType.ObjectType => (schema.properties.values ++ schema.additionalPropertiesSchema).flatMap(directReferencesIn).toSet
+    case SchemaType.ArrayType  => schema.items.toSet.flatMap(directReferencesIn)
+    case _                     => Set.empty
   }
 
   private def collectUsageByTag(calls: Seq[BaklavaSerializableCall]): Map[String, Set[String]] = {
@@ -382,10 +386,15 @@ private[tsfetch] class BaklavaTsFetchGenerator(calls: Seq[BaklavaSerializableCal
     val acc                                       = scala.collection.mutable.Set.empty[String]
     def visit(s: BaklavaSchemaSerializable): Unit = s.`type` match {
       case SchemaType.ObjectType if isNamedInterface(s) =>
-        if (acc.add(s.className)) s.properties.values.foreach(visit)
-      case SchemaType.ObjectType => s.properties.values.foreach(visit)
-      case SchemaType.ArrayType  => s.items.foreach(visit)
-      case _                     => ()
+        if (acc.add(s.className)) {
+          s.properties.values.foreach(visit)
+          s.additionalPropertiesSchema.foreach(visit)
+        }
+      case SchemaType.ObjectType =>
+        s.properties.values.foreach(visit)
+        s.additionalPropertiesSchema.foreach(visit)
+      case SchemaType.ArrayType => s.items.foreach(visit)
+      case _                    => ()
     }
     c.request.bodySchema.foreach(visit)
     c.response.bodySchema.foreach(visit)
@@ -473,8 +482,12 @@ private[tsfetch] class BaklavaTsFetchGenerator(calls: Seq[BaklavaSerializableCal
       if (inner.contains(" | ") || inner.contains(" & ")) s"($inner)[]" else s"$inner[]"
     case SchemaType.ObjectType =>
       if (isNamedInterface(schema)) tsSafeIdent(schema.className)
-      else if (schema.properties.isEmpty) "Record<string, unknown>"
-      else renderInterfaceBody(schema)
+      else
+        schema.additionalPropertiesSchema match {
+          case Some(v) if schema.properties.nonEmpty => s"${renderInterfaceBody(schema)} & Record<string, ${tsType(v)}>"
+          case Some(v)                               => s"Record<string, ${tsType(v)}>"
+          case None => if (schema.properties.isEmpty) "Record<string, unknown>" else renderInterfaceBody(schema)
+        }
   }
 
   private def functionName(req: BaklavaRequestContextSerializable): String =

--- a/tsfetch/src/main/scala/pl/iterators/baklava/tsfetch/BaklavaTsFetchGenerator.scala
+++ b/tsfetch/src/main/scala/pl/iterators/baklava/tsfetch/BaklavaTsFetchGenerator.scala
@@ -484,9 +484,8 @@ private[tsfetch] class BaklavaTsFetchGenerator(calls: Seq[BaklavaSerializableCal
       if (isNamedInterface(schema)) tsSafeIdent(schema.className)
       else
         schema.additionalPropertiesSchema match {
-          case Some(v) if schema.properties.nonEmpty => s"${renderInterfaceBody(schema)} & Record<string, ${tsType(v)}>"
-          case Some(v)                               => s"Record<string, ${tsType(v)}>"
-          case None => if (schema.properties.isEmpty) "Record<string, unknown>" else renderInterfaceBody(schema)
+          case Some(v) => s"Record<string, ${tsType(v)}>"
+          case None    => if (schema.properties.isEmpty) "Record<string, unknown>" else renderInterfaceBody(schema)
         }
   }
 

--- a/tsfetch/src/test/scala/pl/iterators/baklava/tsfetch/BaklavaTsFetchGeneratorSpec.scala
+++ b/tsfetch/src/test/scala/pl/iterators/baklava/tsfetch/BaklavaTsFetchGeneratorSpec.scala
@@ -210,7 +210,21 @@ class BaklavaTsFetchGeneratorSpec extends AnyFunSpec with Matchers {
       indexTs should include("""export * from "./projects/endpoints";""")
       indexTs should include("""export * as Users from "./users/types";""")
     }
+
+    it("renders a Map[String, V] field as Record<string, V> and emits the value interface (#108)") {
+      cleanSrc()
+      val base = getCall("/images", tag = Some("Images"))
+      val call =
+        base.let(c => c.copy(response = c.response.copy(bodySchema = Some(BaklavaSchemaSerializable(implicitly[Schema[ImageDto]])))))
+      val typesTs = generateAndRead("src/images/types.ts", Seq(call))
+      typesTs should include("export interface ImageDto")
+      typesTs should include("variants: Record<string, Variant>;")
+      typesTs should include("export interface Variant")
+    }
   }
+
+  case class Variant(url: String, width: Int)
+  case class ImageDto(id: String, variants: Map[String, Variant])
 
   private def namedObject(name: String, props: Map[String, PrimitiveSchema[?]]): BaklavaSchemaSerializable =
     BaklavaSchemaSerializable(

--- a/tsrest/src/main/scala/pl/iterators/baklava/tsrest/BaklavaDslFormatterTsRest.scala
+++ b/tsrest/src/main/scala/pl/iterators/baklava/tsrest/BaklavaDslFormatterTsRest.scala
@@ -313,15 +313,22 @@ class BaklavaDslFormatterTsRest extends BaklavaDslFormatter {
         val item = schema.items.map(zod).getOrElse("z.any()")
         s"z.array($item)$desc"
       case SchemaType.ObjectType =>
-        if (schema.properties.isEmpty) s"z.object({})$desc"
-        else {
-          val props = schema.properties.toSeq
-            .sortBy(_._1)
-            .map { case (k, v) =>
-              s""""${escapeTsDoubleQuoted(k)}": ${zod(v)}${if (!v.required) ".nullish()" else ""}"""
-            }
-            .mkString("\n        ", ",\n        ", "")
-          s"z.object({$props})$desc"
+        val objectBody =
+          if (schema.properties.isEmpty) "z.object({})"
+          else {
+            val props = schema.properties.toSeq
+              .sortBy(_._1)
+              .map { case (k, v) =>
+                s""""${escapeTsDoubleQuoted(k)}": ${zod(v)}${if (!v.required) ".nullish()" else ""}"""
+              }
+              .mkString("\n        ", ",\n        ", "")
+            s"z.object({$props})"
+          }
+        schema.additionalPropertiesSchema match {
+          // A map-like object: all values conform to one schema -> z.record (keys are strings in JSON).
+          case Some(v) if schema.properties.isEmpty => s"z.record(z.string(), ${zod(v)})$desc"
+          case Some(v)                              => s"$objectBody.catchall(${zod(v)})$desc"
+          case None                                 => s"$objectBody$desc"
         }
       case SchemaType.NullType => s"z.null()$desc"
     }

--- a/tsrest/src/test/scala/pl/iterators/baklava/tsrest/BaklavaDslFormatterTsRestSpec.scala
+++ b/tsrest/src/test/scala/pl/iterators/baklava/tsrest/BaklavaDslFormatterTsRestSpec.scala
@@ -84,6 +84,24 @@ class BaklavaDslFormatterTsRestSpec extends AnyFunSpec with Matchers {
     }
   }
 
+  describe("zod(): maps (additionalProperties)") {
+
+    it("renders a map-like object (only a value schema) as z.record(z.string(), <value>)") {
+      generator.zod(objectSchema(Map.empty, additionalPropertiesValueSchema = Some(stringSchema()))) shouldBe
+      "z.record(z.string(), z.string())"
+      val uuid = stringSchema().copy(format = Some("uuid"))
+      generator.zod(objectSchema(Map.empty, additionalPropertiesValueSchema = Some(uuid))) shouldBe
+      "z.record(z.string(), z.string().uuid())"
+    }
+
+    it("renders an object with both declared properties and a value schema using .catchall") {
+      val out = generator.zod(objectSchema(Map("known" -> stringSchema()), additionalPropertiesValueSchema = Some(stringSchema())))
+      out should startWith("z.object({")
+      out should include(""""known": z.string()""")
+      out should endWith(".catchall(z.string())")
+    }
+  }
+
   describe("collapseZodUnion") {
 
     it("preserves non-object variants alongside object variants (regression)") {
@@ -375,7 +393,10 @@ class BaklavaDslFormatterTsRestSpec extends AnyFunSpec with Matchers {
       description = description
     )
 
-  private def objectSchema(properties: Map[String, BaklavaSchemaSerializable]): BaklavaSchemaSerializable =
+  private def objectSchema(
+      properties: Map[String, BaklavaSchemaSerializable],
+      additionalPropertiesValueSchema: Option[BaklavaSchemaSerializable] = None
+  ): BaklavaSchemaSerializable =
     BaklavaSchemaSerializable(
       className = "Object",
       `type` = SchemaType.ObjectType,
@@ -384,8 +405,9 @@ class BaklavaDslFormatterTsRestSpec extends AnyFunSpec with Matchers {
       items = None,
       `enum` = None,
       required = true,
-      additionalProperties = false,
+      additionalProperties = additionalPropertiesValueSchema.isDefined,
       default = None,
-      description = None
+      description = None,
+      additionalPropertiesSchema = additionalPropertiesValueSchema
     )
 }


### PR DESCRIPTION
Fixes #108.

A `Map[K, V]` case-class field derived a `type: object` schema with the value type discarded — OpenAPI emitted bare `type: object` (`additionalProperties: true` at best), and ts-rest emitted `z.object({})`, so consumers couldn't see the value type. sttp-client / ts-fetch / simple-HTML had the same gap. All five schema-rendering generators are fixed here, on the existing OpenAPI 3.0.x output.

## Changes

- **`core`** — `Schema` gains `additionalPropertiesSchema: Option[Schema[?]]` (a concrete `def = None`, so the existing ~12 `Schema` impls don't need touching; transparent wrappers — `withDescription`/`withDefault`/`optionSchema`/`FormOf.schema` — propagate it). `stringMapSchema[T]` is generalised to `mapSchema[K, V](implicit keySchema: Schema[K], valueSchema: Schema[V])`: `type: object`, `additionalPropertiesSchema = Some(valueSchema)`, `className = "Map[<K>, <V>]"`. For `Map[String, V]` the output is byte-identical to before plus the new value schema; for non-string keys (`Map[Enum, V]`, …) the key constraint is dropped (not expressible in OpenAPI 3.0 — JSON object keys are strings regardless), per the issue.
- **`core`** — `BaklavaSchemaSerializable` gains an optional `additionalPropertiesSchema` field (recursive, exactly like the existing `items` field for arrays); it's `None` for everything that isn't a map, so the on-disk call format is unchanged for existing calls (jsoniter's `transientNone` omits it).
- **`openapi`** — `baklavaSchemaToOpenAPISchema` emits `additionalProperties: <value schema>` when present, and skips the `x-class` extension on a *pure* map (`properties.isEmpty && additionalPropertiesSchema.isDefined`) — a map is structural, not a named class, so a component-extracting post-processor lifts the *value* type into `components/schemas`, not `Map[..]`. An object that has both declared properties and a catch-all (never produced by the derivation) is still a named DTO and keeps its `x-class`. Result:
  ```yaml
  variants:
    type: object
    additionalProperties:
      $ref: '#/components/schemas/VariantDto'
  ```
- **`tsrest`** — `zod` emits `z.record(z.string(), <value>)` for a map-like object (and `<obj>.catchall(<value>)` for the rare object-with-known-props-plus-open-extras case) instead of `z.object({})`.
- **`sttpclient`** — `scalaType` renders `Map[String, V]`; `isTypedBodySchema` now also accepts `ObjectType` with `additionalPropertiesSchema.nonEmpty`, so a top-level `Map[String, V]` JSON body is a typed `Map[String, V]` rather than the raw `String` / `Either[String, String]` fallback (circe has a built-in `Encoder/Decoder[Map[String, V]]` given one for `V`). The anonymous/open-object fallback `Map[String, io.circe.Json]` stays for schemas with no value type.
- **`tsfetch`** — `tsType` renders `Record<string, V>` (or `Record<string, V>` for the props-plus-catch-all case — the TS index-signature analog over-constrains declared keys, so it's deliberately *not* `{...} & Record<string, V>`).
- **`sttpclient` + `tsfetch`** — all schema-traversal passes (`collect*`, `findTopLevelRef` / `directReferencesIn`, `referencedClassesInCall`) descend into `additionalPropertiesSchema`, so a named value type reachable only through a map still gets its case class / interface emitted and tag-attributed.
- **`simple`** — the JSON Schema v7 block renders `additionalProperties: <value schema>` when present, else the boolean as before.
- **`docs`** — `Map[K, V]` rows added to the ts-rest (`z.record(z.string(), …)`), sttp-client (`Map[String, V]`), ts-fetch (`Record<string, V>`) type-mapping tables.

No OpenAPI version change — `additionalProperties` with a schema value is valid OpenAPI 3.0.x (inherited from JSON Schema). `patternProperties` (which could express an enum key set) is 3.1-only, so it's not used, as the issue concludes.

## Tests

- `core` `SchemaSpec`: `Map[String, Int]`, `Map[UUID, String]` (non-string key), a case class with a `Map[String, String]` field, `Option[Map[String, Int]]`. `SchemaCompare` shallow-compares `additionalPropertiesSchema`.
- `openapi` `BaklavaDslFormatterOpenAPIWorkerSpec`: a map-typed request body renders `additionalProperties` as the value schema, the map itself is untagged (`getExtensions` null, `getRequired` null), the value type keeps its `x-class`.
- `tsrest` / `sttpclient` / `tsfetch` / `simple` formatter specs: map field in a DTO, top-level map body (sttp-client), and the JSON Schema v7 value-schema rendering (simple).
- **`ComprehensiveGoldSpec`** — the `POST /users/{userId}/photo` upload endpoint now responds `201 Created` with `PhotoUpload(id, variants: Map[String, PhotoVariant])`, so the gold comparison exercises the map end to end across all six output formats (OpenAPI, ts-rest, sttp-client, ts-fetch, postman, simple HTML). Gold files regenerated.

Verified: full `sbt test` on Scala 2.13 — 117 tests, all green; `core/test` on Scala 3 — 33 tests, all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)