### PR TITLE
orpc v3: named schemas, typed error literals, client factory, zod 4, tsc gold gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -223,3 +223,29 @@ jobs:
           apps: scala-steward
 
       - run: scala-steward validate-repo-config .scala-steward.conf
+
+  tsc-gold:
+    name: Compile gold TypeScript output
+    strategy:
+      matrix:
+        os: [ubuntu-22.04]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Checkout current branch (fast)
+        uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: 'tsc: orpc gold'
+        run: |
+          cd openapi/src/test/resources/gold/orpc
+          npm install --no-save typescript@5.9 "zod@^4" "@orpc/contract@^1.14.6" "@orpc/client@^1.14.6" "@orpc/openapi-client@^1.14.6"
+          npx tsc --noEmit --strict --skipLibCheck --target es2022 --module esnext --moduleResolution bundler src/*.ts
+
+      - name: 'tsc: tsrest gold'
+        run: |
+          cd openapi/src/test/resources/gold/tsrest
+          npm install --no-save typescript@5.9 "zod@^3.25" "@ts-rest/core@^3.52"
+          npx tsc --noEmit --strict --skipLibCheck --target es2022 --module esnext --moduleResolution bundler src/*.ts

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,11 +75,11 @@ jobs:
 
       - name: Make target directories
         if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main')
-        run: mkdir -p scalatest/target http4sroutes/target http4s/target postman/target openapi/target tsfetch/target pekkohttproutes/target simple/target orpc/target sbtplugin/target sttpclient/target munit/target core/target tsrest/target specs2/target pekkohttp/target project/target
+        run: mkdir -p scalatest/target http4sroutes/target http4s/target postman/target openapi/target tsfetch/target pekkohttproutes/target simple/target orpc/target sbtplugin/target sttpclient/target munit/target core/target tsrest/target specs2/target pekkohttp/target tscommon/target project/target
 
       - name: Compress target directories
         if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main')
-        run: tar cf targets.tar scalatest/target http4sroutes/target http4s/target postman/target openapi/target tsfetch/target pekkohttproutes/target simple/target orpc/target sbtplugin/target sttpclient/target munit/target core/target tsrest/target specs2/target pekkohttp/target project/target
+        run: tar cf targets.tar scalatest/target http4sroutes/target http4s/target postman/target openapi/target tsfetch/target pekkohttproutes/target simple/target orpc/target sbtplugin/target sttpclient/target munit/target core/target tsrest/target specs2/target pekkohttp/target tscommon/target project/target
 
       - name: Upload target directories
         if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main')

--- a/build.sbt
+++ b/build.sbt
@@ -22,6 +22,36 @@ ThisBuild / publishTo          := {
 ThisBuild / tlMimaPreviousVersions     := Set.empty
 ThisBuild / githubWorkflowJavaVersions := Seq(JavaSpec.temurin("11"))
 
+// The gold files are checked byte-for-byte by ComprehensiveGoldSpec, but byte-identical output
+// can still be uncompilable TypeScript — so CI also compiles the TS-emitting formats' gold
+// output with tsc against their declared peer dependencies.
+ThisBuild / githubWorkflowAddedJobs += WorkflowJob(
+  id = "tsc-gold",
+  name = "Compile gold TypeScript output",
+  scalas = List.empty,
+  javas = List.empty,
+  steps = List(
+    WorkflowStep.Checkout,
+    WorkflowStep.Use(UseRef.Public("actions", "setup-node", "v4"), params = Map("node-version" -> "22")),
+    WorkflowStep.Run(
+      name = Some("tsc: orpc gold"),
+      commands = List(
+        "cd openapi/src/test/resources/gold/orpc",
+        "npm install --no-save typescript@5.9 \"zod@^4\" \"@orpc/contract@^1.14.6\" \"@orpc/client@^1.14.6\" \"@orpc/openapi-client@^1.14.6\"",
+        "npx tsc --noEmit --strict --skipLibCheck --target es2022 --module esnext --moduleResolution bundler src/*.ts"
+      )
+    ),
+    WorkflowStep.Run(
+      name = Some("tsc: tsrest gold"),
+      commands = List(
+        "cd openapi/src/test/resources/gold/tsrest",
+        "npm install --no-save typescript@5.9 \"zod@^3.25\" \"@ts-rest/core@^3.52\"",
+        "npx tsc --noEmit --strict --skipLibCheck --target es2022 --module esnext --moduleResolution bundler src/*.ts"
+      )
+    )
+  )
+)
+
 scalacOptions += "-Xmax-inlines:64"
 // Suppress magnolia macro type parameter shadowing warning (magnolia 1.1.x generates shadowed type params)
 ThisBuild / scalacOptions ++= {

--- a/build.sbt
+++ b/build.sbt
@@ -49,6 +49,7 @@ lazy val perScalaVersionTestSources = Test / unmanagedSourceDirectories ++= {
 lazy val baklava =
   tlCrossRootProject.aggregate(
     core,
+    tscommon,
     simple,
     openapi,
     tsrest,
@@ -134,16 +135,23 @@ lazy val postman = project
     )
   )
 
+lazy val tscommon = project
+  .in(file("tscommon"))
+  .dependsOn(core)
+  .settings(
+    name := "baklava-tscommon"
+  )
+
 lazy val tsrest = project
   .in(file("tsrest"))
-  .dependsOn(core, scalatest % "test")
+  .dependsOn(core, tscommon, scalatest % "test")
   .settings(
     name := "baklava-tsrest"
   )
 
 lazy val orpc = project
   .in(file("orpc"))
-  .dependsOn(core, scalatest % "test")
+  .dependsOn(core, tscommon, scalatest % "test")
   .settings(
     name := "baklava-orpc"
   )

--- a/docs/output-formats.md
+++ b/docs/output-formats.md
@@ -191,12 +191,14 @@ Generates a TypeScript npm package of [oRPC](https://orpc.dev) contracts ([`@orp
 
 ### Generated Files
 
-- `package.json` — npm package with build scripts, peer dependencies on `@orpc/contract` and `zod`
+- `package.json` — npm package with build scripts, peer dependencies on `@orpc/contract`, `@orpc/client`, `@orpc/openapi-client` and `zod` (**v4**)
 - `tsconfig.json` — TypeScript configuration (ES2022, strict mode)
 - `src/contracts.ts` — main exports file aggregating all contracts into one router object
 - `src/{name}.contract.ts` — one contract file per route group
+- `src/schemas.ts` — named, deduplicated schemas: any object schema occurring more than once anywhere in the output is hoisted under a name derived from its Scala case-class name (`AuctionDto` → `auctionDtoSchema`), giving consumers `z.infer`-able named types
+- `src/client.ts` — a ready-made client factory (`createContractsClient(url)`): an `OpenAPILink` whose error decoder lifts the backend's discriminated error bodies into defined `ORPCError`s under the declared codes
 
-File naming follows the same path-derived scheme as the TS-REST format (`/pet/{petId}` → `pet---petId.contract.ts`). The Zod schema mapping table above applies with one deliberate difference: `date-time` fields render as `z.string().datetime({ offset: true })` rather than `z.coerce.date()` — over HTTP a timestamp *is* an ISO string and `OpenAPILink` performs no client-side coercion, so the contract type tells the wire truth.
+File naming follows the same path-derived scheme as the TS-REST format (`/pet/{petId}` → `pet---petId.contract.ts`). Schemas use the **zod 4** vocabulary and deliberately tell the wire truth: `date-time` fields render `z.iso.datetime({ offset: true })` (over HTTP a timestamp *is* an ISO string and `OpenAPILink` performs no client-side coercion), `uuid` → `z.uuid()`, `email` → `z.email()`, multipart file parts → `z.file()`. The rest of the Zod mapping table above applies unchanged.
 
 ### Contract Shape
 
@@ -232,7 +234,7 @@ Mapping decisions:
 
 - **Paths keep `{param}` placeholders** — oRPC's native syntax, no conversion.
 - **`inputStructure: 'detailed'`** throughout: the input object has explicit `params` (path), `query`, `headers`, and `body` groups. A query/header group whose parameters are all optional is emitted `.optional()`, so callers may omit it.
-- **One success shape per procedure** (oRPC's model): the lowest captured 2xx status becomes `successStatus`, all captured 2xx bodies union into `.output(...)`, and a bodyless success (e.g. 204) renders `z.void()`.
+- **Success statuses are preserved truthfully**: with one captured 2xx status it becomes `successStatus` and the body is the compact `.output(...)` (bodyless success renders `z.void()`). With *several* distinct 2xx statuses the procedure switches to `outputStructure: 'detailed'` and the output is a union of `{ status: z.literal(s), body }` objects — which-status is real information the API returns, and a flat body union would destroy it.
 - **Multipart bodies** render as `z.object` fields with `z.instanceof(File)` / `z.string()`; oRPC serializes File-bearing bodies as `multipart/form-data` on the wire.
 - **`tags` and `operationId`** are emitted when captured, so OpenAPI specs generated *from* the contract group and name operations like the original.
 
@@ -249,9 +251,9 @@ Backends documented by baklava don't speak oRPC's own error envelope, but most s
 })
 ```
 
-The discriminator field defaults to `type` and is configurable via the `orpc-error-code-field` config key. Error responses whose body carries no extractable discriminator (bodyless 429s, non-JSON payloads) are left undeclared and surface through oRPC's defaults.
+The discriminator field defaults to `type` and is configurable via the `orpc-error-code-field` config key. Inside each declared error's `data` schema the discriminator property is narrowed to `z.enum(["<the code>"])`, so payloads are self-discriminating. Error responses whose body carries no extractable discriminator (bodyless 429s, non-JSON payloads) are left undeclared and surface through oRPC's defaults.
 
-On the client, pair this with `OpenAPILink`'s [`customErrorResponseBodyDecoder`](https://orpc.dev/docs/openapi/advanced/customizing-error-response) constructing `ORPCError`s whose `code` is the same discriminator value (and `defined: true`) — then [`isDefinedError`](https://orpc.dev/docs/client/error-handling) narrows errors to the declared union, giving statically typed, exhaustively checkable error handling end to end.
+The generated `src/client.ts` completes the loop: its `createContractsClient(url)` wires an `OpenAPILink` with a [`customErrorResponseBodyDecoder`](https://orpc.dev/docs/openapi/advanced/customizing-error-response) that lifts error bodies into `ORPCError`s whose `code` is the same discriminator value (and `defined: true`) — so [`isDefinedError`](https://orpc.dev/docs/client/error-handling) narrows errors to the declared union, giving statically typed, exhaustively checkable error handling end to end, out of the box.
 
 ### Configuration
 
@@ -274,21 +276,24 @@ baklavaGenerateConfigs := Map(
 ### Usage in Frontend
 
 ```typescript
-import { createORPCClient } from "@orpc/client";
-import { OpenAPILink } from "@orpc/openapi-client/fetch";
-import type { JsonifiedClient } from "@orpc/openapi-client";
-import type { ContractRouterClient } from "@orpc/contract";
-import { contracts } from "@company/backend-orpc-contracts";
+import { createContractsClient } from "@company/backend-orpc-contracts/client";
+import { isDefinedError } from "@orpc/client";
 
-const link = new OpenAPILink(contracts, { url: "https://api.example.com" });
-const client: JsonifiedClient<ContractRouterClient<typeof contracts>> =
-  createORPCClient(link);
+const client = createContractsClient("https://api.example.com");
 
-// Full type safety; JsonifiedClient types are wire-true (dates are ISO strings)
+// Full type safety; types are wire-true (dates are ISO strings)
 const user = await client["users---userId"].get({ params: { userId } });
+
+try {
+  await client["users---userId"].get({ params: { userId: missing } });
+} catch (error) {
+  if (isDefinedError(error)) {
+    // narrowed to the declared union; error.data is the typed error body
+  }
+}
 ```
 
-For TanStack Query, wrap the client with `createTanstackQueryUtils` from `@orpc/tanstack-query`.
+For TanStack Query, wrap the client with `createTanstackQueryUtils` from `@orpc/tanstack-query`. To customize the link (auth-aware fetch, headers), pass `{ fetch, headers }` to `createContractsClient`, or build your own `OpenAPILink` — the generated `client.ts` shows the error-decoder recipe.
 
 ## Postman Collection Format
 

--- a/openapi/src/test/resources/gold/orpc/package.json
+++ b/openapi/src/test/resources/gold/orpc/package.json
@@ -15,14 +15,16 @@
     "dist"
   ],
   "scripts": {
-    "build:js": "esbuild src/contracts.ts --bundle --platform=node --target=es2022 --format=esm --tree-shaking=true --external:@orpc/contract --external:zod --outfile=dist/index.js",
+    "build:js": "esbuild src/contracts.ts src/client.ts --bundle --platform=node --target=es2022 --format=esm --tree-shaking=true --external:@orpc/contract --external:@orpc/client --external:@orpc/openapi-client --external:zod --outdir=dist",
     "build:dts": "dts-bundle-generator -o dist/index.d.ts src/contracts.ts",
     "build:package": "cp package-contracts.json dist/package.json && sed -i \"s/VERSION/${VERSION}/g\" dist/package.json",
     "build": "pnpm run build:js && pnpm run build:dts && pnpm run build:package"
   },
   "peerDependencies": {
     "@orpc/contract": "^1.14.6",
-    "zod": "^3.25.32"
+    "@orpc/client": "^1.14.6",
+    "@orpc/openapi-client": "^1.14.6",
+    "zod": "^4.0.0"
   },
   "devDependencies": {
     "esbuild": "^0.25.2",

--- a/openapi/src/test/resources/gold/orpc/src/auth-login.contract.ts
+++ b/openapi/src/test/resources/gold/orpc/src/auth-login.contract.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 import { oc } from "@orpc/contract";
+import { loginFormSchema, userSchema } from "./schemas";
 
 export const authLoginContract = {
   post: oc
@@ -14,22 +15,16 @@ export const authLoginContract = {
       inputStructure: 'detailed'
     })
     .input(z.object({
-      body: z.object({
-        "client_id": z.string(),
-        "grant_type": z.string()})
+      body: loginFormSchema
     }))
     .output(z.object({
         "token": z.string(),
-        "user": z.object({
-        "email": z.string(),
-        "id": z.string().uuid(),
-        "name": z.string(),
-        "role": z.enum(["admin","guest","member"]).describe("User role within the system")})}))
+        "user": userSchema}))
     .errors({
       'unauthorized': {
         status: 401,
         data: z.object({
-        "code": z.string(),
+        "code": z.enum(["unauthorized"]),
         "details": z.array(z.string()).nullish(),
         "message": z.string()})
       }

--- a/openapi/src/test/resources/gold/orpc/src/client.ts
+++ b/openapi/src/test/resources/gold/orpc/src/client.ts
@@ -1,0 +1,39 @@
+import { createORPCClient, ORPCError } from "@orpc/client";
+import type { ContractRouterClient } from "@orpc/contract";
+import type { JsonifiedClient } from "@orpc/openapi-client";
+import { OpenAPILink } from "@orpc/openapi-client/fetch";
+import { contracts } from "./contracts";
+
+const ERROR_CODE_FIELD = "code";
+
+export type ContractsClient = JsonifiedClient<ContractRouterClient<typeof contracts>>;
+
+export interface CreateContractsClientOptions {
+  fetch?: typeof globalThis.fetch;
+  headers?: Record<string, string> | (() => Record<string, string>);
+}
+
+export function createContractsClient(
+  url: string,
+  options: CreateContractsClientOptions = {},
+): ContractsClient {
+  const link = new OpenAPILink(contracts, {
+    url,
+    fetch: options.fetch,
+    headers: options.headers,
+    customErrorResponseBodyDecoder: (body, response) => {
+      if (body === null || typeof body !== "object") return null;
+      const record = body as Record<string, unknown>;
+      const code = record[ERROR_CODE_FIELD];
+      if (typeof code !== "string") return null;
+      const title = record["title"];
+      return new ORPCError(code, {
+        status: response.status,
+        message: typeof title === "string" ? title : code,
+        data: body,
+        defined: true,
+      });
+    },
+  });
+  return createORPCClient(link);
+}

--- a/openapi/src/test/resources/gold/orpc/src/me.contract.ts
+++ b/openapi/src/test/resources/gold/orpc/src/me.contract.ts
@@ -1,5 +1,5 @@
-import { z } from "zod";
 import { oc } from "@orpc/contract";
+import { userSchema } from "./schemas";
 
 export const meContract = {
   get: oc
@@ -13,9 +13,5 @@ export const meContract = {
       successStatus: 200,
       inputStructure: 'detailed'
     })
-    .output(z.object({
-        "email": z.string(),
-        "id": z.string().uuid(),
-        "name": z.string(),
-        "role": z.enum(["admin","guest","member"]).describe("User role within the system")}))
+    .output(userSchema)
 };

--- a/openapi/src/test/resources/gold/orpc/src/projects---projectId-tasks.contract.ts
+++ b/openapi/src/test/resources/gold/orpc/src/projects---projectId-tasks.contract.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 import { oc } from "@orpc/contract";
+import { taskSchema } from "./schemas";
 
 export const projectsProjectIdTasksContract = {
   get: oc
@@ -16,12 +17,7 @@ export const projectsProjectIdTasksContract = {
     .input(z.object({
       params: z.object({projectId: z.number().int()})
     }))
-    .output(z.array(z.object({
-        "description": z.string().nullish(),
-        "done": z.boolean(),
-        "id": z.number().int(),
-        "priority": z.enum(["high","low","medium"]).describe("Task priority level"),
-        "title": z.string()}))),
+    .output(z.array(taskSchema)),
   post: oc
     .route({
       method: 'POST',
@@ -40,10 +36,5 @@ export const projectsProjectIdTasksContract = {
         "priority": z.enum(["high","low","medium"]).describe("Task priority level"),
         "title": z.string()})
     }))
-    .output(z.object({
-        "description": z.string().nullish(),
-        "done": z.boolean(),
-        "id": z.number().int(),
-        "priority": z.enum(["high","low","medium"]).describe("Task priority level"),
-        "title": z.string()}))
+    .output(taskSchema)
 };

--- a/openapi/src/test/resources/gold/orpc/src/projects---projectId.contract.ts
+++ b/openapi/src/test/resources/gold/orpc/src/projects---projectId.contract.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 import { oc } from "@orpc/contract";
+import { projectSchema } from "./schemas";
 
 export const projectsProjectIdContract = {
   patch: oc
@@ -20,11 +21,5 @@ export const projectsProjectIdContract = {
         "name": z.string().nullish(),
         "status": z.enum(["active","archived","draft"]).describe("Lifecycle state of a project").nullish()})
     }))
-    .output(z.object({
-        "createdAt": z.string(),
-        "description": z.string().nullish(),
-        "id": z.number().int(),
-        "name": z.string(),
-        "ownerId": z.string().uuid(),
-        "status": z.enum(["active","archived","draft"]).describe("Lifecycle state of a project")}))
+    .output(projectSchema)
 };

--- a/openapi/src/test/resources/gold/orpc/src/projects.contract.ts
+++ b/openapi/src/test/resources/gold/orpc/src/projects.contract.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 import { oc } from "@orpc/contract";
+import { createProjectRequestSchema, projectSchema } from "./schemas";
 
 export const projectsContract = {
   get: oc
@@ -16,13 +17,7 @@ export const projectsContract = {
     .input(z.object({
       query: z.object({status: z.enum(["active","archived","draft"]).describe("Lifecycle state of a project").nullish()}).optional()
     }))
-    .output(z.array(z.object({
-        "createdAt": z.string(),
-        "description": z.string().nullish(),
-        "id": z.number().int(),
-        "name": z.string(),
-        "ownerId": z.string().uuid(),
-        "status": z.enum(["active","archived","draft"]).describe("Lifecycle state of a project")}))),
+    .output(z.array(projectSchema)),
   post: oc
     .route({
       method: 'POST',
@@ -35,23 +30,14 @@ export const projectsContract = {
       inputStructure: 'detailed'
     })
     .input(z.object({
-      body: z.object({
-        "description": z.string().nullish(),
-        "name": z.string(),
-        "status": z.enum(["active","archived","draft"]).describe("Lifecycle state of a project")})
+      body: createProjectRequestSchema
     }))
-    .output(z.object({
-        "createdAt": z.string(),
-        "description": z.string().nullish(),
-        "id": z.number().int(),
-        "name": z.string(),
-        "ownerId": z.string().uuid(),
-        "status": z.enum(["active","archived","draft"]).describe("Lifecycle state of a project")}))
+    .output(projectSchema)
     .errors({
       'validation': {
         status: 400,
         data: z.object({
-        "code": z.string(),
+        "code": z.enum(["validation"]),
         "details": z.array(z.string()).nullish(),
         "message": z.string()})
       }

--- a/openapi/src/test/resources/gold/orpc/src/schemas.ts
+++ b/openapi/src/test/resources/gold/orpc/src/schemas.ts
@@ -1,0 +1,35 @@
+import { z } from "zod";
+
+export const createProjectRequestSchema = z.object({
+        "description": z.string().nullish(),
+        "name": z.string(),
+        "status": z.enum(["active","archived","draft"]).describe("Lifecycle state of a project")});
+
+export const loginFormSchema = z.object({
+        "client_id": z.string(),
+        "grant_type": z.string()});
+
+export const projectSchema = z.object({
+        "createdAt": z.string(),
+        "description": z.string().nullish(),
+        "id": z.number().int(),
+        "name": z.string(),
+        "ownerId": z.uuid(),
+        "status": z.enum(["active","archived","draft"]).describe("Lifecycle state of a project")});
+
+export const taskSchema = z.object({
+        "description": z.string().nullish(),
+        "done": z.boolean(),
+        "id": z.number().int(),
+        "priority": z.enum(["high","low","medium"]).describe("Task priority level"),
+        "title": z.string()});
+
+export const userSchema = z.object({
+        "email": z.string(),
+        "id": z.uuid(),
+        "name": z.string(),
+        "role": z.enum(["admin","guest","member"]).describe("User role within the system")});
+
+export const webhookPayloadSchema = z.object({
+        "data": z.string(),
+        "event": z.string()});

--- a/openapi/src/test/resources/gold/orpc/src/users---userId-photo.contract.ts
+++ b/openapi/src/test/resources/gold/orpc/src/users---userId-photo.contract.ts
@@ -14,11 +14,11 @@ export const usersUserIdPhotoContract = {
       inputStructure: 'detailed'
     })
     .input(z.object({
-      params: z.object({userId: z.string().uuid()}),
-      body: z.object({caption: z.string(), photo: z.instanceof(File)})
+      params: z.object({userId: z.uuid()}),
+      body: z.object({caption: z.string(), photo: z.file()})
     }))
     .output(z.object({
-        "id": z.string().uuid(),
+        "id": z.uuid(),
         "variants": z.record(z.string(), z.object({
         "format": z.string(),
         "height": z.number().int(),

--- a/openapi/src/test/resources/gold/orpc/src/users---userId.contract.ts
+++ b/openapi/src/test/resources/gold/orpc/src/users---userId.contract.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 import { oc } from "@orpc/contract";
+import { userSchema } from "./schemas";
 
 export const usersUserIdContract = {
   delete: oc
@@ -14,7 +15,7 @@ export const usersUserIdContract = {
       inputStructure: 'detailed'
     })
     .input(z.object({
-      params: z.object({userId: z.string().uuid()})
+      params: z.object({userId: z.uuid()})
     }))
     .output(z.void()),
   get: oc
@@ -29,18 +30,14 @@ export const usersUserIdContract = {
       inputStructure: 'detailed'
     })
     .input(z.object({
-      params: z.object({userId: z.string().uuid()})
+      params: z.object({userId: z.uuid()})
     }))
-    .output(z.object({
-        "email": z.string(),
-        "id": z.string().uuid(),
-        "name": z.string(),
-        "role": z.enum(["admin","guest","member"]).describe("User role within the system")}))
+    .output(userSchema)
     .errors({
       'not_found': {
         status: 404,
         data: z.object({
-        "code": z.string(),
+        "code": z.enum(["not_found"]),
         "details": z.array(z.string()).nullish(),
         "message": z.string()})
       }
@@ -57,14 +54,10 @@ export const usersUserIdContract = {
       inputStructure: 'detailed'
     })
     .input(z.object({
-      params: z.object({userId: z.string().uuid()}),
+      params: z.object({userId: z.uuid()}),
       body: z.object({
         "name": z.string(),
         "role": z.enum(["admin","guest","member"]).describe("User role within the system")})
     }))
-    .output(z.object({
-        "email": z.string(),
-        "id": z.string().uuid(),
-        "name": z.string(),
-        "role": z.enum(["admin","guest","member"]).describe("User role within the system")}))
+    .output(userSchema)
 };

--- a/openapi/src/test/resources/gold/orpc/src/users.contract.ts
+++ b/openapi/src/test/resources/gold/orpc/src/users.contract.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 import { oc } from "@orpc/contract";
+import { userSchema } from "./schemas";
 
 export const usersContract = {
   get: oc
@@ -20,9 +21,5 @@ export const usersContract = {
         "limit": z.number().int(),
         "page": z.number().int(),
         "total": z.number().int(),
-        "users": z.array(z.object({
-        "email": z.string(),
-        "id": z.string().uuid(),
-        "name": z.string(),
-        "role": z.enum(["admin","guest","member"]).describe("User role within the system")}))}))
+        "users": z.array(userSchema)}))
 };

--- a/openapi/src/test/resources/gold/orpc/src/webhooks.contract.ts
+++ b/openapi/src/test/resources/gold/orpc/src/webhooks.contract.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 import { oc } from "@orpc/contract";
+import { webhookPayloadSchema } from "./schemas";
 
 export const webhooksContract = {
   post: oc
@@ -14,9 +15,7 @@ export const webhooksContract = {
       inputStructure: 'detailed'
     })
     .input(z.object({
-      body: z.object({
-        "data": z.string(),
-        "event": z.string()})
+      body: webhookPayloadSchema
     }))
     .output(z.union([z.object({
         "received": z.boolean()}), z.string()]))

--- a/orpc/src/main/scala/pl/iterators/baklava/orpc/BaklavaDslFormatterOrpc.scala
+++ b/orpc/src/main/scala/pl/iterators/baklava/orpc/BaklavaDslFormatterOrpc.scala
@@ -305,8 +305,6 @@ class BaklavaDslFormatterOrpc extends BaklavaDslFormatter {
 
   private def escapeTsSingleQuoted(s: String): String = renderer.escapeTsSingleQuoted(s)
 
-  private def escapeTsDoubleQuoted(s: String): String = renderer.escapeTsDoubleQuoted(s)
-
   private[orpc] def zod(schema: BaklavaSchemaSerializable): String = renderer.zod(schema)
 
   private[orpc] def collapseZodUnion(zods: Seq[String]): String = renderer.collapseZodUnion(zods)

--- a/orpc/src/main/scala/pl/iterators/baklava/orpc/BaklavaDslFormatterOrpc.scala
+++ b/orpc/src/main/scala/pl/iterators/baklava/orpc/BaklavaDslFormatterOrpc.scala
@@ -1,12 +1,15 @@
 package pl.iterators.baklava.orpc
 
 import pl.iterators.baklava.*
+import pl.iterators.baklava.tscommon.{TsNaming, TsZodDialect, TsZodRenderer}
 import sttp.model.Method
 
 import java.io.{File, FileWriter, PrintWriter}
 import scala.util.Using
 
 class BaklavaDslFormatterOrpc extends BaklavaDslFormatter {
+  private val renderer = new TsZodRenderer(TsZodDialect.orpc)
+
   private val dirName                 = "target/baklava/orpc"
   private val sourcesDirName          = "target/baklava/orpc/src"
   private val packageContractJsonPath = s"$dirName/package-contracts.json"
@@ -89,20 +92,7 @@ class BaklavaDslFormatterOrpc extends BaklavaDslFormatter {
       paramsPerCall: Seq[Seq[P]],
       nameOf: P => String,
       schemaOf: P => BaklavaSchemaSerializable
-  ): Option[String] = {
-    val distinctSets = paramsPerCall.distinct
-    if (!distinctSets.exists(_.nonEmpty)) None
-    else {
-      val zds = distinctSets.map { params =>
-        val fields = params.map { p =>
-          val nullishMaybe = if (!schemaOf(p).required) ".nullish()" else ""
-          s"${tsObjectKey(nameOf(p))}: ${zod(schemaOf(p))}$nullishMaybe"
-        }
-        "z.object({" + fields.mkString(", ") + "})"
-      }
-      Some(collapseZodUnion(zds))
-    }
-  }
+  ): Option[String] = renderer.buildParamsZod(paramsPerCall, nameOf, schemaOf)
 
   // A parameter group where every field is optional may be omitted by the caller entirely.
   private[orpc] def isFullyOptionalGroup[P](
@@ -111,48 +101,18 @@ class BaklavaDslFormatterOrpc extends BaklavaDslFormatter {
   ): Boolean =
     paramsPerCall.distinct.forall(_.forall(p => !schemaOf(p).required))
 
-  private val jsIdentifier = "[A-Za-z_$][A-Za-z0-9_$]*".r
-
-  // An object key may be written bare only if it's a valid JS identifier; query/header/path-param
-  // names can be kebab-case (`seller-id`, `X-Forwarded-For`) or start with a digit, which would
-  // otherwise produce uncompilable TypeScript — so quote anything that isn't identifier-shaped.
-  private[orpc] def tsObjectKey(name: String): String =
-    if (jsIdentifier.matches(name)) name
-    else s""""${escapeTsDoubleQuoted(name)}""""
+  private[orpc] def tsObjectKey(name: String): String = renderer.tsObjectKey(name)
 
   // Render one captured `Multipart` value as a body schema: a `z.object` keyed by part name,
   // `FilePart` -> `z.instanceof(File)`, `TextPart` -> `z.string()`. oRPC serializes a body
   // containing `File` values as `multipart/form-data` on the wire. A repeated part name
   // (a multi-value form field) becomes a `z.array(...)`; a name that mixes file and text parts
   // unions the element schemas. Names and element schemas are sorted so output is deterministic.
-  private[orpc] def renderMultipartBody(parts: Seq[BaklavaMultipartPartSerializable]): String = {
-    val fields = parts
-      .groupBy(_.name)
-      .toSeq
-      .sortBy(_._1)
-      .map { case (name, ps) =>
-        val element = collapseZodUnion(ps.map(p => if (p.isFile) "z.instanceof(File)" else "z.string()").sorted)
-        val schema  = if (ps.size > 1) s"z.array($element)" else element
-        s"${tsObjectKey(name)}: $schema"
-      }
-    s"z.object({${fields.mkString(", ")}})"
-  }
+  private[orpc] def renderMultipartBody(parts: Seq[BaklavaMultipartPartSerializable]): String =
+    renderer.renderMultipartBody(parts)
 
-  private[orpc] def contractNameFromSymbolicPath(path: String): String = {
-    val cleaned = path.stripPrefix("/").stripSuffix("/")
-    if (cleaned.isEmpty) "root"
-    else {
-      cleaned
-        .split("/")
-        .map {
-          case p if p.startsWith("{") && p.endsWith("}") => "--" + p.substring(1, p.length - 1)
-          case p if p.startsWith(":")                    => "--" + p.substring(1)
-          case p                                         => p
-        }
-        .mkString("-")
-        .replace(".", "---")
-    }
-  }
+  private[orpc] def contractNameFromSymbolicPath(path: String): String =
+    TsNaming.contractNameFromSymbolicPath(path)
 
   private def createContractForGroup(
       contractName: String,
@@ -339,74 +299,16 @@ class BaklavaDslFormatterOrpc extends BaklavaDslFormatter {
   }
 
   private def isEmptyBodyInstance(schema: BaklavaSchemaSerializable): Boolean =
-    schema.`type` == SchemaType.StringType &&
-      schema.`enum`.exists(enums => enums.contains("EmptyBodyInstance") && enums.size == 1)
+    renderer.isEmptyBodyInstance(schema)
 
-  private def toCamelCase(s: String): String = {
-    val base = s.replaceAll("--", "-")
-    base
-      .split("-")
-      .filter(_.nonEmpty)
-      .zipWithIndex
-      .map { case (s, i) =>
-        if (i == 0) s.toLowerCase else s.capitalize
-      }
-      .mkString
-  }
+  private def toCamelCase(s: String): String = TsNaming.toCamelCase(s)
 
-  private def escapeTsSingleQuoted(s: String): String =
-    s.replace("\\", "\\\\").replace("'", "\\'").replace("\n", "\\n").replace("\r", "\\r")
+  private def escapeTsSingleQuoted(s: String): String = renderer.escapeTsSingleQuoted(s)
 
-  private def escapeTsDoubleQuoted(s: String): String =
-    s.replace("\\", "\\\\").replace("\"", "\\\"").replace("\n", "\\n").replace("\r", "\\r")
+  private def escapeTsDoubleQuoted(s: String): String = renderer.escapeTsDoubleQuoted(s)
 
-  private[orpc] def zod(schema: BaklavaSchemaSerializable): String = {
-    val desc = schema.description.map(d => s""".describe("${escapeTsDoubleQuoted(d)}")""").getOrElse("")
-    schema.`type` match {
-      case SchemaType.StringType =>
-        if (schema.`enum`.exists(_.nonEmpty)) {
-          // Sort for deterministic output; escape for double-quoted TS string context.
-          val e = schema.`enum`.get.toList.sorted.map(s => "\"" + escapeTsDoubleQuoted(s) + "\"").mkString(",")
-          s"z.enum([$e])$desc"
-        } else if (schema.format.contains("email")) s"z.string().email()$desc"
-        else if (schema.format.contains("uuid")) s"z.string().uuid()$desc"
-        // Wire-true: over HTTP a timestamp is an ISO string and OpenAPILink runs no client-side
-        // coercion, so the contract type says string (no JsonifiedClient rewrite needed for dates).
-        else if (schema.format.contains("date-time")) s"z.string().datetime({ offset: true })$desc"
-        else s"z.string()$desc"
-      case SchemaType.BooleanType => s"z.boolean()$desc"
-      case SchemaType.IntegerType => s"z.number().int()$desc"
-      case SchemaType.NumberType  => s"z.number()$desc"
-      case SchemaType.ArrayType   =>
-        val item = schema.items.map(zod).getOrElse("z.any()")
-        s"z.array($item)$desc"
-      case SchemaType.ObjectType =>
-        val objectBody =
-          if (schema.properties.isEmpty) "z.object({})"
-          else {
-            val props = schema.properties.toSeq
-              .sortBy(_._1)
-              .map { case (k, v) =>
-                s""""${escapeTsDoubleQuoted(k)}": ${zod(v)}${if (!v.required) ".nullish()" else ""}"""
-              }
-              .mkString("\n        ", ",\n        ", "")
-            s"z.object({$props})"
-          }
-        schema.additionalPropertiesSchema match {
-          // A map-like object: all values conform to one schema -> z.record (keys are strings in JSON).
-          case Some(v) if schema.properties.isEmpty => s"z.record(z.string(), ${zod(v)})$desc"
-          case Some(v)                              => s"$objectBody.catchall(${zod(v)})$desc"
-          case None                                 => s"$objectBody$desc"
-        }
-      case SchemaType.NullType => s"z.null()$desc"
-    }
-  }
+  private[orpc] def zod(schema: BaklavaSchemaSerializable): String = renderer.zod(schema)
 
-  private[orpc] def collapseZodUnion(zods: Seq[String]): String = {
-    val distinct = zods.distinct
-    if (distinct.isEmpty) "z.void()"
-    else if (distinct.size == 1) distinct.head
-    else s"z.union([${distinct.mkString(", ")}])"
-  }
+  private[orpc] def collapseZodUnion(zods: Seq[String]): String = renderer.collapseZodUnion(zods)
 
 }

--- a/orpc/src/main/scala/pl/iterators/baklava/orpc/BaklavaDslFormatterOrpc.scala
+++ b/orpc/src/main/scala/pl/iterators/baklava/orpc/BaklavaDslFormatterOrpc.scala
@@ -440,13 +440,4 @@ class BaklavaDslFormatterOrpc extends BaklavaDslFormatter {
 
   private def toCamelCase(s: String): String = TsNaming.toCamelCase(s)
 
-  <<<<<<< HEAD
-    =======
-  private def escapeTsSingleQuoted(s: String): String = renderer.escapeTsSingleQuoted(s)
-
-  private[orpc] def zod(schema: BaklavaSchemaSerializable): String = renderer.zod(schema)
-
-  private[orpc] def collapseZodUnion(zods: Seq[String]): String = renderer.collapseZodUnion(zods)
-
-  >>>>>>> feat / tscommon
 }

--- a/orpc/src/main/scala/pl/iterators/baklava/orpc/BaklavaDslFormatterOrpc.scala
+++ b/orpc/src/main/scala/pl/iterators/baklava/orpc/BaklavaDslFormatterOrpc.scala
@@ -8,13 +8,15 @@ import java.io.{File, FileWriter, PrintWriter}
 import scala.util.Using
 
 class BaklavaDslFormatterOrpc extends BaklavaDslFormatter {
-  private val renderer = new TsZodRenderer(TsZodDialect.orpc)
+  private val plainRenderer = new TsZodRenderer(TsZodDialect.orpc)
 
   private val dirName                 = "target/baklava/orpc"
   private val sourcesDirName          = "target/baklava/orpc/src"
   private val packageContractJsonPath = s"$dirName/package-contracts.json"
 
   private val contractTsPath = s"$sourcesDirName/contracts.ts"
+  private val schemasTsPath  = s"$sourcesDirName/schemas.ts"
+  private val clientTsPath   = s"$sourcesDirName/client.ts"
 
   override def create(config: Map[String, String], calls: Seq[BaklavaSerializableCall]): Unit = {
     // Create all target directories upfront so downstream writes don't depend on ordering.
@@ -52,9 +54,12 @@ class BaklavaDslFormatterOrpc extends BaklavaDslFormatter {
 
     val errorCodeField = config.getOrElse("orpc-error-code-field", "type")
 
+    val refs = buildSchemaRefs(callsGroupedBySymbolicPathIntoContractName.flatMap(_._2), errorCodeField)
+    if (refs.nonEmpty) writeSchemasFile(refs)
+
     val contractNames = callsGroupedBySymbolicPathIntoContractName
       .map { case (name, endpoints) =>
-        val constName = createContractForGroup(name, endpoints, errorCodeField)
+        val constName = createContractForGroup(name, endpoints, errorCodeField, refs)
         (name, constName)
       }
 
@@ -83,6 +88,8 @@ class BaklavaDslFormatterOrpc extends BaklavaDslFormatter {
          |};
          |\n""".stripMargin
     )
+
+    writeTo(clientTsPath, BaklavaOrpcFiles.clientTs(errorCodeField))
   }
 
   private def writeTo(path: String, content: String): Unit =
@@ -91,7 +98,8 @@ class BaklavaDslFormatterOrpc extends BaklavaDslFormatter {
   private[orpc] def buildParamsZod[P](
       paramsPerCall: Seq[Seq[P]],
       nameOf: P => String,
-      schemaOf: P => BaklavaSchemaSerializable
+      schemaOf: P => BaklavaSchemaSerializable,
+      renderer: TsZodRenderer
   ): Option[String] = renderer.buildParamsZod(paramsPerCall, nameOf, schemaOf)
 
   // A parameter group where every field is optional may be omitted by the caller entirely.
@@ -101,39 +109,121 @@ class BaklavaDslFormatterOrpc extends BaklavaDslFormatter {
   ): Boolean =
     paramsPerCall.distinct.forall(_.forall(p => !schemaOf(p).required))
 
-  private[orpc] def tsObjectKey(name: String): String = renderer.tsObjectKey(name)
-
-  // Render one captured `Multipart` value as a body schema: a `z.object` keyed by part name,
-  // `FilePart` -> `z.instanceof(File)`, `TextPart` -> `z.string()`. oRPC serializes a body
-  // containing `File` values as `multipart/form-data` on the wire. A repeated part name
-  // (a multi-value form field) becomes a `z.array(...)`; a name that mixes file and text parts
-  // unions the element schemas. Names and element schemas are sorted so output is deterministic.
-  private[orpc] def renderMultipartBody(parts: Seq[BaklavaMultipartPartSerializable]): String =
-    renderer.renderMultipartBody(parts)
-
   private[orpc] def contractNameFromSymbolicPath(path: String): String =
     TsNaming.contractNameFromSymbolicPath(path)
+
+  // --- Named, deduplicated schemas -----------------------------------------------------------
+
+  private def collectObjectNodes(schema: BaklavaSchemaSerializable): Seq[BaklavaSchemaSerializable] = {
+    val children =
+      schema.properties.values.toSeq ++ schema.items.toSeq ++ schema.additionalPropertiesSchema.toSeq
+    val self =
+      if (schema.`type` == SchemaType.ObjectType && schema.properties.nonEmpty) Seq(schema) else Seq.empty
+    self ++ children.flatMap(collectObjectNodes)
+  }
+
+  private val genericClassNames = Set("Object", "Map", "Option", "Some", "None", "List", "Seq", "Vector", "Set")
+
+  private def hoistableName(schema: BaklavaSchemaSerializable): Option[String] =
+    Option(schema.className)
+      .filter(_.matches("[A-Za-z][A-Za-z0-9]*"))
+      .filterNot(genericClassNames.contains)
+      .map(n => n.head.toLower.toString + n.tail + "Schema")
+
+  // Object schemas that occur more than once anywhere in the rendered output (bodies, success
+  // outputs, declared error data — including nested occurrences) are hoisted into schemas.ts
+  // under a name derived from the captured case-class name. Same derived name with a different
+  // structure gets a deterministic hash suffix.
+  private[orpc] def buildSchemaRefs(
+      endpoints: Seq[((Option[Method], String), Seq[BaklavaSerializableCall])],
+      errorCodeField: String
+  ): Map[BaklavaSchemaSerializable, String] = {
+    val calls    = endpoints.flatMap(_._2)
+    val rendered =
+      calls.flatMap(_.request.bodySchema).filterNot(plainRenderer.isEmptyBodyInstance) ++
+        calls.filter(c => c.response.status.code >= 200 && c.response.status.code < 300).flatMap(_.response.bodySchema) ++
+        endpoints.flatMap { case (_, epCalls) => errorDataSchemas(epCalls, errorCodeField).map(_._2).flatten }
+    val counts    = rendered.flatMap(collectObjectNodes).groupBy(identity).view.mapValues(_.size).toMap
+    val hoistable = counts.collect { case (schema, n) if n >= 2 => schema }.toSeq
+    val named     = hoistable.flatMap(s => hoistableName(s).map(_ -> s))
+    named
+      .groupBy(_._1)
+      .toSeq
+      .flatMap { case (name, entries) =>
+        val schemas = entries.map(_._2).sortBy(plainRenderer.zodDefinition)
+        schemas.zipWithIndex.map { case (schema, i) =>
+          val finalName = if (i == 0) name else s"$name${f"${plainRenderer.zodDefinition(schema).hashCode.abs}%x".take(4)}"
+          schema -> finalName
+        }
+      }
+      .toMap
+  }
+
+  private def writeSchemasFile(refs: Map[BaklavaSchemaSerializable, String]): Unit = {
+    // Definition order: dependencies before dependents (a hoisted schema may reference another).
+    val remaining = scala.collection.mutable.LinkedHashMap.from(refs.toSeq.sortBy(_._2))
+    val ordered   = scala.collection.mutable.ListBuffer.empty[(BaklavaSchemaSerializable, String)]
+    while (remaining.nonEmpty) {
+      val ready = remaining.filter { case (schema, _) =>
+        collectObjectNodes(schema).filterNot(_ == schema).forall(n => !remaining.contains(n))
+      }
+      ready.foreach { entry =>
+        ordered += entry
+        remaining -= entry._1
+      }
+    }
+    val renderer = rendererWith(refs, _ => ())
+    val defs     = ordered
+      .map { case (schema, name) =>
+        val body = renderer.zodDefinition(schema)
+        s"export const $name = $body;"
+      }
+      .mkString("\n\n")
+    writeTo(schemasTsPath, "import { z } from \"zod\";\n\n" + defs + "\n")
+  }
+
+  private def rendererWith(
+      refs: Map[BaklavaSchemaSerializable, String],
+      record: String => Unit
+  ): TsZodRenderer =
+    new TsZodRenderer(
+      TsZodDialect.orpc,
+      schema =>
+        refs.get(schema).map { name =>
+          record(name)
+          name
+        }
+    )
+
+  // --- Contract emission ---------------------------------------------------------------------
 
   private def createContractForGroup(
       contractName: String,
       endpointsWithCalls: Seq[((Option[Method], String), Seq[BaklavaSerializableCall])],
-      errorCodeField: String
+      errorCodeField: String,
+      refs: Map[BaklavaSchemaSerializable, String]
   ): String = {
     val contractConstName = toCamelCase(contractName) + "Contract"
     val sortedEndpoints   = endpointsWithCalls.sortBy(_._1._1.map(_.toString).getOrElse(""))
 
+    val usedRefs = scala.collection.mutable.SortedSet.empty[String]
+    val renderer = rendererWith(refs, usedRefs += _)
+
     val code =
       s"""export const $contractConstName = {
-         |${sortedEndpoints.map(e => createContractForEndpoint(e, errorCodeField)).mkString(",\n")}
+         |${sortedEndpoints.map(e => createContractForEndpoint(e, errorCodeField, renderer)).mkString(",\n")}
          |};
          |""".stripMargin
 
+    val schemaImport =
+      if (usedRefs.isEmpty) ""
+      else s"import { ${usedRefs.mkString(", ")} } from \"./schemas\";\n"
     // A contract with no schemas at all (e.g. a bare WebSocket upgrade route) uses no `z` —
     // strict consumer tsconfigs (noUnusedLocals) reject the unused import.
     val zImport = if (code.contains("z.")) "import { z } from \"zod\";\n" else ""
     writeTo(
       s"$sourcesDirName/$contractName.contract.ts",
-      zImport + "import { oc } from \"@orpc/contract\";\n\n" + code
+      zImport + "import { oc } from \"@orpc/contract\";\n" + schemaImport + "\n" + code
     )
     contractConstName
   }
@@ -144,7 +234,8 @@ class BaklavaDslFormatterOrpc extends BaklavaDslFormatter {
   // Contract endpoint generator: one `<method>: oc.route({...}).input(...).output(...).errors({...})` entry.
   private[orpc] def createContractForEndpoint(
       endpoint: ((Option[Method], String), Seq[BaklavaSerializableCall]),
-      errorCodeField: String = "type"
+      errorCodeField: String = "type",
+      renderer: TsZodRenderer = plainRenderer
   ): String = {
     val ((httpMethodOpt, _), calls) = endpoint
     require(
@@ -155,18 +246,20 @@ class BaklavaDslFormatterOrpc extends BaklavaDslFormatter {
 
     val firstCall   = calls.head
     val req         = firstCall.request
-    val summary     = escapeTsSingleQuoted(calls.flatMap(_.request.operationSummary).distinct.mkString(" / "))
-    val description = escapeTsSingleQuoted(calls.flatMap(_.request.operationDescription).distinct.mkString("\n\n"))
+    val summary     = renderer.escapeTsSingleQuoted(calls.flatMap(_.request.operationSummary).distinct.mkString(" / "))
+    val description = renderer.escapeTsSingleQuoted(calls.flatMap(_.request.operationDescription).distinct.mkString("\n\n"))
 
     val pathParamsZodOpt = buildParamsZod(
       calls.map(_.request.pathParametersSeq),
       (p: BaklavaPathParamSerializable) => p.name,
-      (p: BaklavaPathParamSerializable) => p.schema
+      (p: BaklavaPathParamSerializable) => p.schema,
+      renderer
     )
     val queryParamsZodOpt = buildParamsZod(
       calls.map(_.request.queryParametersSeq),
       (p: BaklavaQueryParamSerializable) => p.name,
-      (p: BaklavaQueryParamSerializable) => p.schema
+      (p: BaklavaQueryParamSerializable) => p.schema,
+      renderer
     )
     val queryOptionalSuffix =
       if (isFullyOptionalGroup(calls.map(_.request.queryParametersSeq), (p: BaklavaQueryParamSerializable) => p.schema)) ".optional()"
@@ -174,7 +267,8 @@ class BaklavaDslFormatterOrpc extends BaklavaDslFormatter {
     val headersZodOpt = buildParamsZod(
       calls.map(_.request.headersSeq),
       (h: BaklavaHeaderSerializable) => h.name,
-      (h: BaklavaHeaderSerializable) => h.schema
+      (h: BaklavaHeaderSerializable) => h.schema,
+      renderer
     )
     val headersOptionalSuffix =
       if (isFullyOptionalGroup(calls.map(_.request.headersSeq), (h: BaklavaHeaderSerializable) => h.schema)) ".optional()"
@@ -190,26 +284,50 @@ class BaklavaDslFormatterOrpc extends BaklavaDslFormatter {
         (-names.size, names.sorted.mkString(","))
       }
     val bodyZodOpt =
-      if (multipartPartSets.nonEmpty) Some(collapseZodUnion(multipartPartSets.map(renderMultipartBody)))
+      if (multipartPartSets.nonEmpty) Some(renderer.collapseZodUnion(multipartPartSets.map(renderer.renderMultipartBody)))
       else {
         val bodySchemas    = calls.flatMap(_.request.bodySchema).distinct
-        val notEmptyBodies = bodySchemas.filterNot(isEmptyBodyInstance)
-        if (notEmptyBodies.isEmpty) None else Some(collapseZodUnion(notEmptyBodies.map(zod)))
+        val notEmptyBodies = bodySchemas.filterNot(renderer.isEmptyBodyInstance)
+        if (notEmptyBodies.isEmpty) None else Some(renderer.collapseZodUnion(notEmptyBodies.map(renderer.zod)))
       }
 
     // --- Success responses ---
-    // oRPC models one success shape per procedure: the lowest captured 2xx becomes
-    // `successStatus`, all captured 2xx bodies union into `.output(...)`. Bodyless
-    // success (204 etc.) renders as `z.void()`.
-    val succStatuses     = successStatuses(calls)
-    val successStatusOpt = succStatuses.headOption
-    val successCalls     = calls.filter(c => c.response.status.code >= 200 && c.response.status.code < 300)
-    val successSchemas   = successCalls.map(_.response.bodySchema).distinct
-    val outputZods       = successSchemas.map {
-      case Some(schema) => zod(schema)
-      case None         => "z.void()"
-    }.distinct
-    val outputZodOpt = if (successCalls.isEmpty) None else Some(collapseZodUnion(outputZods))
+    // One captured 2xx status: compact output (the plain body), `successStatus` on the route.
+    // Several distinct 2xx statuses: `outputStructure: 'detailed'` with a union of
+    // `{ status: z.literal(s), body }` objects — which-status is real information the API
+    // returns, and a compact body union would destroy it.
+    val succStatuses = successStatuses(calls)
+    val successCalls = calls.filter(c => c.response.status.code >= 200 && c.response.status.code < 300)
+
+    val (successStatusOpt, outputStructure, outputZodOpt) =
+      if (succStatuses.size <= 1) {
+        val outputZods = successCalls
+          .map(_.response.bodySchema)
+          .distinct
+          .map {
+            case Some(schema) => renderer.zod(schema)
+            case None         => "z.void()"
+          }
+          .distinct
+        (succStatuses.headOption, "detailed-input-only", if (successCalls.isEmpty) None else Some(renderer.collapseZodUnion(outputZods)))
+      } else {
+        val variants = succStatuses.map { status =>
+          val schemas = successCalls.filter(_.response.status.code == status).flatMap(_.response.bodySchema).distinct
+          if (schemas.isEmpty) s"z.object({status: z.literal($status)})"
+          else s"z.object({status: z.literal($status), body: ${renderer.collapseZodUnion(schemas.map(renderer.zod))}})"
+        }
+        (None, "detailed", Some(s"z.union([${variants.mkString(", ")}])"))
+      }
+
+    val tags         = calls.flatMap(_.request.operationTags).distinct.sorted
+    val tagsFieldOpt =
+      if (tags.isEmpty) None
+      else Some(s"      tags: [${tags.map(t => s"'${renderer.escapeTsSingleQuoted(t)}'").mkString(", ")}]")
+    val operationIdOpt = calls
+      .flatMap(_.request.operationId)
+      .distinct
+      .headOption
+      .map(id => s"      operationId: '${renderer.escapeTsSingleQuoted(id)}'")
 
     val inputGroups = List(
       pathParamsZodOpt.map(z => s"      params: $z"),
@@ -217,16 +335,6 @@ class BaklavaDslFormatterOrpc extends BaklavaDslFormatter {
       headersZodOpt.map(z => s"      headers: $z$headersOptionalSuffix"),
       bodyZodOpt.map(z => s"      body: $z")
     ).flatten
-
-    val tags         = calls.flatMap(_.request.operationTags).distinct.sorted
-    val tagsFieldOpt =
-      if (tags.isEmpty) None
-      else Some(s"      tags: [${tags.map(t => s"'${escapeTsSingleQuoted(t)}'").mkString(", ")}]")
-    val operationIdOpt = calls
-      .flatMap(_.request.operationId)
-      .distinct
-      .headOption
-      .map(id => s"      operationId: '${escapeTsSingleQuoted(id)}'")
 
     val routeFields = List(
       Some(s"      method: '${httpMethod.toUpperCase()}'"),
@@ -236,7 +344,8 @@ class BaklavaDslFormatterOrpc extends BaklavaDslFormatter {
       operationIdOpt,
       tagsFieldOpt,
       successStatusOpt.map(s => s"      successStatus: $s"),
-      Some(s"      inputStructure: 'detailed'")
+      Some(s"      inputStructure: 'detailed'"),
+      if (outputStructure == "detailed") Some(s"      outputStructure: 'detailed'") else None
     ).flatten
 
     val lines = List(
@@ -253,7 +362,7 @@ class BaklavaDslFormatterOrpc extends BaklavaDslFormatter {
            s"    }))"
          )) ++
       outputZodOpt.toList.map(z => s"    .output($z)") ++
-      declaredErrors(calls, errorCodeField).toList
+      declaredErrors(calls, errorCodeField, renderer).toList
 
     lines.mkString("\n")
   }
@@ -271,44 +380,67 @@ class BaklavaDslFormatterOrpc extends BaklavaDslFormatter {
     regex.findFirstMatchIn(bodyString).map(_.group(1))
   }
 
+  // The discriminator property in a declared error's data schema is narrowed to the literal
+  // code it was declared under, so payloads are self-discriminating (`switch` on it gets
+  // exhaustiveness checking, not just narrowing by error code).
+  private def withLiteralDiscriminator(
+      schema: BaklavaSchemaSerializable,
+      field: String,
+      code: String
+  ): BaklavaSchemaSerializable =
+    schema.properties.get(field) match {
+      case Some(prop) if prop.`type` == SchemaType.StringType && prop.`enum`.isEmpty =>
+        schema.copy(properties = schema.properties.updated(field, prop.copy(format = None, `enum` = Some(Set(code)))))
+      case _ => schema
+    }
+
+  private def errorDataSchemas(
+      calls: Seq[BaklavaSerializableCall],
+      errorCodeField: String
+  ): Seq[(String, Seq[BaklavaSchemaSerializable])] = {
+    val errorCalls = calls.filter(c => c.response.status.code < 200 || c.response.status.code >= 300)
+    errorCalls
+      .flatMap(c => extractErrorCode(c.response.bodyString, errorCodeField).map(_ -> c))
+      .groupBy(_._1)
+      .toList
+      .sortBy(_._1)
+      .map { case (code, codeCalls) =>
+        code -> codeCalls.flatMap(_._2.response.bodySchema).distinct.map(withLiteralDiscriminator(_, errorCodeField, code))
+      }
+  }
+
   // Declared, typed errors: non-2xx calls grouped by the code extracted from their example
   // bodies. Codes match what a client-side error decoder should set on its ORPCErrors, making
   // `isDefinedError` narrowing work end to end. Calls whose body carries no extractable code
   // (bodyless 429s, non-JSON payloads) are left undeclared and surface via oRPC's defaults.
   private[orpc] def declaredErrors(
       calls: Seq[BaklavaSerializableCall],
-      errorCodeField: String
+      errorCodeField: String,
+      renderer: TsZodRenderer = plainRenderer
   ): Option[String] = {
     val errorCalls = calls.filter(c => c.response.status.code < 200 || c.response.status.code >= 300)
-    val byCode     = errorCalls
-      .flatMap(c => extractErrorCode(c.response.bodyString, errorCodeField).map(_ -> c))
-      .groupBy(_._1)
-      .toList
-      .sortBy(_._1)
+    val byCode     = errorDataSchemas(calls, errorCodeField)
     if (byCode.isEmpty) None
     else {
-      val entries = byCode.map { case (code, codeCalls) =>
-        val status  = codeCalls.map(_._2.response.status.code).min
-        val schemas = codeCalls.flatMap(_._2.response.bodySchema).distinct.map(zod)
-        val dataOpt = if (schemas.isEmpty) None else Some(s"        data: ${collapseZodUnion(schemas)}")
+      val statusByCode = errorCalls
+        .flatMap(c => extractErrorCode(c.response.bodyString, errorCodeField).map(_ -> c.response.status.code))
+        .groupBy(_._1)
+        .view
+        .mapValues(_.map(_._2).min)
+        .toMap
+      val entries = byCode.map { case (code, schemas) =>
+        val status  = statusByCode(code)
+        val dataOpt = if (schemas.isEmpty) None else Some(s"        data: ${renderer.collapseZodUnion(schemas.map(renderer.zod))}")
         val fields  = List(Some(s"        status: $status"), dataOpt).flatten.mkString(",\n")
-        s"      '${escapeTsSingleQuoted(code)}': {\n$fields\n      }"
+        s"      '${renderer.escapeTsSingleQuoted(code)}': {\n$fields\n      }"
       }
       Some(s"    .errors({\n${entries.mkString(",\n")}\n    })")
     }
   }
 
   private def isEmptyBodyInstance(schema: BaklavaSchemaSerializable): Boolean =
-    renderer.isEmptyBodyInstance(schema)
+    plainRenderer.isEmptyBodyInstance(schema)
 
   private def toCamelCase(s: String): String = TsNaming.toCamelCase(s)
-
-  private def escapeTsSingleQuoted(s: String): String = renderer.escapeTsSingleQuoted(s)
-
-  private def escapeTsDoubleQuoted(s: String): String = renderer.escapeTsDoubleQuoted(s)
-
-  private[orpc] def zod(schema: BaklavaSchemaSerializable): String = renderer.zod(schema)
-
-  private[orpc] def collapseZodUnion(zods: Seq[String]): String = renderer.collapseZodUnion(zods)
 
 }

--- a/orpc/src/main/scala/pl/iterators/baklava/orpc/BaklavaOrpcFiles.scala
+++ b/orpc/src/main/scala/pl/iterators/baklava/orpc/BaklavaOrpcFiles.scala
@@ -22,14 +22,16 @@ object BaklavaOrpcFiles {
         |    "dist"
         |  ],
         |  "scripts": {
-        |    "build:js": "esbuild src/contracts.ts --bundle --platform=node --target=es2022 --format=esm --tree-shaking=true --external:@orpc/contract --external:zod --outfile=dist/index.js",
+        |    "build:js": "esbuild src/contracts.ts src/client.ts --bundle --platform=node --target=es2022 --format=esm --tree-shaking=true --external:@orpc/contract --external:@orpc/client --external:@orpc/openapi-client --external:zod --outdir=dist",
         |    "build:dts": "dts-bundle-generator -o dist/index.d.ts src/contracts.ts",
         |    "build:package": "cp package-contracts.json dist/package.json && sed -i \"s/VERSION/${VERSION}/g\" dist/package.json",
         |    "build": "pnpm run build:js && pnpm run build:dts && pnpm run build:package"
         |  },
         |  "peerDependencies": {
         |    "@orpc/contract": "^1.14.6",
-        |    "zod": "^3.25.32"
+        |    "@orpc/client": "^1.14.6",
+        |    "@orpc/openapi-client": "^1.14.6",
+        |    "zod": "^4.0.0"
         |  },
         |  "devDependencies": {
         |    "esbuild": "^0.25.2",
@@ -61,4 +63,50 @@ object BaklavaOrpcFiles {
     )
   )
 
+  /** The ready-made client: an OpenAPILink whose error decoder lifts the backend's discriminated error bodies (RFC 9457 `type` by default)
+    * into defined ORPCErrors under the same codes the contracts declare via `.errors(...)` — so `isDefinedError` narrows end to end.
+    */
+  def clientTs(errorCodeField: String): String = {
+    val field = errorCodeField.replace("\\", "\\\\").replace("\"", "\\\"")
+    s"""import { createORPCClient, ORPCError } from "@orpc/client";
+       |import type { ContractRouterClient } from "@orpc/contract";
+       |import type { JsonifiedClient } from "@orpc/openapi-client";
+       |import { OpenAPILink } from "@orpc/openapi-client/fetch";
+       |import { contracts } from "./contracts";
+       |
+       |const ERROR_CODE_FIELD = "$field";
+       |
+       |export type ContractsClient = JsonifiedClient<ContractRouterClient<typeof contracts>>;
+       |
+       |export interface CreateContractsClientOptions {
+       |  fetch?: typeof globalThis.fetch;
+       |  headers?: Record<string, string> | (() => Record<string, string>);
+       |}
+       |
+       |export function createContractsClient(
+       |  url: string,
+       |  options: CreateContractsClientOptions = {},
+       |): ContractsClient {
+       |  const link = new OpenAPILink(contracts, {
+       |    url,
+       |    fetch: options.fetch,
+       |    headers: options.headers,
+       |    customErrorResponseBodyDecoder: (body, response) => {
+       |      if (body === null || typeof body !== "object") return null;
+       |      const record = body as Record<string, unknown>;
+       |      const code = record[ERROR_CODE_FIELD];
+       |      if (typeof code !== "string") return null;
+       |      const title = record["title"];
+       |      return new ORPCError(code, {
+       |        status: response.status,
+       |        message: typeof title === "string" ? title : code,
+       |        data: body,
+       |        defined: true,
+       |      });
+       |    },
+       |  });
+       |  return createORPCClient(link);
+       |}
+       |""".stripMargin
+  }
 }

