### PR TITLE
Extract shared TS/zod rendering into baklava-tscommon

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,11 +75,11 @@ jobs:
 
       - name: Make target directories
         if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main')
-        run: mkdir -p scalatest/target http4sroutes/target http4s/target postman/target openapi/target tsfetch/target pekkohttproutes/target simple/target orpc/target sbtplugin/target sttpclient/target munit/target core/target tsrest/target specs2/target pekkohttp/target project/target
+        run: mkdir -p scalatest/target http4sroutes/target http4s/target postman/target openapi/target tsfetch/target pekkohttproutes/target simple/target orpc/target sbtplugin/target sttpclient/target munit/target core/target tsrest/target specs2/target pekkohttp/target tscommon/target project/target
 
       - name: Compress target directories
         if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main')
-        run: tar cf targets.tar scalatest/target http4sroutes/target http4s/target postman/target openapi/target tsfetch/target pekkohttproutes/target simple/target orpc/target sbtplugin/target sttpclient/target munit/target core/target tsrest/target specs2/target pekkohttp/target project/target
+        run: tar cf targets.tar scalatest/target http4sroutes/target http4s/target postman/target openapi/target tsfetch/target pekkohttproutes/target simple/target orpc/target sbtplugin/target sttpclient/target munit/target core/target tsrest/target specs2/target pekkohttp/target tscommon/target project/target
 
       - name: Upload target directories
         if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main')

--- a/build.sbt
+++ b/build.sbt
@@ -49,6 +49,7 @@ lazy val perScalaVersionTestSources = Test / unmanagedSourceDirectories ++= {
 lazy val baklava =
   tlCrossRootProject.aggregate(
     core,
+    tscommon,
     simple,
     openapi,
     tsrest,
@@ -134,16 +135,23 @@ lazy val postman = project
     )
   )
 
+lazy val tscommon = project
+  .in(file("tscommon"))
+  .dependsOn(core)
+  .settings(
+    name := "baklava-tscommon"
+  )
+
 lazy val tsrest = project
   .in(file("tsrest"))
-  .dependsOn(core, scalatest % "test")
+  .dependsOn(core, tscommon, scalatest % "test")
   .settings(
     name := "baklava-tsrest"
   )
 
 lazy val orpc = project
   .in(file("orpc"))
-  .dependsOn(core, scalatest % "test")
+  .dependsOn(core, tscommon, scalatest % "test")
   .settings(
     name := "baklava-orpc"
   )

