### PR TITLE
Bump sbt-typelevel to 0.8.7 to fix Validate Steward Config CI job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -204,19 +204,19 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-22.04]
-        java: [temurin@11]
+        java: [temurin@17]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout current branch (fast)
         uses: actions/checkout@v6
 
-      - name: Setup Java (temurin@11)
-        id: setup-java-temurin-11
-        if: matrix.java == 'temurin@11'
+      - name: Setup Java (temurin@17)
+        id: setup-java-temurin-17
+        if: matrix.java == 'temurin@17'
         uses: actions/setup-java@v5
         with:
           distribution: temurin
-          java-version: 11
+          java-version: 17
 
       - uses: coursier/setup-action@v1
         with:

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,4 @@
-addSbtPlugin("org.typelevel" % "sbt-typelevel" % "0.8.5")
+addSbtPlugin("org.typelevel" % "sbt-typelevel" % "0.8.7")
 
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.5.6")
 


### PR DESCRIPTION
## Problem

The **Validate Steward Config** CI job fails on every branch (first seen on #122, a docs-only PR):

```
UnsupportedClassVersionError: org/scalasteward/core/Main has been compiled by a more recent
version of the Java Runtime (class file version 61.0), this version of the Java Runtime only
recognizes class file versions up to 55.0
```

The job installs the **latest** scala-steward via `coursier/setup-action` but runs on temurin@11, hardcoded by sbt-typelevel ≤ 0.8.6. Recent scala-steward releases (0.39.x) ship Java-17 bytecode, so the job broke upstream of us — the last green run on `main` was July 9.

## Fix

sbt-typelevel [v0.8.7 bumps the steward-validate job to temurin@17](https://github.com/typelevel/sbt-typelevel/blob/v0.8.7/ci/src/main/scala/org/typelevel/sbt/TypelevelCiPlugin.scala#L180). This PR:

- bumps `sbt-typelevel` 0.8.5 → 0.8.7 in `project/plugins.sbt`
- regenerates `.github/workflows/ci.yml` via `sbt githubWorkflowGenerate` (only diff: temurin@11 → temurin@17 in that one job)

## Verification

`scala-steward validate-repo-config .scala-steward.conf` run locally with scala-steward 0.39.1 on JDK 17:

```
INFO  Configuration file at .../.scala-steward.conf is valid.
```

After merging, re-running CI on #122 should go green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)