--- a/orpc/src/test/scala/pl/iterators/baklava/orpc/BaklavaDslFormatterOrpcSpec.scala
+++ b/orpc/src/test/scala/pl/iterators/baklava/orpc/BaklavaDslFormatterOrpcSpec.scala
@@ -3,11 +3,13 @@ package pl.iterators.baklava.orpc
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
 import pl.iterators.baklava.*
+import pl.iterators.baklava.tscommon.{TsZodDialect, TsZodRenderer}
 import sttp.model.{Method, StatusCode}
 
 class BaklavaDslFormatterOrpcSpec extends AnyFunSpec with Matchers {
 
-  private val generator = new BaklavaDslFormatterOrpc
+  private val generator   = new BaklavaDslFormatterOrpc
+  private val zodRenderer = new TsZodRenderer(TsZodDialect.orpc)
 
   describe("createContractForEndpoint(): route block") {
 
@@ -34,14 +36,17 @@ class BaklavaDslFormatterOrpcSpec extends AnyFunSpec with Matchers {
       (entry should not).include(":user-id")
     }
 
-    it("picks the lowest captured 2xx as successStatus") {
+    it("switches to detailed output when several distinct 2xx statuses were captured") {
       val entry = endpoint(
         "POST",
         "/v1/things",
-        call("/v1/things", method = "POST", status = 201),
+        call("/v1/things", method = "POST", status = 201, responseSchema = Some(objectSchema(Map("id" -> stringSchema())))),
         call("/v1/things", method = "POST", status = 200)
       )
-      entry should include("      successStatus: 200")
+      (entry should not).include("successStatus")
+      entry should include("      outputStructure: 'detailed'")
+      entry should include("z.object({status: z.literal(200)})")
+      entry should include("z.object({status: z.literal(201), body: z.object(")
     }
   }
 
@@ -53,7 +58,7 @@ class BaklavaDslFormatterOrpcSpec extends AnyFunSpec with Matchers {
         "/v1/auctions/{auctionId}",
         call("/v1/auctions/{auctionId}", pathParams = Seq("auctionId" -> uuidSchema(required = true)))
       )
-      entry should include("      params: z.object({auctionId: z.string().uuid()})")
+      entry should include("      params: z.object({auctionId: z.uuid()})")
     }
 
     it("marks a query group .optional() when every parameter is optional") {
@@ -81,7 +86,7 @@ class BaklavaDslFormatterOrpcSpec extends AnyFunSpec with Matchers {
         "/v1/auctions",
         call("/v1/auctions", queryParams = Seq("after-id" -> uuidSchema(required = false)))
       )
-      entry should include(""""after-id": z.string().uuid().nullish()""")
+      entry should include(""""after-id": z.uuid().nullish()""")
     }
 
     it("omits .input entirely when there are no parameters and no body") {
@@ -110,7 +115,7 @@ class BaklavaDslFormatterOrpcSpec extends AnyFunSpec with Matchers {
           multipartParts = Some(Seq(BaklavaMultipartPartSerializable("file", isFile = true)))
         )
       )
-      entry should include("      body: z.object({file: z.instanceof(File)})")
+      entry should include("      body: z.object({file: z.file()})")
     }
   }
 