--- a/orpc/src/main/scala/pl/iterators/baklava/orpc/BaklavaDslFormatterOrpc.scala
+++ b/orpc/src/main/scala/pl/iterators/baklava/orpc/BaklavaDslFormatterOrpc.scala
@@ -305,8 +305,6 @@ class BaklavaDslFormatterOrpc extends BaklavaDslFormatter {
 
   private def escapeTsSingleQuoted(s: String): String = renderer.escapeTsSingleQuoted(s)
 
-  private def escapeTsDoubleQuoted(s: String): String = renderer.escapeTsDoubleQuoted(s)
-
   private[orpc] def zod(schema: BaklavaSchemaSerializable): String = renderer.zod(schema)
 
   private[orpc] def collapseZodUnion(zods: Seq[String]): String = renderer.collapseZodUnion(zods)

--- a/orpc/src/main/scala/pl/iterators/baklava/orpc/BaklavaDslFormatterOrpc.scala
+++ b/orpc/src/main/scala/pl/iterators/baklava/orpc/BaklavaDslFormatterOrpc.scala
@@ -1,12 +1,15 @@
 package pl.iterators.baklava.orpc
 
 import pl.iterators.baklava.*
+import pl.iterators.baklava.tscommon.{TsNaming, TsZodDialect, TsZodRenderer}
 import sttp.model.Method
 
 import java.io.{File, FileWriter, PrintWriter}
 import scala.util.Using
 
 class BaklavaDslFormatterOrpc extends BaklavaDslFormatter {
+  private val renderer = new TsZodRenderer(TsZodDialect.orpc)
+
   private val dirName                 = "target/baklava/orpc"
   private val sourcesDirName          = "target/baklava/orpc/src"
   private val packageContractJsonPath = s"$dirName/package-contracts.json"
@@ -89,20 +92,7 @@ class BaklavaDslFormatterOrpc extends BaklavaDslFormatter {
       paramsPerCall: Seq[Seq[P]],
       nameOf: P => String,
       schemaOf: P => BaklavaSchemaSerializable
-  ): Option[String] = {
-    val distinctSets = paramsPerCall.distinct
-    if (!distinctSets.exists(_.nonEmpty)) None
-    else {
-      val zds = distinctSets.map { params =>
-        val fields = params.map { p =>
-          val nullishMaybe = if (!schemaOf(p).required) ".nullish()" else ""
-          s"${tsObjectKey(nameOf(p))}: ${zod(schemaOf(p))}$nullishMaybe"
-        }
-        "z.object({" + fields.mkString(", ") + "})"
-      }
-      Some(collapseZodUnion(zds))
-    }
-  }
+  ): Option[String] = renderer.buildParamsZod(paramsPerCall, nameOf, schemaOf)
 
   // A parameter group where every field is optional may be omitted by the caller entirely.
   private[orpc] def isFullyOptionalGroup[P](
@@ -111,48 +101,18 @@ class BaklavaDslFormatterOrpc extends BaklavaDslFormatter {
   ): Boolean =
     paramsPerCall.distinct.forall(_.forall(p => !schemaOf(p).required))
 
-  private val jsIdentifier = "[A-Za-z_$][A-Za-z0-9_$]*".r
-
-  // An object key may be written bare only if it's a valid JS identifier; query/header/path-param
-  // names can be kebab-case (`seller-id`, `X-Forwarded-For`) or start with a digit, which would
-  // otherwise produce uncompilable TypeScript — so quote anything that isn't identifier-shaped.
-  private[orpc] def tsObjectKey(name: String): String =
-    if (jsIdentifier.matches(name)) name
-    else s""""${escapeTsDoubleQuoted(name)}""""
+  private[orpc] def tsObjectKey(name: String): String = renderer.tsObjectKey(name)
 
   // Render one captured `Multipart` value as a body schema: a `z.object` keyed by part name,
   // `FilePart` -> `z.instanceof(File)`, `TextPart` -> `z.string()`. oRPC serializes a body
   // containing `File` values as `multipart/form-data` on the wire. A repeated part name
   // (a multi-value form field) becomes a `z.array(...)`; a name that mixes file and text parts
   // unions the element schemas. Names and element schemas are sorted so output is deterministic.
-  private[orpc] def renderMultipartBody(parts: Seq[BaklavaMultipartPartSerializable]): String = {
-    val fields = parts
-      .groupBy(_.name)
-      .toSeq
-      .sortBy(_._1)
-      .map { case (name, ps) =>
-        val element = collapseZodUnion(ps.map(p => if (p.isFile) "z.instanceof(File)" else "z.string()").sorted)
-        val schema  = if (ps.size > 1) s"z.array($element)" else element
-        s"${tsObjectKey(name)}: $schema"
-      }
-    s"z.object({${fields.mkString(", ")}})"
-  }
+  private[orpc] def renderMultipartBody(parts: Seq[BaklavaMultipartPartSerializable]): String =
+    renderer.renderMultipartBody(parts)
 
-  private[orpc] def contractNameFromSymbolicPath(path: String): String = {
-    val cleaned = path.stripPrefix("/").stripSuffix("/")
-    if (cleaned.isEmpty) "root"
-    else {
-      cleaned
-        .split("/")
-        .map {
-          case p if p.startsWith("{") && p.endsWith("}") => "--" + p.substring(1, p.length - 1)
-          case p if p.startsWith(":")                    => "--" + p.substring(1)
-          case p                                         => p
-        }
-        .mkString("-")
-        .replace(".", "---")
-    }
-  }
+  private[orpc] def contractNameFromSymbolicPath(path: String): String =
+    TsNaming.contractNameFromSymbolicPath(path)
 
   private def createContractForGroup(
       contractName: String,
@@ -339,74 +299,16 @@ class BaklavaDslFormatterOrpc extends BaklavaDslFormatter {
   }
 
   private def isEmptyBodyInstance(schema: BaklavaSchemaSerializable): Boolean =
-    schema.`type` == SchemaType.StringType &&
-      schema.`enum`.exists(enums => enums.contains("EmptyBodyInstance") && enums.size == 1)
+    renderer.isEmptyBodyInstance(schema)
 
-  private def toCamelCase(s: String): String = {
-    val base = s.replaceAll("--", "-")
-    base
-      .split("-")
-      .filter(_.nonEmpty)
-      .zipWithIndex
-      .map { case (s, i) =>
-        if (i == 0) s.toLowerCase else s.capitalize
-      }
-      .mkString
-  }
+  private def toCamelCase(s: String): String = TsNaming.toCamelCase(s)
 
-  private def escapeTsSingleQuoted(s: String): String =
-    s.replace("\\", "\\\\").replace("'", "\\'").replace("\n", "\\n").replace("\r", "\\r")
+  private def escapeTsSingleQuoted(s: String): String = renderer.escapeTsSingleQuoted(s)
 
-  private def escapeTsDoubleQuoted(s: String): String =
-    s.replace("\\", "\\\\").replace("\"", "\\\"").replace("\n", "\\n").replace("\r", "\\r")
+  private def escapeTsDoubleQuoted(s: String): String = renderer.escapeTsDoubleQuoted(s)
 
-  private[orpc] def zod(schema: BaklavaSchemaSerializable): String = {
-    val desc = schema.description.map(d => s""".describe("${escapeTsDoubleQuoted(d)}")""").getOrElse("")
-    schema.`type` match {
-      case SchemaType.StringType =>
-        if (schema.`enum`.exists(_.nonEmpty)) {
-          // Sort for deterministic output; escape for double-quoted TS string context.
-          val e = schema.`enum`.get.toList.sorted.map(s => "\"" + escapeTsDoubleQuoted(s) + "\"").mkString(",")
-          s"z.enum([$e])$desc"
-        } else if (schema.format.contains("email")) s"z.string().email()$desc"
-        else if (schema.format.contains("uuid")) s"z.string().uuid()$desc"
-        // Wire-true: over HTTP a timestamp is an ISO string and OpenAPILink runs no client-side
-        // coercion, so the contract type says string (no JsonifiedClient rewrite needed for dates).
-        else if (schema.format.contains("date-time")) s"z.string().datetime({ offset: true })$desc"
-        else s"z.string()$desc"
-      case SchemaType.BooleanType => s"z.boolean()$desc"
-      case SchemaType.IntegerType => s"z.number().int()$desc"
-      case SchemaType.NumberType  => s"z.number()$desc"
-      case SchemaType.ArrayType   =>
-        val item = schema.items.map(zod).getOrElse("z.any()")
-        s"z.array($item)$desc"
-      case SchemaType.ObjectType =>
-        val objectBody =
-          if (schema.properties.isEmpty) "z.object({})"
-          else {
-            val props = schema.properties.toSeq
-              .sortBy(_._1)
-              .map { case (k, v) =>
-                s""""${escapeTsDoubleQuoted(k)}": ${zod(v)}${if (!v.required) ".nullish()" else ""}"""
-              }
-              .mkString("\n        ", ",\n        ", "")
-            s"z.object({$props})"
-          }
-        schema.additionalPropertiesSchema match {
-          // A map-like object: all values conform to one schema -> z.record (keys are strings in JSON).
-          case Some(v) if schema.properties.isEmpty => s"z.record(z.string(), ${zod(v)})$desc"
-          case Some(v)                              => s"$objectBody.catchall(${zod(v)})$desc"
-          case None                                 => s"$objectBody$desc"
-        }
-      case SchemaType.NullType => s"z.null()$desc"
-    }
-  }
+  private[orpc] def zod(schema: BaklavaSchemaSerializable): String = renderer.zod(schema)
 
-  private[orpc] def collapseZodUnion(zods: Seq[String]): String = {
-    val distinct = zods.distinct
-    if (distinct.isEmpty) "z.void()"
-    else if (distinct.size == 1) distinct.head
-    else s"z.union([${distinct.mkString(", ")}])"
-  }
+  private[orpc] def collapseZodUnion(zods: Seq[String]): String = renderer.collapseZodUnion(zods)
 
 }

--- a/tscommon/src/main/scala/pl/iterators/baklava/tscommon/TsZodRenderer.scala
+++ b/tscommon/src/main/scala/pl/iterators/baklava/tscommon/TsZodRenderer.scala
@@ -1,0 +1,171 @@
+package pl.iterators.baklava.tscommon
+
+import pl.iterators.baklava.*
+
+/** The per-format zod vocabulary. The TypeScript-emitting formatters share one renderer; the few places where their output legitimately
+  * differs are captured here instead of forked code.
+  */
+final case class TsZodDialect(
+    dateTime: String,
+    email: String,
+    uuid: String,
+    filePart: String,
+    emptyUnion: String
+)
+
+object TsZodDialect {
+  val tsRest: TsZodDialect =
+    TsZodDialect(
+      dateTime = "z.coerce.date()",
+      email = "z.string().email()",
+      uuid = "z.string().uuid()",
+      filePart = "z.instanceof(File)",
+      emptyUnion = "z.undefined()"
+    )
+
+  val orpc: TsZodDialect =
+    TsZodDialect(
+      dateTime = "z.string().datetime({ offset: true })",
+      email = "z.string().email()",
+      uuid = "z.string().uuid()",
+      filePart = "z.instanceof(File)",
+      emptyUnion = "z.void()"
+    )
+}
+
+object TsNaming {
+
+  def toCamelCase(s: String): String = {
+    val base = s.replaceAll("--", "-")
+    base
+      .split("-")
+      .filter(_.nonEmpty)
+      .zipWithIndex
+      .map { case (s, i) =>
+        if (i == 0) s.toLowerCase else s.capitalize
+      }
+      .mkString
+  }
+
+  def contractNameFromSymbolicPath(path: String): String = {
+    val cleaned = path.stripPrefix("/").stripSuffix("/")
+    if (cleaned.isEmpty) "root"
+    else {
+      cleaned
+        .split("/")
+        .map {
+          case p if p.startsWith("{") && p.endsWith("}") => "--" + p.substring(1, p.length - 1)
+          case p if p.startsWith(":")                    => "--" + p.substring(1)
+          case p                                         => p
+        }
+        .mkString("-")
+        .replace(".", "---")
+    }
+  }
+}
+
+class TsZodRenderer(dialect: TsZodDialect) {
+
+  private val jsIdentifier = "[A-Za-z_$][A-Za-z0-9_$]*".r
+
+  // An object key may be written bare only if it's a valid JS identifier; query/header/path-param
+  // names can be kebab-case (`seller-id`, `X-Forwarded-For`) or start with a digit, which would
+  // otherwise produce uncompilable TypeScript — so quote anything that isn't identifier-shaped.
+  def tsObjectKey(name: String): String =
+    if (jsIdentifier.matches(name)) name
+    else s""""${escapeTsDoubleQuoted(name)}""""
+
+  def escapeTsSingleQuoted(s: String): String =
+    s.replace("\\", "\\\\").replace("'", "\\'").replace("\n", "\\n").replace("\r", "\\r")
+
+  def escapeTsDoubleQuoted(s: String): String =
+    s.replace("\\", "\\\\").replace("\"", "\\\"").replace("\n", "\\n").replace("\r", "\\r")
+
+  def isEmptyBodyInstance(schema: BaklavaSchemaSerializable): Boolean =
+    schema.`type` == SchemaType.StringType &&
+      schema.`enum`.exists(enums => enums.contains("EmptyBodyInstance") && enums.size == 1)
+
+  def buildParamsZod[P](
+      paramsPerCall: Seq[Seq[P]],
+      nameOf: P => String,
+      schemaOf: P => BaklavaSchemaSerializable
+  ): Option[String] = {
+    val distinctSets = paramsPerCall.distinct
+    if (!distinctSets.exists(_.nonEmpty)) None
+    else {
+      val zds = distinctSets.map { params =>
+        val fields = params.map { p =>
+          val nullishMaybe = if (!schemaOf(p).required) ".nullish()" else ""
+          s"${tsObjectKey(nameOf(p))}: ${zod(schemaOf(p))}$nullishMaybe"
+        }
+        "z.object({" + fields.mkString(", ") + "})"
+      }
+      Some(collapseZodUnion(zds))
+    }
+  }
+
+  // Render one captured `Multipart` value as a body schema: a `z.object` keyed by part name,
+  // `FilePart` -> the dialect's file schema, `TextPart` -> `z.string()`. A repeated part name
+  // (a multi-value form field) becomes a `z.array(...)`; a name that mixes file and text parts
+  // unions the element schemas. Names and element schemas are sorted so output is deterministic.
+  def renderMultipartBody(parts: Seq[BaklavaMultipartPartSerializable]): String = {
+    val fields = parts
+      .groupBy(_.name)
+      .toSeq
+      .sortBy(_._1)
+      .map { case (name, ps) =>
+        val element = collapseZodUnion(ps.map(p => if (p.isFile) dialect.filePart else "z.string()").sorted)
+        val schema  = if (ps.size > 1) s"z.array($element)" else element
+        s"${tsObjectKey(name)}: $schema"
+      }
+    s"z.object({${fields.mkString(", ")}})"
+  }
+
+  def zod(schema: BaklavaSchemaSerializable): String = {
+    val desc = schema.description.map(d => s""".describe("${escapeTsDoubleQuoted(d)}")""").getOrElse("")
+    schema.`type` match {
+      case SchemaType.StringType =>
+        if (schema.`enum`.exists(_.nonEmpty)) {
+          // Sort for deterministic output; escape for double-quoted TS string context.
+          val e = schema.`enum`.get.toList.sorted.map(s => "\"" + escapeTsDoubleQuoted(s) + "\"").mkString(",")
+          s"z.enum([$e])$desc"
+        } else if (schema.format.contains("email")) s"${dialect.email}$desc"
+        else if (schema.format.contains("uuid")) s"${dialect.uuid}$desc"
+        else if (schema.format.contains("date-time")) s"${dialect.dateTime}$desc"
+        else s"z.string()$desc"
+      case SchemaType.BooleanType => s"z.boolean()$desc"
+      case SchemaType.IntegerType => s"z.number().int()$desc"
+      case SchemaType.NumberType  => s"z.number()$desc"
+      case SchemaType.ArrayType   =>
+        val item = schema.items.map(zod).getOrElse("z.any()")
+        s"z.array($item)$desc"
+      case SchemaType.ObjectType =>
+        val objectBody =
+          if (schema.properties.isEmpty) "z.object({})"
+          else {
+            val props = schema.properties.toSeq
+              .sortBy(_._1)
+              .map { case (k, v) =>
+                s""""${escapeTsDoubleQuoted(k)}": ${zod(v)}${if (!v.required) ".nullish()" else ""}"""
+              }
+              .mkString("\n        ", ",\n        ", "")
+            s"z.object({$props})"
+          }
+        schema.additionalPropertiesSchema match {
+          // A map-like object: all values conform to one schema -> z.record (keys are strings in JSON).
+          case Some(v) if schema.properties.isEmpty => s"z.record(z.string(), ${zod(v)})$desc"
+          case Some(v)                              => s"$objectBody.catchall(${zod(v)})$desc"
+          case None                                 => s"$objectBody$desc"
+        }
+      case SchemaType.NullType => s"z.null()$desc"
+    }
+  }
+
+  def collapseZodUnion(zods: Seq[String]): String = {
+    val distinct = zods.distinct
+    if (distinct.isEmpty) dialect.emptyUnion
+    else if (distinct.size == 1) distinct.head
+    else s"z.union([${distinct.mkString(", ")}])"
+  }
+
+}

--- a/tsrest/src/main/scala/pl/iterators/baklava/tsrest/BaklavaDslFormatterTsRest.scala
+++ b/tsrest/src/main/scala/pl/iterators/baklava/tsrest/BaklavaDslFormatterTsRest.scala
@@ -239,8 +239,6 @@ class BaklavaDslFormatterTsRest extends BaklavaDslFormatter {
 
   private def escapeTsSingleQuoted(s: String): String = renderer.escapeTsSingleQuoted(s)
 
-  private def escapeTsDoubleQuoted(s: String): String = renderer.escapeTsDoubleQuoted(s)
-
   private[tsrest] def zod(schema: BaklavaSchemaSerializable): String = renderer.zod(schema)
 
   private[tsrest] def collapseZodUnion(zods: Seq[String]): String = renderer.collapseZodUnion(zods)

--- a/tsrest/src/main/scala/pl/iterators/baklava/tsrest/BaklavaDslFormatterTsRest.scala
+++ b/tsrest/src/main/scala/pl/iterators/baklava/tsrest/BaklavaDslFormatterTsRest.scala
@@ -1,12 +1,15 @@
 package pl.iterators.baklava.tsrest
 
 import pl.iterators.baklava.*
+import pl.iterators.baklava.tscommon.{TsNaming, TsZodDialect, TsZodRenderer}
 import sttp.model.Method
 
 import java.io.{File, FileWriter, PrintWriter}
 import scala.util.Using
 
 class BaklavaDslFormatterTsRest extends BaklavaDslFormatter {
+  private val renderer = new TsZodRenderer(TsZodDialect.tsRest)
+
   private val dirName                 = "target/baklava/tsrest"
   private val sourcesDirName          = "target/baklava/tsrest/src"
   private val packageContractJsonPath = s"$dirName/package-contracts.json"
@@ -87,47 +90,17 @@ class BaklavaDslFormatterTsRest extends BaklavaDslFormatter {
       paramsPerCall: Seq[Seq[P]],
       nameOf: P => String,
       schemaOf: P => BaklavaSchemaSerializable
-  ): Option[String] = {
-    val distinctSets = paramsPerCall.distinct
-    if (!distinctSets.exists(_.nonEmpty)) None
-    else {
-      val zds = distinctSets.map { params =>
-        val fields = params.map { p =>
-          val nullishMaybe = if (!schemaOf(p).required) ".nullish()" else ""
-          s"${tsObjectKey(nameOf(p))}: ${zod(schemaOf(p))}$nullishMaybe"
-        }
-        "z.object({" + fields.mkString(", ") + "})"
-      }
-      Some(collapseZodUnion(zds))
-    }
-  }
+  ): Option[String] = renderer.buildParamsZod(paramsPerCall, nameOf, schemaOf)
 
-  private val jsIdentifier = "[A-Za-z_$][A-Za-z0-9_$]*".r
-
-  // An object key may be written bare only if it's a valid JS identifier; query/header/path-param
-  // names can be kebab-case (`seller-id`, `X-Forwarded-For`) or start with a digit, which would
-  // otherwise produce uncompilable TypeScript — so quote anything that isn't identifier-shaped.
-  private[tsrest] def tsObjectKey(name: String): String =
-    if (jsIdentifier.matches(name)) name
-    else s""""${escapeTsDoubleQuoted(name)}""""
+  private[tsrest] def tsObjectKey(name: String): String = renderer.tsObjectKey(name)
 
   // Render one captured `Multipart` value as a ts-rest body schema (see
   // https://ts-rest.com/docs/core/multi-part): a `z.object` keyed by part name, `FilePart` ->
   // `z.instanceof(File)`, `TextPart` -> `z.string()`. A repeated part name (a multi-value form
   // field) becomes a `z.array(...)`; a name that mixes file and text parts unions the element
   // schemas. Names and element schemas are sorted so output is deterministic.
-  private[tsrest] def renderMultipartBody(parts: Seq[BaklavaMultipartPartSerializable]): String = {
-    val fields = parts
-      .groupBy(_.name)
-      .toSeq
-      .sortBy(_._1)
-      .map { case (name, ps) =>
-        val element = collapseZodUnion(ps.map(p => if (p.isFile) "z.instanceof(File)" else "z.string()").sorted)
-        val schema  = if (ps.size > 1) s"z.array($element)" else element
-        s"${tsObjectKey(name)}: $schema"
-      }
-    s"z.object({${fields.mkString(", ")}})"
-  }
+  private[tsrest] def renderMultipartBody(parts: Seq[BaklavaMultipartPartSerializable]): String =
+    renderer.renderMultipartBody(parts)
 
   /** Convert a Baklava `{name}` placeholder path to the ts-rest `:name` syntax. Non-placeholder braces (i.e. anything containing `/` or
     * nested braces) are left alone. Param names can contain any character except `{`, `}`, or `/` — so hyphens and dots survive.
@@ -135,21 +108,8 @@ class BaklavaDslFormatterTsRest extends BaklavaDslFormatter {
   private[tsrest] def toTsRestPath(symbolicPath: String): String =
     symbolicPath.replaceAll("""\{([^{}/]+)\}""", ":$1")
 
-  private[tsrest] def contractNameFromSymbolicPath(path: String): String = {
-    val cleaned = path.stripPrefix("/").stripSuffix("/")
-    if (cleaned.isEmpty) "root"
-    else {
-      cleaned
-        .split("/")
-        .map {
-          case p if p.startsWith("{") && p.endsWith("}") => "--" + p.substring(1, p.length - 1)
-          case p if p.startsWith(":")                    => "--" + p.substring(1)
-          case p                                         => p
-        }
-        .mkString("-")
-        .replace(".", "---")
-    }
-  }
+  private[tsrest] def contractNameFromSymbolicPath(path: String): String =
+    TsNaming.contractNameFromSymbolicPath(path)
 
   private def createContractForGroup(
       contractName: String,
@@ -273,72 +233,16 @@ class BaklavaDslFormatterTsRest extends BaklavaDslFormatter {
   }
 
   private def isEmptyBodyInstance(schema: BaklavaSchemaSerializable): Boolean =
-    schema.`type` == SchemaType.StringType &&
-      schema.`enum`.exists(enums => enums.contains("EmptyBodyInstance") && enums.size == 1)
+    renderer.isEmptyBodyInstance(schema)
 
-  private def toCamelCase(s: String): String = {
-    val base = s.replaceAll("--", "-")
-    base
-      .split("-")
-      .filter(_.nonEmpty)
-      .zipWithIndex
-      .map { case (s, i) =>
-        if (i == 0) s.toLowerCase else s.capitalize
-      }
-      .mkString
-  }
+  private def toCamelCase(s: String): String = TsNaming.toCamelCase(s)
 
-  private def escapeTsSingleQuoted(s: String): String =
-    s.replace("\\", "\\\\").replace("'", "\\'").replace("\n", "\\n").replace("\r", "\\r")
+  private def escapeTsSingleQuoted(s: String): String = renderer.escapeTsSingleQuoted(s)
 
-  private def escapeTsDoubleQuoted(s: String): String =
-    s.replace("\\", "\\\\").replace("\"", "\\\"").replace("\n", "\\n").replace("\r", "\\r")
+  private def escapeTsDoubleQuoted(s: String): String = renderer.escapeTsDoubleQuoted(s)
 
-  private[tsrest] def zod(schema: BaklavaSchemaSerializable): String = {
-    val desc = schema.description.map(d => s""".describe("${escapeTsDoubleQuoted(d)}")""").getOrElse("")
-    schema.`type` match {
-      case SchemaType.StringType =>
-        if (schema.`enum`.exists(_.nonEmpty)) {
-          // Sort for deterministic output; escape for double-quoted TS string context.
-          val e = schema.`enum`.get.toList.sorted.map(s => "\"" + escapeTsDoubleQuoted(s) + "\"").mkString(",")
-          s"z.enum([$e])$desc"
-        } else if (schema.format.contains("email")) s"z.string().email()$desc"
-        else if (schema.format.contains("uuid")) s"z.string().uuid()$desc"
-        else if (schema.format.contains("date-time")) s"z.coerce.date()$desc"
-        else s"z.string()$desc"
-      case SchemaType.BooleanType => s"z.boolean()$desc"
-      case SchemaType.IntegerType => s"z.number().int()$desc"
-      case SchemaType.NumberType  => s"z.number()$desc"
-      case SchemaType.ArrayType   =>
-        val item = schema.items.map(zod).getOrElse("z.any()")
-        s"z.array($item)$desc"
-      case SchemaType.ObjectType =>
-        val objectBody =
-          if (schema.properties.isEmpty) "z.object({})"
-          else {
-            val props = schema.properties.toSeq
-              .sortBy(_._1)
-              .map { case (k, v) =>
-                s""""${escapeTsDoubleQuoted(k)}": ${zod(v)}${if (!v.required) ".nullish()" else ""}"""
-              }
-              .mkString("\n        ", ",\n        ", "")
-            s"z.object({$props})"
-          }
-        schema.additionalPropertiesSchema match {
-          // A map-like object: all values conform to one schema -> z.record (keys are strings in JSON).
-          case Some(v) if schema.properties.isEmpty => s"z.record(z.string(), ${zod(v)})$desc"
-          case Some(v)                              => s"$objectBody.catchall(${zod(v)})$desc"
-          case None                                 => s"$objectBody$desc"
-        }
-      case SchemaType.NullType => s"z.null()$desc"
-    }
-  }
+  private[tsrest] def zod(schema: BaklavaSchemaSerializable): String = renderer.zod(schema)
 
-  private[tsrest] def collapseZodUnion(zods: Seq[String]): String = {
-    val distinct = zods.distinct
-    if (distinct.isEmpty) "z.undefined()"
-    else if (distinct.size == 1) distinct.head
-    else s"z.union([${distinct.mkString(", ")}])"
-  }
+  private[tsrest] def collapseZodUnion(zods: Seq[String]): String = renderer.collapseZodUnion(zods)
 
 }


### PR DESCRIPTION
Stacked on #113 (base is `feat/orpc-contract-format`; retarget to `main` after #113 merges).

Pure refactor: the tsrest and orpc formatters carried near-identical copies of the zod renderer, union collapsing, TS escaping/quoting, multipart rendering, and naming derivations. New `baklava-tscommon` module hosts `TsZodRenderer`, parameterized by a `TsZodDialect` capturing the only legitimate differences between the two formats (date-time schema, file-part schema, empty-union fallback), plus `TsNaming`.

**Proof of purity:** both formatters delegate, their specs are untouched, and `ComprehensiveGoldSpec` passes **without regenerating** the gold files, on Scala 2.13.18 and 3.3.7 — no output byte changes.

`tsfetch` is deliberately not touched: it renders plain TS types (no zod) and shares nothing of substance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)