### PR TITLE
Add naming-strategy hooks to SchemaDerivation (snake_case et al.)

### DIFF
--- a/core/src/main/scala-2.13/pl/iterators/baklava/SchemaDerivation.scala
+++ b/core/src/main/scala-2.13/pl/iterators/baklava/SchemaDerivation.scala
@@ -5,14 +5,19 @@ import magnolia1.*
 trait SchemaDerivation {
   type Typeclass[T] = Schema[T]
 
+  // override to match the codec's wire naming (e.g. SchemaNameTransform.snakeCase)
+  def transformMemberName(name: String): String      = name
+  def transformConstructorName(name: String): String = name
+
   def join[T](ctx: CaseClass[Schema, T]): Schema[T] = new Schema[T] {
     val className: String                  = ctx.typeName.short
     val `type`: SchemaType                 = SchemaType.ObjectType
     val format: Option[String]             = None
     val properties: Map[String, Schema[?]] = ctx.parameters.map { p =>
       p.default match {
-        case Some(default) => p.label -> p.typeclass.withDefault(default) // certainly not perfect as it depends on JSON serialization
-        case None          => p.label -> p.typeclass
+        case Some(default) =>
+          transformMemberName(p.label) -> p.typeclass.withDefault(default) // certainly not perfect as it depends on JSON serialization
+        case None => transformMemberName(p.label) -> p.typeclass
       }
     }.toMap
     val items: Option[Schema[?]]      = None
@@ -29,7 +34,7 @@ trait SchemaDerivation {
     val format: Option[String]                = None
     val properties: Map[String, Typeclass[?]] = Map.empty
     val items: Option[Typeclass[?]]           = None
-    val `enum`: Option[Set[String]]           = Some(ctx.subtypes.map(_.typeName.short).toSet)
+    val `enum`: Option[Set[String]]           = Some(ctx.subtypes.map(s => transformConstructorName(s.typeName.short)).toSet)
     val required: Boolean                     = true
     val additionalProperties: Boolean         = false
     val default: Option[T]                    = None

--- a/core/src/main/scala-3/pl/iterators/baklava/SchemaDerivation.scala
+++ b/core/src/main/scala-3/pl/iterators/baklava/SchemaDerivation.scala
@@ -3,14 +3,19 @@ package pl.iterators.baklava
 import magnolia1.*
 
 trait SchemaDerivation extends AutoDerivation[Schema] {
+  // override to match the codec's wire naming (e.g. SchemaNameTransform.snakeCase)
+  def transformMemberName(name: String): String      = name
+  def transformConstructorName(name: String): String = name
+
   def join[T](caseClass: CaseClass[Schema, T]): Schema[T] = new Schema[T] {
     val className: String                  = caseClass.typeInfo.short
     val `type`: SchemaType                 = SchemaType.ObjectType
     val format: Option[String]             = None
     val properties: Map[String, Schema[?]] = caseClass.parameters.map { p =>
       p.default match {
-        case Some(default) => p.label -> p.typeclass.withDefault(default) // certainly not perfect as it depends on JSON serialization
-        case None          => p.label -> p.typeclass
+        case Some(default) =>
+          transformMemberName(p.label) -> p.typeclass.withDefault(default) // certainly not perfect as it depends on JSON serialization
+        case None => transformMemberName(p.label) -> p.typeclass
       }
     }.toMap
     val items: Option[Schema[?]]      = None
@@ -27,7 +32,7 @@ trait SchemaDerivation extends AutoDerivation[Schema] {
     val format: Option[String]                = None
     val properties: Map[String, Typeclass[?]] = Map.empty
     val items: Option[Typeclass[?]]           = None
-    val `enum`: Option[Set[String]]           = Some(sealedTrait.subtypes.map(_.typeInfo.short).toSet)
+    val `enum`: Option[Set[String]]           = Some(sealedTrait.subtypes.map(s => transformConstructorName(s.typeInfo.short)).toSet)
     val required: Boolean                     = true
     val additionalProperties: Boolean         = false
     val default: Option[T]                    = None

--- a/core/src/main/scala/pl/iterators/baklava/SchemaNameTransform.scala
+++ b/core/src/main/scala/pl/iterators/baklava/SchemaNameTransform.scala
@@ -1,0 +1,15 @@
+package pl.iterators.baklava
+
+object SchemaNameTransform {
+  // acronym-aware: "myHTTPStatus" → "my" | "HTTP" | "Status"
+  private def delimited(name: String, sep: String): String =
+    name
+      .replaceAll("([A-Z]+)([A-Z][a-z])", "$1" + sep + "$2")
+      .replaceAll("([a-z\\d])([A-Z])", "$1" + sep + "$2")
+
+  def snakeCase(name: String): String = delimited(name, "_").toLowerCase
+
+  def screamingSnakeCase(name: String): String = delimited(name, "_").toUpperCase
+
+  def kebabCase(name: String): String = delimited(name, "-").toLowerCase
+}

--- a/core/src/test/scala-2.13/pl/iterators/baklava/SchemaNamingSpec.scala
+++ b/core/src/test/scala-2.13/pl/iterators/baklava/SchemaNamingSpec.scala
@@ -1,0 +1,79 @@
+package pl.iterators.baklava
+
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
+
+class SchemaNamingSpec extends AnyFunSpec with Matchers {
+  import SchemaNamingFixtures._
+
+  describe("SchemaDerivation with snake_case transforms") {
+    import SnakeCaseSchemas._
+
+    it("transforms flat case class property names and keeps types") {
+      val derived = implicitly[Schema[InnerPayload]]
+      derived.properties.keySet shouldBe Set("inner_field", "some_count")
+      derived.properties("inner_field").`type` shouldBe SchemaType.StringType
+      derived.properties("some_count").`type` shouldBe SchemaType.IntegerType
+    }
+
+    it("does not transform the class name") {
+      val derived = implicitly[Schema[InnerPayload]]
+      derived.className shouldBe "InnerPayload"
+    }
+
+    it("keeps Option fields optional under transformed keys") {
+      val derived = implicitly[Schema[OuterPayload]]
+      derived.properties("last_name").required shouldBe false
+      derived.properties("first_name").required shouldBe true
+    }
+
+    it("transforms nested case class property names") {
+      val derived = implicitly[Schema[OuterPayload]]
+      derived.properties("inner_payload").properties.keySet shouldBe Set("inner_field", "some_count")
+    }
+
+    it("transforms property names inside collection item schemas") {
+      val derived = implicitly[Schema[OuterPayload]]
+      derived.properties("tags_list").`type` shouldBe SchemaType.ArrayType
+      derived.properties("tags_list").items.get.properties.keySet shouldBe Set("inner_field", "some_count")
+    }
+
+    it("transforms property names inside map value schemas") {
+      val derived = implicitly[Schema[OuterPayload]]
+      derived.properties("extra_data").additionalPropertiesSchema.get.properties.keySet shouldBe Set("inner_field", "some_count")
+    }
+
+    it("transforms sealed trait enum values") {
+      val derived = implicitly[Schema[UserStatus]]
+      derived.`enum` shouldBe Some(Set("active_user", "banned_user"))
+      derived.className shouldBe "UserStatus"
+    }
+
+    it("transforms enum values of a sealed trait field") {
+      val derived = implicitly[Schema[WithStatus]]
+      derived.properties("current_status").`enum` shouldBe Some(Set("active_user", "banned_user"))
+    }
+
+    it("transforms the key of a field with a default value and keeps the default") {
+      val derived = implicitly[Schema[WithDefault]]
+      derived.properties("page_size").default shouldBe Some(42)
+    }
+  }
+
+  describe("SchemaDerivation with a member-only transform") {
+    import MemberOnlySnakeCaseSchemas._
+
+    it("transforms member names but leaves enum values untouched") {
+      val derived = implicitly[Schema[WithStatus]]
+      derived.properties("current_status").`enum` shouldBe Some(Set("ActiveUser", "BannedUser"))
+    }
+  }
+
+  describe("default Schema derivation") {
+    it("keeps identity naming for members and enum values") {
+      val derived = implicitly[Schema[OuterPayload]]
+      derived.properties.keySet shouldBe Set("firstName", "lastName", "innerPayload", "tagsList", "extraData")
+      implicitly[Schema[UserStatus]].`enum` shouldBe Some(Set("ActiveUser", "BannedUser"))
+    }
+  }
+}

--- a/core/src/test/scala-3/pl/iterators/baklava/SchemaNamingSpec.scala
+++ b/core/src/test/scala-3/pl/iterators/baklava/SchemaNamingSpec.scala
@@ -1,0 +1,83 @@
+package pl.iterators.baklava
+
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
+
+enum TrafficLight {
+  case RedLight, GreenLight
+}
+
+class SchemaNamingSpec extends AnyFunSpec with Matchers {
+  import SchemaNamingFixtures.*
+
+  describe("SchemaDerivation with snake_case transforms") {
+    import SnakeCaseSchemas.given
+
+    it("transforms flat case class property names and keeps types") {
+      val derived = implicitly[Schema[InnerPayload]]
+      derived.properties.keySet shouldBe Set("inner_field", "some_count")
+      derived.properties("inner_field").`type` shouldBe SchemaType.StringType
+      derived.properties("some_count").`type` shouldBe SchemaType.IntegerType
+    }
+
+    it("does not transform the class name") {
+      val derived = implicitly[Schema[InnerPayload]]
+      derived.className shouldBe "InnerPayload"
+    }
+
+    it("keeps Option fields optional under transformed keys") {
+      val derived = implicitly[Schema[OuterPayload]]
+      derived.properties("last_name").required shouldBe false
+      derived.properties("first_name").required shouldBe true
+    }
+
+    it("transforms nested case class property names") {
+      val derived = implicitly[Schema[OuterPayload]]
+      derived.properties("inner_payload").properties.keySet shouldBe Set("inner_field", "some_count")
+    }
+
+    it("transforms property names inside collection item schemas") {
+      val derived = implicitly[Schema[OuterPayload]]
+      derived.properties("tags_list").`type` shouldBe SchemaType.ArrayType
+      derived.properties("tags_list").items.get.properties.keySet shouldBe Set("inner_field", "some_count")
+    }
+
+    it("transforms property names inside map value schemas") {
+      val derived = implicitly[Schema[OuterPayload]]
+      derived.properties("extra_data").additionalPropertiesSchema.get.properties.keySet shouldBe Set("inner_field", "some_count")
+    }
+
+    it("transforms sealed trait enum values") {
+      val derived = implicitly[Schema[UserStatus]]
+      derived.`enum` shouldBe Some(Set("active_user", "banned_user"))
+      derived.className shouldBe "UserStatus"
+    }
+
+    it("transforms enum values of a sealed trait field") {
+      val derived = implicitly[Schema[WithStatus]]
+      derived.properties("current_status").`enum` shouldBe Some(Set("active_user", "banned_user"))
+    }
+
+    it("transforms Scala 3 enum values") {
+      val derived = implicitly[Schema[TrafficLight]]
+      derived.`enum` shouldBe Some(Set("red_light", "green_light"))
+    }
+  }
+
+  describe("SchemaDerivation with a member-only transform") {
+    import MemberOnlySnakeCaseSchemas.given
+
+    it("transforms member names but leaves enum values untouched") {
+      val derived = implicitly[Schema[WithStatus]]
+      derived.properties("current_status").`enum` shouldBe Some(Set("ActiveUser", "BannedUser"))
+    }
+  }
+
+  describe("default Schema derivation") {
+    it("keeps identity naming for members and enum values") {
+      val derived = implicitly[Schema[OuterPayload]]
+      derived.properties.keySet shouldBe Set("firstName", "lastName", "innerPayload", "tagsList", "extraData")
+      implicitly[Schema[UserStatus]].`enum` shouldBe Some(Set("ActiveUser", "BannedUser"))
+    }
+  }
+}

--- a/core/src/test/scala/pl/iterators/baklava/SchemaNameTransformSpec.scala
+++ b/core/src/test/scala/pl/iterators/baklava/SchemaNameTransformSpec.scala
@@ -1,0 +1,48 @@
+package pl.iterators.baklava
+
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
+
+class SchemaNameTransformSpec extends AnyFunSpec with Matchers {
+
+  describe("snakeCase") {
+    it("transforms camelCase") {
+      SchemaNameTransform.snakeCase("firstName") shouldBe "first_name"
+    }
+
+    it("transforms PascalCase") {
+      SchemaNameTransform.snakeCase("AdminUser") shouldBe "admin_user"
+    }
+
+    it("keeps acronyms together") {
+      SchemaNameTransform.snakeCase("HTTPStatus") shouldBe "http_status"
+      SchemaNameTransform.snakeCase("myHTTPStatus") shouldBe "my_http_status"
+    }
+
+    it("splits before an uppercase letter following a digit-terminated word") {
+      SchemaNameTransform.snakeCase("userId2") shouldBe "user_id2"
+      SchemaNameTransform.snakeCase("value2X") shouldBe "value2_x"
+    }
+
+    it("leaves single words and already-snake_case names untouched") {
+      SchemaNameTransform.snakeCase("name") shouldBe "name"
+      SchemaNameTransform.snakeCase("first_name") shouldBe "first_name"
+      SchemaNameTransform.snakeCase("a") shouldBe "a"
+      SchemaNameTransform.snakeCase("") shouldBe ""
+    }
+  }
+
+  describe("screamingSnakeCase") {
+    it("transforms camelCase to upper snake") {
+      SchemaNameTransform.screamingSnakeCase("activeUser") shouldBe "ACTIVE_USER"
+      SchemaNameTransform.screamingSnakeCase("BannedUser") shouldBe "BANNED_USER"
+    }
+  }
+
+  describe("kebabCase") {
+    it("transforms camelCase to kebab") {
+      SchemaNameTransform.kebabCase("firstName") shouldBe "first-name"
+      SchemaNameTransform.kebabCase("myHTTPStatus") shouldBe "my-http-status"
+    }
+  }
+}

--- a/core/src/test/scala/pl/iterators/baklava/SchemaNamingFixtures.scala
+++ b/core/src/test/scala/pl/iterators/baklava/SchemaNamingFixtures.scala
@@ -1,0 +1,30 @@
+package pl.iterators.baklava
+
+object SchemaNamingFixtures {
+  case class InnerPayload(innerField: String, someCount: Int)
+  case class OuterPayload(
+      firstName: String,
+      lastName: Option[String],
+      innerPayload: InnerPayload,
+      tagsList: Seq[InnerPayload],
+      extraData: Map[String, InnerPayload]
+  )
+
+  sealed trait UserStatus
+  object UserStatus {
+    case object ActiveUser extends UserStatus
+    case object BannedUser extends UserStatus
+  }
+  case class WithStatus(currentStatus: UserStatus)
+
+  case class WithDefault(pageSize: Int = 42)
+}
+
+object SnakeCaseSchemas extends SchemaDerivation with SchemaDefaults {
+  override def transformMemberName(name: String): String      = SchemaNameTransform.snakeCase(name)
+  override def transformConstructorName(name: String): String = SchemaNameTransform.snakeCase(name)
+}
+
+object MemberOnlySnakeCaseSchemas extends SchemaDerivation with SchemaDefaults {
+  override def transformMemberName(name: String): String = SchemaNameTransform.snakeCase(name)
+}

--- a/docs/dsl-reference.md
+++ b/docs/dsl-reference.md
@@ -708,6 +708,30 @@ implicit val myTypeSchema: Schema[MyType] = implicitly[Schema[MyType]]
   .withDefault(MyType("example", 42))
 ```
 
+### Naming Strategies
+
+By default, derived schemas use the Scala field names as property names and sealed trait / enum subtype names as enum values. If your JSON codecs use a different naming strategy (e.g. circe's `Configuration.snakeCaseMemberNames`), override the naming hooks on `SchemaDerivation` so the documented schemas match the wire format:
+
+```scala
+object MySchemas extends SchemaDerivation with SchemaDefaults {
+  override def transformMemberName(name: String): String      = SchemaNameTransform.snakeCase(name)
+  override def transformConstructorName(name: String): String = SchemaNameTransform.snakeCase(name)
+}
+```
+
+Then import its derivation instead of relying on the default one:
+
+```scala
+import MySchemas._     // Scala 2.13
+import MySchemas.given // Scala 3
+```
+
+The transform applies to the whole schema tree — nested case classes, collection items and map values included. `transformMemberName` maps case class fields to property names; `transformConstructorName` maps sealed trait / enum subtypes to enum values. Class names (used for `x-class` and schema references) are not transformed.
+
+`SchemaNameTransform` ships with `snakeCase`, `screamingSnakeCase` and `kebabCase`, but any `String => String` works as a transform — the hooks are plain methods, so custom conventions (acronym tables, legacy field maps) need no extra machinery.
+
+Note that the hooks only affect documentation and generated clients; runtime serialization in tests still goes through your own codecs, so the transform must match what those codecs actually emit.
+
 ## Best Practices
 
 1. **Use descriptive names**: Provide clear `description` and `summary` fields for better documentation

--- a/docs/scala-cli.md
+++ b/docs/scala-cli.md
@@ -49,15 +49,15 @@ case class GitHubRepo(name: String, fullName: String, description: Option[String
 case class GitHubError(message: String, documentationUrl: Option[String]) derives ConfiguredCodec
 
 // documented schemas must match the wire format, so mirror the codec's naming strategy
-object GitHubSchemas extends SchemaDerivation with SchemaDefaults {
+trait GitHubSchemas extends SchemaDerivation with SchemaDefaults {
   override def transformMemberName(name: String): String      = SchemaNameTransform.snakeCase(name)
   override def transformConstructorName(name: String): String = SchemaNameTransform.snakeCase(name)
 }
-import GitHubSchemas.given
 
 class GitHubApiSpec
     extends BaklavaMunit[HttpRoutes[IO], BaklavaHttp4s.ToEntityMarshaller, BaklavaHttp4s.FromEntityUnmarshaller]
-    with BaklavaHttp4s[Unit, Unit, MunitAsExecution] {
+    with BaklavaHttp4s[Unit, Unit, MunitAsExecution]
+    with GitHubSchemas {
 
   implicit val runtime: IORuntime                = IORuntime.global
   override def strictHeaderCheckDefault: Boolean = false
@@ -229,6 +229,6 @@ final case class GitHubUser(company: Option[String] = None, followers: Int, id: 
 ## How it works
 
 - **Remote APIs via `performRequest`**: Baklava's DSL builds an `http4s` `Request[IO]` and hands it to `performRequest`, which normally runs it against local routes. Overriding it to send the request with a real client (Ember here) turns Baklava into a documentation-generating integration test for any HTTP service. The response body is compiled to memory so it can be read both by your assertions and by the serializer.
-- **Naming strategies**: the case classes use idiomatic camelCase, while GitHub's wire format is snake_case. Two things bridge that gap, and they must agree: circe's `Configuration.withSnakeCaseMemberNames` handles runtime decoding, and `GitHubSchemas` (a `SchemaDerivation` with the matching `SchemaNameTransform.snakeCase` override, imported via `import GitHubSchemas.given`) makes the documented schemas and generated clients use the wire names — `public_repos`, not `publicRepos`. See [Naming Strategies](dsl-reference.md#naming-strategies).
+- **Naming strategies**: the case classes use idiomatic camelCase, while GitHub's wire format is snake_case. Two things bridge that gap, and they must agree: circe's `Configuration.withSnakeCaseMemberNames` handles runtime decoding, and the `GitHubSchemas` mixin (a `SchemaDerivation` with the matching `SchemaNameTransform.snakeCase` override) makes the documented schemas and generated clients use the wire names — `public_repos`, not `publicRepos`. See [Naming Strategies](dsl-reference.md#naming-strategies).
 - **Generation in `afterAll`**: the sbt plugin normally runs `BaklavaGenerate` after `sbt test`. In a standalone script we call it from `afterAll` instead, so a single `scala-cli test` invocation runs the tests and generates output. Config entries use the `key|<base64 value>` argument format; formatters are auto-discovered from the classpath, so which outputs you get is controlled purely by the `//> using dep` lines — swap in `baklava-tsrest`, `baklava-orpc`, `baklava-simple`, or `baklava-postman` to taste.
 - **Rate limits**: unauthenticated GitHub API calls are limited to 60/hour per IP; this script makes 3 per run. If you document an API that needs auth, add the header in `performRequest` (e.g. a bearer token from an environment variable) or document it properly with Baklava's `security` DSL — see [DSL Reference](dsl-reference.md).

--- a/docs/scala-cli.md
+++ b/docs/scala-cli.md
@@ -28,20 +28,32 @@ Save as `github-api-docs.test.scala`:
 
 import cats.effect.IO
 import cats.effect.unsafe.IORuntime
-import io.circe.generic.auto.*
+import io.circe.derivation.{Configuration, ConfiguredCodec}
 import org.http4s.circe.CirceEntityDecoder.*
 import org.http4s.ember.client.EmberClientBuilder
 import org.http4s.{Header, HttpRoutes, Request, Response, Uri}
 import org.http4s.Method.*
 import org.http4s.Status.*
 import org.typelevel.ci.CIString
-import pl.iterators.baklava.BaklavaGenerate
+import pl.iterators.baklava.{BaklavaGenerate, SchemaDefaults, SchemaDerivation, SchemaNameTransform}
 import pl.iterators.baklava.http4s.BaklavaHttp4s
 import pl.iterators.baklava.munit.{BaklavaMunit, MunitAsExecution}
 
-case class GitHubUser(login: String, id: Long, name: Option[String], company: Option[String], public_repos: Int, followers: Int)
-case class GitHubRepo(name: String, full_name: String, description: Option[String], stargazers_count: Int, language: Option[String])
-case class GitHubError(message: String, documentation_url: Option[String])
+// GitHub's JSON is snake_case; the codec decodes it into idiomatic camelCase fields
+given Configuration = Configuration.default.withSnakeCaseMemberNames
+
+case class GitHubUser(login: String, id: Long, name: Option[String], company: Option[String], publicRepos: Int, followers: Int)
+    derives ConfiguredCodec
+case class GitHubRepo(name: String, fullName: String, description: Option[String], stargazersCount: Int, language: Option[String])
+    derives ConfiguredCodec
+case class GitHubError(message: String, documentationUrl: Option[String]) derives ConfiguredCodec
+
+// documented schemas must match the wire format, so mirror the codec's naming strategy
+object GitHubSchemas extends SchemaDerivation with SchemaDefaults {
+  override def transformMemberName(name: String): String      = SchemaNameTransform.snakeCase(name)
+  override def transformConstructorName(name: String): String = SchemaNameTransform.snakeCase(name)
+}
+import GitHubSchemas.given
 
 class GitHubApiSpec
     extends BaklavaMunit[HttpRoutes[IO], BaklavaHttp4s.ToEntityMarshaller, BaklavaHttp4s.FromEntityUnmarshaller]
@@ -101,7 +113,7 @@ class GitHubApiSpec
         .respondsWith[GitHubRepo](Ok, description = "Repository found")
         .assert { ctx =>
           val response = ctx.performRequest(routes)
-          assertEquals(response.body.full_name, "theiterators/baklava")
+          assertEquals(response.body.fullName, "theiterators/baklava")
         }
     )
   )
@@ -217,5 +229,6 @@ final case class GitHubUser(company: Option[String] = None, followers: Int, id: 
 ## How it works
 
 - **Remote APIs via `performRequest`**: Baklava's DSL builds an `http4s` `Request[IO]` and hands it to `performRequest`, which normally runs it against local routes. Overriding it to send the request with a real client (Ember here) turns Baklava into a documentation-generating integration test for any HTTP service. The response body is compiled to memory so it can be read both by your assertions and by the serializer.
+- **Naming strategies**: the case classes use idiomatic camelCase, while GitHub's wire format is snake_case. Two things bridge that gap, and they must agree: circe's `Configuration.withSnakeCaseMemberNames` handles runtime decoding, and `GitHubSchemas` (a `SchemaDerivation` with the matching `SchemaNameTransform.snakeCase` override, imported via `import GitHubSchemas.given`) makes the documented schemas and generated clients use the wire names — `public_repos`, not `publicRepos`. See [Naming Strategies](dsl-reference.md#naming-strategies).
 - **Generation in `afterAll`**: the sbt plugin normally runs `BaklavaGenerate` after `sbt test`. In a standalone script we call it from `afterAll` instead, so a single `scala-cli test` invocation runs the tests and generates output. Config entries use the `key|<base64 value>` argument format; formatters are auto-discovered from the classpath, so which outputs you get is controlled purely by the `//> using dep` lines — swap in `baklava-tsrest`, `baklava-orpc`, `baklava-simple`, or `baklava-postman` to taste.
 - **Rate limits**: unauthenticated GitHub API calls are limited to 60/hour per IP; this script makes 3 per run. If you document an API that needs auth, add the header in `performRequest` (e.g. a bearer token from an environment variable) or document it properly with Baklava's `security` DSL — see [DSL Reference](dsl-reference.md).


### PR DESCRIPTION
Closes #124 (proposal 1: naming-strategy hook).

## Problem

`Schema[T]` derivation used raw Scala field names (`p.label`) and sealed trait subtype names, with no way to match a JSON codec's naming strategy. With e.g. snake_case circe codecs, captured examples showed `first_name` while schemas said `firstName` — making the OpenAPI/JSON Schema output internally inconsistent and the generated sttp/tsfetch/tsrest/oRPC clients runtime-broken (details in #124).

## Change

- `transformMemberName` / `transformConstructorName` hooks on `SchemaDerivation` (default identity — the default `Schema` companion derivation is unchanged), applied to property keys in `join` and enum values in `split`, identically on Scala 2.13 and 3. `className` stays untransformed (type identity for `x-class`/refs, not wire data).
- `SchemaNameTransform` with acronym-aware `snakeCase` (`myHTTPStatus` → `my_http_status`), `screamingSnakeCase`, `kebabCase`. Any `String => String` works as a custom transform.
- Since every consumer reads `Schema.properties` verbatim, one override fixes OpenAPI, JSON Schema, sttp, tsfetch, tsrest and oRPC output simultaneously.

Usage:

```scala
object MySchemas extends SchemaDerivation with SchemaDefaults {
  override def transformMemberName(name: String)      = SchemaNameTransform.snakeCase(name)
  override def transformConstructorName(name: String) = SchemaNameTransform.snakeCase(name)
}

import MySchemas._     // Scala 2.13
import MySchemas.given // Scala 3
```

The import shadows the companion derivation (lexical scope wins on both compilers), and the transform propagates through the whole schema tree — nested case classes, collection items, map value schemas — which the tests pin down explicitly.

## Tests

- `SchemaNameTransformSpec` (shared): transform functions — camelCase, PascalCase, acronyms, digit boundaries, already-snake, empty.
- `SchemaNamingSpec` per Scala version (imports differ: `._` vs `.given`): flat/nested/collection-item/map-value property names, Option requiredness, sealed trait enums, member-only transform leaving enums alone, `className` untransformed, default derivation identity. 2.13 additionally covers default-valued fields (magnolia on Scala 3 doesn't surface defaults without `-Yretain-trees`); Scala 3 additionally covers native `enum`.
- Full core suite green on both versions (44 tests on 2.13, 51 on 3), scalafmt clean.

Docs: new "Naming Strategies" section in `docs/dsl-reference.md`.