@@ -235,6 +240,81 @@ class BaklavaDslFormatterOrpcSpec extends AnyFunSpec with Matchers {
     }
   }
 
+  describe("literal discriminators in declared error data") {
+
+    it("narrows the discriminator property to the declared code") {
+      val problem = objectSchema(Map("type" -> stringSchema(), "title" -> stringSchema()))
+      val entry   = endpoint(
+        "POST",
+        "/v1/things",
+        call("/v1/things", method = "POST", status = 201),
+        call(
+          "/v1/things",
+          method = "POST",
+          status = 409,
+          responseSchema = Some(problem),
+          responseBodyString = """{"type":"result:bid-too-low","status":409}"""
+        )
+      )
+      entry should include(""""type": z.enum(["result:bid-too-low"])""")
+      (entry should not).include(""""type": z.string()""")
+    }
+  }
+
+  describe("named schema hoisting (buildSchemaRefs)") {
+
+    def dtoSchema(marker: String): BaklavaSchemaSerializable =
+      objectSchema(Map(marker -> stringSchema())).copy(className = "AuctionDto")
+
+    it("hoists an object schema that occurs more than once, named from its className") {
+      val dto  = dtoSchema("a")
+      val refs = generator.buildSchemaRefs(
+        Seq(
+          ((Some(Method("GET")), "/a"), Seq(call("/a", responseSchema = Some(dto)))),
+          ((Some(Method("GET")), "/b"), Seq(call("/b", responseSchema = Some(dto))))
+        ),
+        "type"
+      )
+      refs.get(dto) shouldBe Some("auctionDtoSchema")
+    }
+
+    it("leaves single-occurrence schemas inline") {
+      val dto  = dtoSchema("a")
+      val refs = generator.buildSchemaRefs(
+        Seq(((Some(Method("GET")), "/a"), Seq(call("/a", responseSchema = Some(dto))))),
+        "type"
+      )
+      refs shouldBe empty
+    }
+
+    it("suffixes colliding names deterministically") {
+      val dto1 = dtoSchema("a")
+      val dto2 = dtoSchema("b")
+      val refs = generator.buildSchemaRefs(
+        Seq(
+          ((Some(Method("GET")), "/a"), Seq(call("/a", responseSchema = Some(dto1)), call("/a", responseSchema = Some(dto1)))),
+          ((Some(Method("GET")), "/b"), Seq(call("/b", responseSchema = Some(dto2)), call("/b", responseSchema = Some(dto2))))
+        ),
+        "type"
+      )
+      refs.values.toSet should have size 2
+      refs.values.count(_ == "auctionDtoSchema") shouldBe 1
+      refs.values.filterNot(_ == "auctionDtoSchema").head should startWith("auctionDtoSchema")
+    }
+
+    it("skips schemas with generic classNames") {
+      val obj  = objectSchema(Map("a" -> stringSchema()))
+      val refs = generator.buildSchemaRefs(
+        Seq(
+          ((Some(Method("GET")), "/a"), Seq(call("/a", responseSchema = Some(obj)))),
+          ((Some(Method("GET")), "/b"), Seq(call("/b", responseSchema = Some(obj))))
+        ),
+        "type"
+      )
+      refs shouldBe empty
+    }
+  }
+
   describe("route metadata") {
 
     it("emits sorted distinct tags and the operationId") {
@@ -266,14 +346,14 @@ class BaklavaDslFormatterOrpcSpec extends AnyFunSpec with Matchers {
   describe("zod()") {
 
     it("renders uuid, date-time and enum formats") {
-      generator.zod(uuidSchema(required = true)) shouldBe "z.string().uuid()"
-      generator.zod(stringSchema(format = Some("date-time"))) shouldBe "z.string().datetime({ offset: true })"
-      generator.zod(stringSchema(enumValues = Some(Set("b", "a")))) shouldBe """z.enum(["a","b"])"""
+      zodRenderer.zod(uuidSchema(required = true)) shouldBe "z.uuid()"
+      zodRenderer.zod(stringSchema(format = Some("date-time"))) shouldBe "z.iso.datetime({ offset: true })"
+      zodRenderer.zod(stringSchema(enumValues = Some(Set("b", "a")))) shouldBe """z.enum(["a","b"])"""
     }
 
     it("sorts object properties for deterministic output") {
-      val a = generator.zod(objectSchema(Map("b" -> stringSchema(), "a" -> stringSchema())))
-      val b = generator.zod(objectSchema(Map("a" -> stringSchema(), "b" -> stringSchema())))
+      val a = zodRenderer.zod(objectSchema(Map("b" -> stringSchema(), "a" -> stringSchema())))
+      val b = zodRenderer.zod(objectSchema(Map("a" -> stringSchema(), "b" -> stringSchema())))
       a shouldBe b
     }
   }

--- a/tscommon/src/main/scala/pl/iterators/baklava/tscommon/TsZodRenderer.scala
+++ b/tscommon/src/main/scala/pl/iterators/baklava/tscommon/TsZodRenderer.scala
@@ -1,0 +1,171 @@
+package pl.iterators.baklava.tscommon
+
+import pl.iterators.baklava.*
+
+/** The per-format zod vocabulary. The TypeScript-emitting formatters share one renderer; the few places where their output legitimately
+  * differs are captured here instead of forked code.
+  */
+final case class TsZodDialect(
+    dateTime: String,
+    email: String,
+    uuid: String,
+    filePart: String,
+    emptyUnion: String
+)
+
+object TsZodDialect {
+  val tsRest: TsZodDialect =
+    TsZodDialect(
+      dateTime = "z.coerce.date()",
+      email = "z.string().email()",
+      uuid = "z.string().uuid()",
+      filePart = "z.instanceof(File)",
+      emptyUnion = "z.undefined()"
+    )
+
+  val orpc: TsZodDialect =
+    TsZodDialect(
+      dateTime = "z.string().datetime({ offset: true })",
+      email = "z.string().email()",
+      uuid = "z.string().uuid()",
+      filePart = "z.instanceof(File)",
+      emptyUnion = "z.void()"
+    )
+}
+
+object TsNaming {
+
+  def toCamelCase(s: String): String = {
+    val base = s.replaceAll("--", "-")
+    base
+      .split("-")
+      .filter(_.nonEmpty)
+      .zipWithIndex
+      .map { case (s, i) =>
+        if (i == 0) s.toLowerCase else s.capitalize
+      }
+      .mkString
+  }
+
+  def contractNameFromSymbolicPath(path: String): String = {
+    val cleaned = path.stripPrefix("/").stripSuffix("/")
+    if (cleaned.isEmpty) "root"
+    else {
+      cleaned
+        .split("/")
+        .map {
+          case p if p.startsWith("{") && p.endsWith("}") => "--" + p.substring(1, p.length - 1)
+          case p if p.startsWith(":")                    => "--" + p.substring(1)
+          case p                                         => p
+        }
+        .mkString("-")
+        .replace(".", "---")
+    }
+  }
+}
+
+class TsZodRenderer(dialect: TsZodDialect) {
+
+  private val jsIdentifier = "[A-Za-z_$][A-Za-z0-9_$]*".r
+
+  // An object key may be written bare only if it's a valid JS identifier; query/header/path-param
+  // names can be kebab-case (`seller-id`, `X-Forwarded-For`) or start with a digit, which would
+  // otherwise produce uncompilable TypeScript — so quote anything that isn't identifier-shaped.
+  def tsObjectKey(name: String): String =
+    if (jsIdentifier.matches(name)) name
+    else s""""${escapeTsDoubleQuoted(name)}""""
+
+  def escapeTsSingleQuoted(s: String): String =
+    s.replace("\\", "\\\\").replace("'", "\\'").replace("\n", "\\n").replace("\r", "\\r")
+
+  def escapeTsDoubleQuoted(s: String): String =
+    s.replace("\\", "\\\\").replace("\"", "\\\"").replace("\n", "\\n").replace("\r", "\\r")
+
+  def isEmptyBodyInstance(schema: BaklavaSchemaSerializable): Boolean =
+    schema.`type` == SchemaType.StringType &&
+      schema.`enum`.exists(enums => enums.contains("EmptyBodyInstance") && enums.size == 1)
+
+  def buildParamsZod[P](
+      paramsPerCall: Seq[Seq[P]],
+      nameOf: P => String,
+      schemaOf: P => BaklavaSchemaSerializable
+  ): Option[String] = {
+    val distinctSets = paramsPerCall.distinct
+    if (!distinctSets.exists(_.nonEmpty)) None
+    else {
+      val zds = distinctSets.map { params =>
+        val fields = params.map { p =>
+          val nullishMaybe = if (!schemaOf(p).required) ".nullish()" else ""
+          s"${tsObjectKey(nameOf(p))}: ${zod(schemaOf(p))}$nullishMaybe"
+        }
+        "z.object({" + fields.mkString(", ") + "})"
+      }
+      Some(collapseZodUnion(zds))
+    }
+  }
+
+  // Render one captured `Multipart` value as a body schema: a `z.object` keyed by part name,
+  // `FilePart` -> the dialect's file schema, `TextPart` -> `z.string()`. A repeated part name
+  // (a multi-value form field) becomes a `z.array(...)`; a name that mixes file and text parts
+  // unions the element schemas. Names and element schemas are sorted so output is deterministic.
+  def renderMultipartBody(parts: Seq[BaklavaMultipartPartSerializable]): String = {
+    val fields = parts
+      .groupBy(_.name)
+      .toSeq
+      .sortBy(_._1)
+      .map { case (name, ps) =>
+        val element = collapseZodUnion(ps.map(p => if (p.isFile) dialect.filePart else "z.string()").sorted)
+        val schema  = if (ps.size > 1) s"z.array($element)" else element
+        s"${tsObjectKey(name)}: $schema"
+      }
+    s"z.object({${fields.mkString(", ")}})"
+  }
+
+  def zod(schema: BaklavaSchemaSerializable): String = {
+    val desc = schema.description.map(d => s""".describe("${escapeTsDoubleQuoted(d)}")""").getOrElse("")
+    schema.`type` match {
+      case SchemaType.StringType =>
+        if (schema.`enum`.exists(_.nonEmpty)) {
+          // Sort for deterministic output; escape for double-quoted TS string context.
+          val e = schema.`enum`.get.toList.sorted.map(s => "\"" + escapeTsDoubleQuoted(s) + "\"").mkString(",")
+          s"z.enum([$e])$desc"
+        } else if (schema.format.contains("email")) s"${dialect.email}$desc"
+        else if (schema.format.contains("uuid")) s"${dialect.uuid}$desc"
+        else if (schema.format.contains("date-time")) s"${dialect.dateTime}$desc"
+        else s"z.string()$desc"
+      case SchemaType.BooleanType => s"z.boolean()$desc"
+      case SchemaType.IntegerType => s"z.number().int()$desc"
+      case SchemaType.NumberType  => s"z.number()$desc"
+      case SchemaType.ArrayType   =>
+        val item = schema.items.map(zod).getOrElse("z.any()")
+        s"z.array($item)$desc"
+      case SchemaType.ObjectType =>
+        val objectBody =
+          if (schema.properties.isEmpty) "z.object({})"
+          else {
+            val props = schema.properties.toSeq
+              .sortBy(_._1)
+              .map { case (k, v) =>
+                s""""${escapeTsDoubleQuoted(k)}": ${zod(v)}${if (!v.required) ".nullish()" else ""}"""
+              }
+              .mkString("\n        ", ",\n        ", "")
+            s"z.object({$props})"
+          }
+        schema.additionalPropertiesSchema match {
+          // A map-like object: all values conform to one schema -> z.record (keys are strings in JSON).
+          case Some(v) if schema.properties.isEmpty => s"z.record(z.string(), ${zod(v)})$desc"
+          case Some(v)                              => s"$objectBody.catchall(${zod(v)})$desc"
+          case None                                 => s"$objectBody$desc"
+        }
+      case SchemaType.NullType => s"z.null()$desc"
+    }
+  }
+
+  def collapseZodUnion(zods: Seq[String]): String = {
+    val distinct = zods.distinct
+    if (distinct.isEmpty) dialect.emptyUnion
+    else if (distinct.size == 1) distinct.head
+    else s"z.union([${distinct.mkString(", ")}])"
+  }
+
+}

--- a/tscommon/src/main/scala/pl/iterators/baklava/tscommon/TsZodRenderer.scala
+++ b/tscommon/src/main/scala/pl/iterators/baklava/tscommon/TsZodRenderer.scala
@@ -23,12 +23,13 @@ object TsZodDialect {
       emptyUnion = "z.undefined()"
     )
 
+  // zod 4 vocabulary: top-level string formats and the dedicated file schema.
   val orpc: TsZodDialect =
     TsZodDialect(
-      dateTime = "z.string().datetime({ offset: true })",
-      email = "z.string().email()",
-      uuid = "z.string().uuid()",
-      filePart = "z.instanceof(File)",
+      dateTime = "z.iso.datetime({ offset: true })",
+      email = "z.email()",
+      uuid = "z.uuid()",
+      filePart = "z.file()",
       emptyUnion = "z.void()"
     )
 }
@@ -64,7 +65,11 @@ object TsNaming {
   }
 }
 
-class TsZodRenderer(dialect: TsZodDialect) {
+class TsZodRenderer(dialect: TsZodDialect, refs: BaklavaSchemaSerializable => Option[String] = _ => None) {
+
+  /** Render a hoisted schema's defining expression: the node itself inlines, nested schemas may still resolve through `refs`.
+    */
+  def zodDefinition(schema: BaklavaSchemaSerializable): String = zodInline(schema)
 
   private val jsIdentifier = "[A-Za-z_$][A-Za-z0-9_$]*".r
 
@@ -121,7 +126,10 @@ class TsZodRenderer(dialect: TsZodDialect) {
     s"z.object({${fields.mkString(", ")}})"
   }
 
-  def zod(schema: BaklavaSchemaSerializable): String = {
+  def zod(schema: BaklavaSchemaSerializable): String =
+    refs(schema).getOrElse(zodInline(schema))
+
+  private def zodInline(schema: BaklavaSchemaSerializable): String = {
     val desc = schema.description.map(d => s""".describe("${escapeTsDoubleQuoted(d)}")""").getOrElse("")
     schema.`type` match {
       case SchemaType.StringType =>

--- a/tsrest/src/main/scala/pl/iterators/baklava/tsrest/BaklavaDslFormatterTsRest.scala
+++ b/tsrest/src/main/scala/pl/iterators/baklava/tsrest/BaklavaDslFormatterTsRest.scala
@@ -239,8 +239,6 @@ class BaklavaDslFormatterTsRest extends BaklavaDslFormatter {
 
   private def escapeTsSingleQuoted(s: String): String = renderer.escapeTsSingleQuoted(s)
 
-  private def escapeTsDoubleQuoted(s: String): String = renderer.escapeTsDoubleQuoted(s)
-
   private[tsrest] def zod(schema: BaklavaSchemaSerializable): String = renderer.zod(schema)
 
   private[tsrest] def collapseZodUnion(zods: Seq[String]): String = renderer.collapseZodUnion(zods)

--- a/tsrest/src/main/scala/pl/iterators/baklava/tsrest/BaklavaDslFormatterTsRest.scala
+++ b/tsrest/src/main/scala/pl/iterators/baklava/tsrest/BaklavaDslFormatterTsRest.scala
@@ -1,12 +1,15 @@
 package pl.iterators.baklava.tsrest
 
 import pl.iterators.baklava.*
+import pl.iterators.baklava.tscommon.{TsNaming, TsZodDialect, TsZodRenderer}
 import sttp.model.Method
 
 import java.io.{File, FileWriter, PrintWriter}
 import scala.util.Using
 
 class BaklavaDslFormatterTsRest extends BaklavaDslFormatter {
+  private val renderer = new TsZodRenderer(TsZodDialect.tsRest)
+
   private val dirName                 = "target/baklava/tsrest"
   private val sourcesDirName          = "target/baklava/tsrest/src"
   private val packageContractJsonPath = s"$dirName/package-contracts.json"
@@ -87,47 +90,17 @@ class BaklavaDslFormatterTsRest extends BaklavaDslFormatter {
       paramsPerCall: Seq[Seq[P]],
       nameOf: P => String,
       schemaOf: P => BaklavaSchemaSerializable
-  ): Option[String] = {
-    val distinctSets = paramsPerCall.distinct
-    if (!distinctSets.exists(_.nonEmpty)) None
-    else {
-      val zds = distinctSets.map { params =>
-        val fields = params.map { p =>
-          val nullishMaybe = if (!schemaOf(p).required) ".nullish()" else ""
-          s"${tsObjectKey(nameOf(p))}: ${zod(schemaOf(p))}$nullishMaybe"
-        }
-        "z.object({" + fields.mkString(", ") + "})"
-      }
-      Some(collapseZodUnion(zds))
-    }
-  }
+  ): Option[String] = renderer.buildParamsZod(paramsPerCall, nameOf, schemaOf)
 
-  private val jsIdentifier = "[A-Za-z_$][A-Za-z0-9_$]*".r
-
-  // An object key may be written bare only if it's a valid JS identifier; query/header/path-param
-  // names can be kebab-case (`seller-id`, `X-Forwarded-For`) or start with a digit, which would
-  // otherwise produce uncompilable TypeScript — so quote anything that isn't identifier-shaped.
-  private[tsrest] def tsObjectKey(name: String): String =
-    if (jsIdentifier.matches(name)) name
-    else s""""${escapeTsDoubleQuoted(name)}""""
+  private[tsrest] def tsObjectKey(name: String): String = renderer.tsObjectKey(name)
 
   // Render one captured `Multipart` value as a ts-rest body schema (see
   // https://ts-rest.com/docs/core/multi-part): a `z.object` keyed by part name, `FilePart` ->
   // `z.instanceof(File)`, `TextPart` -> `z.string()`. A repeated part name (a multi-value form
   // field) becomes a `z.array(...)`; a name that mixes file and text parts unions the element
   // schemas. Names and element schemas are sorted so output is deterministic.
-  private[tsrest] def renderMultipartBody(parts: Seq[BaklavaMultipartPartSerializable]): String = {
-    val fields = parts
-      .groupBy(_.name)
-      .toSeq
-      .sortBy(_._1)
-      .map { case (name, ps) =>
-        val element = collapseZodUnion(ps.map(p => if (p.isFile) "z.instanceof(File)" else "z.string()").sorted)
-        val schema  = if (ps.size > 1) s"z.array($element)" else element
-        s"${tsObjectKey(name)}: $schema"
-      }
-    s"z.object({${fields.mkString(", ")}})"
-  }
+  private[tsrest] def renderMultipartBody(parts: Seq[BaklavaMultipartPartSerializable]): String =
+    renderer.renderMultipartBody(parts)
 
   /** Convert a Baklava `{name}` placeholder path to the ts-rest `:name` syntax. Non-placeholder braces (i.e. anything containing `/` or
     * nested braces) are left alone. Param names can contain any character except `{`, `}`, or `/` — so hyphens and dots survive.
@@ -135,21 +108,8 @@ class BaklavaDslFormatterTsRest extends BaklavaDslFormatter {
   private[tsrest] def toTsRestPath(symbolicPath: String): String =
     symbolicPath.replaceAll("""\{([^{}/]+)\}""", ":$1")
 
-  private[tsrest] def contractNameFromSymbolicPath(path: String): String = {
-    val cleaned = path.stripPrefix("/").stripSuffix("/")
-    if (cleaned.isEmpty) "root"
-    else {
-      cleaned
-        .split("/")
-        .map {
-          case p if p.startsWith("{") && p.endsWith("}") => "--" + p.substring(1, p.length - 1)
-          case p if p.startsWith(":")                    => "--" + p.substring(1)
-          case p                                         => p
-        }
-        .mkString("-")
-        .replace(".", "---")
-    }
-  }
+  private[tsrest] def contractNameFromSymbolicPath(path: String): String =
+    TsNaming.contractNameFromSymbolicPath(path)
 
   private def createContractForGroup(
       contractName: String,
@@ -273,72 +233,16 @@ class BaklavaDslFormatterTsRest extends BaklavaDslFormatter {
   }
 
   private def isEmptyBodyInstance(schema: BaklavaSchemaSerializable): Boolean =
-    schema.`type` == SchemaType.StringType &&
-      schema.`enum`.exists(enums => enums.contains("EmptyBodyInstance") && enums.size == 1)
+    renderer.isEmptyBodyInstance(schema)
 
-  private def toCamelCase(s: String): String = {
-    val base = s.replaceAll("--", "-")
-    base
-      .split("-")
-      .filter(_.nonEmpty)
-      .zipWithIndex
-      .map { case (s, i) =>
-        if (i == 0) s.toLowerCase else s.capitalize
-      }
-      .mkString
-  }
+  private def toCamelCase(s: String): String = TsNaming.toCamelCase(s)
 
-  private def escapeTsSingleQuoted(s: String): String =
-    s.replace("\\", "\\\\").replace("'", "\\'").replace("\n", "\\n").replace("\r", "\\r")
+  private def escapeTsSingleQuoted(s: String): String = renderer.escapeTsSingleQuoted(s)
 
-  private def escapeTsDoubleQuoted(s: String): String =
-    s.replace("\\", "\\\\").replace("\"", "\\\"").replace("\n", "\\n").replace("\r", "\\r")
+  private def escapeTsDoubleQuoted(s: String): String = renderer.escapeTsDoubleQuoted(s)
 
-  private[tsrest] def zod(schema: BaklavaSchemaSerializable): String = {
-    val desc = schema.description.map(d => s""".describe("${escapeTsDoubleQuoted(d)}")""").getOrElse("")
-    schema.`type` match {
-      case SchemaType.StringType =>
-        if (schema.`enum`.exists(_.nonEmpty)) {
-          // Sort for deterministic output; escape for double-quoted TS string context.
-          val e = schema.`enum`.get.toList.sorted.map(s => "\"" + escapeTsDoubleQuoted(s) + "\"").mkString(",")
-          s"z.enum([$e])$desc"
-        } else if (schema.format.contains("email")) s"z.string().email()$desc"
-        else if (schema.format.contains("uuid")) s"z.string().uuid()$desc"
-        else if (schema.format.contains("date-time")) s"z.coerce.date()$desc"
-        else s"z.string()$desc"
-      case SchemaType.BooleanType => s"z.boolean()$desc"
-      case SchemaType.IntegerType => s"z.number().int()$desc"
-      case SchemaType.NumberType  => s"z.number()$desc"
-      case SchemaType.ArrayType   =>
-        val item = schema.items.map(zod).getOrElse("z.any()")
-        s"z.array($item)$desc"
-      case SchemaType.ObjectType =>
-        val objectBody =
-          if (schema.properties.isEmpty) "z.object({})"
-          else {
-            val props = schema.properties.toSeq
-              .sortBy(_._1)
-              .map { case (k, v) =>
-                s""""${escapeTsDoubleQuoted(k)}": ${zod(v)}${if (!v.required) ".nullish()" else ""}"""
-              }
-              .mkString("\n        ", ",\n        ", "")
-            s"z.object({$props})"
-          }
-        schema.additionalPropertiesSchema match {
-          // A map-like object: all values conform to one schema -> z.record (keys are strings in JSON).
-          case Some(v) if schema.properties.isEmpty => s"z.record(z.string(), ${zod(v)})$desc"
-          case Some(v)                              => s"$objectBody.catchall(${zod(v)})$desc"
-          case None                                 => s"$objectBody$desc"
-        }
-      case SchemaType.NullType => s"z.null()$desc"
-    }
-  }
+  private[tsrest] def zod(schema: BaklavaSchemaSerializable): String = renderer.zod(schema)
 
-  private[tsrest] def collapseZodUnion(zods: Seq[String]): String = {
-    val distinct = zods.distinct
-    if (distinct.isEmpty) "z.undefined()"
-    else if (distinct.size == 1) distinct.head
-    else s"z.union([${distinct.mkString(", ")}])"
-  }
+  private[tsrest] def collapseZodUnion(zods: Seq[String]): String = renderer.collapseZodUnion(zods)
 
 }


### PR DESCRIPTION
Stacked on #114 (base `feat/tscommon`; retarget after it merges). The "make the package production-grade" batch:

## Consumer-facing

- **Named, deduplicated schemas** (`src/schemas.ts`): object schemas occurring more than once anywhere in the output are hoisted under names derived from the captured case-class names (`AuctionDto` → `auctionDtoSchema`), dependency-ordered, hash-suffixed on collisions, imported per contract file. Consumers get `z.infer`-able named types instead of anonymous inline shapes.
- **zod 4 vocabulary** (`z.iso.datetime({offset:true})`, `z.uuid()`, `z.email()`, `z.file()`); peer `zod@^4`. The format is new — no zod 3 installed base to serve, so no compat flag.
- **Literal discriminators**: each declared error's `data` narrows its discriminator property to `z.enum(["<code>"])` — self-discriminating payloads, exhaustive `switch`.
- **`src/client.ts`**: `createContractsClient(url, {fetch, headers})` ships the `customErrorResponseBodyDecoder` recipe as code — `isDefinedError` narrows to the declared union with zero consumer setup.
- **Truthful multi-2xx**: several distinct 2xx statuses → `outputStructure: 'detailed'` with a `{ status: z.literal(s), body }` union; single status keeps compact output + `successStatus`.

## Infrastructure

- **`tsc-gold` CI job**: byte-identical gold output can still be uncompilable TypeScript (#113's unused-import bug proved it). CI now compiles both TS gold packages (`orpc` with zod 4 peers, `tsrest` with zod 3 peers) using `tsc --strict`.

## Verification

29 orpc unit tests (hoisting/naming/collisions, literals, detailed-output switch, zod 4 forms); gold regenerated and byte-identical on Scala 2.13.18 + 3.3.7; both gold packages compiled clean locally with the exact CI command.

🤖 Generated with [Claude Code](https://claude.com/claude-code)