### PR TITLE
Emit OpenAPI JSON examples as structured objects instead of strings

### DIFF
--- a/openapi/src/main/scala/pl/iterators/baklava/openapi/BaklavaDslFormatterOpenAPIWorker.scala
+++ b/openapi/src/main/scala/pl/iterators/baklava/openapi/BaklavaDslFormatterOpenAPIWorker.scala
@@ -50,7 +50,7 @@ object BaklavaDslFormatterOpenAPIWorker {
             h.schema(baklavaSchemaToOpenAPISchema(header.schema))
             h.setRequired(header.schema.required)
             header.description.foreach(h.setDescription)
-            caseInsensitiveHeaderLookup(commonStatusCalls, header.name).foreach(h.example)
+            caseInsensitiveHeaderLookup(commonStatusCalls, header.name).map(coerceExample(_, h.getSchema)).foreach(h.example)
             val _ = r.addHeaderObject(header.name, h)
           }
 
@@ -329,23 +329,41 @@ object BaklavaDslFormatterOpenAPIWorker {
     val distinctValues = examples.map(_._2).distinct
     if (distinctValues.isEmpty) () // nothing to attach
     else if (distinctValues.size == 1) {
-      val _ = parameter.example(distinctValues.head)
+      val _ = parameter.example(coerceExample(distinctValues.head, parameter.getSchema))
     } else {
       val used = scala.collection.mutable.Set.empty[String]
       examples.zipWithIndex.foreach { case ((label, value), idx) =>
         val baseKey  = if (label.isEmpty) s"Example $idx" else label
         val finalKey = disambiguateKey(baseKey, used)
-        val _        = parameter.addExample(finalKey, new io.swagger.v3.oas.models.examples.Example().value(value))
+        val _        = parameter.addExample(
+          finalKey,
+          new io.swagger.v3.oas.models.examples.Example().value(coerceExample(value, parameter.getSchema))
+        )
       }
     }
   }
 
-  // application/json examples must reach swagger-core as a Java object tree, not a printed string — otherwise they
+  // application/json and RFC 6839 +json suffix types (application/problem+json etc., #129)
+  private def isJsonMediaType(mediaType: String): Boolean =
+    mediaType == "application/json" || mediaType.endsWith("+json")
+
+  // JSON examples must reach swagger-core as a Java object tree, not a printed string — otherwise they
   // serialize as escaped string blobs that fail `type: object` validation and render poorly in Swagger UI/Redoc (#120).
   // Unparseable JSON and non-JSON content types keep the raw string.
   private def exampleValue(bodyString: String, contentType: Option[String]): Object =
-    if (contentType.contains("application/json")) parse(bodyString).map(jsonToJavaObject).getOrElse(bodyString)
+    if (contentType.exists(isJsonMediaType)) parse(bodyString).map(jsonToJavaObject).getOrElse(bodyString)
     else bodyString
+
+  // Captured parameter/header example values are raw strings; coerce to the declared schema type so they
+  // validate against integer/number/boolean schemas (10, not "10") — #130. Values that don't parse as the
+  // schema type keep the raw string.
+  private def coerceExample(value: String, schema: Schema[?]): Object =
+    Option(schema).flatMap(s => Option(s.getType)) match {
+      case Some("integer") => scala.util.Try(java.lang.Long.valueOf(value): Object).getOrElse(value)
+      case Some("number")  => scala.util.Try(new java.math.BigDecimal(value): Object).getOrElse(value)
+      case Some("boolean") if value == "true" || value == "false" => java.lang.Boolean.valueOf(value)
+      case _                                                      => value
+    }
 
   // Also used for schema defaults (#61): natural Java types make swagger's YAML encoder emit 42, not "42".
   // LinkedHashMap/ArrayList so captured key order survives serialization.

--- a/openapi/src/main/scala/pl/iterators/baklava/openapi/BaklavaDslFormatterOpenAPIWorker.scala
+++ b/openapi/src/main/scala/pl/iterators/baklava/openapi/BaklavaDslFormatterOpenAPIWorker.scala
@@ -343,20 +343,16 @@ object BaklavaDslFormatterOpenAPIWorker {
     }
   }
 
-  // application/json and RFC 6839 +json suffix types (application/problem+json etc., #129)
+  // application/json or an RFC 6839 +json suffix type (#129)
   private def isJsonMediaType(mediaType: String): Boolean =
     mediaType == "application/json" || mediaType.endsWith("+json")
 
-  // JSON examples must reach swagger-core as a Java object tree, not a printed string — otherwise they
-  // serialize as escaped string blobs that fail `type: object` validation and render poorly in Swagger UI/Redoc (#120).
-  // Unparseable JSON and non-JSON content types keep the raw string.
+  // JSON bodies become Java object trees — printed strings fail `type: object` validation (#120)
   private def exampleValue(bodyString: String, contentType: Option[String]): Object =
     if (contentType.exists(isJsonMediaType)) parse(bodyString).map(jsonToJavaObject).getOrElse(bodyString)
     else bodyString
 
-  // Captured parameter/header example values are raw strings; coerce to the declared schema type so they
-  // validate against integer/number/boolean schemas (10, not "10") — #130. Values that don't parse as the
-  // schema type keep the raw string.
+  // captured string values coerced to the declared schema type so examples validate (10, not "10") — #130
   private def coerceExample(value: String, schema: Schema[?]): Object =
     Option(schema).flatMap(s => Option(s.getType)) match {
       case Some("integer") => scala.util.Try(java.lang.Long.valueOf(value): Object).getOrElse(value)
@@ -365,8 +361,7 @@ object BaklavaDslFormatterOpenAPIWorker {
       case _                                                      => value
     }
 
-  // Also used for schema defaults (#61): natural Java types make swagger's YAML encoder emit 42, not "42".
-  // LinkedHashMap/ArrayList so captured key order survives serialization.
+  // LinkedHashMap/ArrayList preserve key order; also serves schema defaults (#61)
   private def jsonToJavaObject(j: io.circe.Json): Object = j.fold(
     jsonNull = null,
     jsonBoolean = b => java.lang.Boolean.valueOf(b),

--- a/openapi/src/main/scala/pl/iterators/baklava/openapi/BaklavaDslFormatterOpenAPIWorker.scala
+++ b/openapi/src/main/scala/pl/iterators/baklava/openapi/BaklavaDslFormatterOpenAPIWorker.scala
@@ -1,6 +1,5 @@
 package pl.iterators.baklava.openapi
 
-import io.circe.Printer
 import io.circe.parser.*
 import io.swagger.v3.oas.models.OpenAPI
 import io.swagger.v3.oas.models.media.{Content, Schema}
@@ -68,16 +67,13 @@ object BaklavaDslFormatterOpenAPIWorker {
 
               val usedExampleKeys = scala.collection.mutable.Set.empty[String]
               commonContentTypeCalls.zipWithIndex.foreach { case (BaklavaSerializableCall(ctx, response), idx) =>
-                val responseStr =
-                  if (contentType.contains("application/json"))
-                    parse(response.bodyString).map(_.printWith(Printer.spaces2)).getOrElse(response.bodyString)
-                  else response.bodyString
+                val responseValue = exampleValue(response.bodyString, contentType)
 
                 val baseKey   = ctx.responseDescription.getOrElse(s"Example $idx")
                 val uniqueKey = disambiguateKey(baseKey, usedExampleKeys)
                 val _         = mediaType.addExamples(
                   uniqueKey,
-                  new io.swagger.v3.oas.models.examples.Example().value(responseStr)
+                  new io.swagger.v3.oas.models.examples.Example().value(responseValue)
                 )
               }
 
@@ -117,16 +113,13 @@ object BaklavaDslFormatterOpenAPIWorker {
               val usedRequestExampleKeys = scala.collection.mutable.Set.empty[String]
               calls.zipWithIndex.foreach { case (call, idx) =>
                 if (call.request.bodyString.nonEmpty) {
-                  val requestStr =
-                    if (contentType.contains("application/json"))
-                      parse(call.request.bodyString).map(_.printWith(Printer.spaces2)).getOrElse(call.request.bodyString)
-                    else call.request.bodyString
+                  val requestValue = exampleValue(call.request.bodyString, contentType)
 
                   val baseKey   = call.request.responseDescription.getOrElse(s"Example $idx")
                   val uniqueKey = disambiguateKey(baseKey, usedRequestExampleKeys)
                   val _         = mediaType.addExamples(
                     uniqueKey,
-                    new io.swagger.v3.oas.models.examples.Example().value(requestStr)
+                    new io.swagger.v3.oas.models.examples.Example().value(requestValue)
                   )
                 }
               }
@@ -347,6 +340,35 @@ object BaklavaDslFormatterOpenAPIWorker {
     }
   }
 
+  // application/json examples must reach swagger-core as a Java object tree, not a printed string — otherwise they
+  // serialize as escaped string blobs that fail `type: object` validation and render poorly in Swagger UI/Redoc (#120).
+  // Unparseable JSON and non-JSON content types keep the raw string.
+  private def exampleValue(bodyString: String, contentType: Option[String]): Object =
+    if (contentType.contains("application/json")) parse(bodyString).map(jsonToJavaObject).getOrElse(bodyString)
+    else bodyString
+
+  // Also used for schema defaults (#61): natural Java types make swagger's YAML encoder emit 42, not "42".
+  // LinkedHashMap/ArrayList so captured key order survives serialization.
+  private def jsonToJavaObject(j: io.circe.Json): Object = j.fold(
+    jsonNull = null,
+    jsonBoolean = b => java.lang.Boolean.valueOf(b),
+    jsonNumber = n =>
+      n.toLong
+        .map(java.lang.Long.valueOf(_): Object)
+        .getOrElse(n.toBigDecimal.getOrElse(BigDecimal(n.toString)).bigDecimal),
+    jsonString = s => s,
+    jsonArray = arr => {
+      val list = new java.util.ArrayList[Object](arr.size)
+      arr.foreach(v => list.add(jsonToJavaObject(v)))
+      list
+    },
+    jsonObject = obj => {
+      val m = new java.util.LinkedHashMap[String, Object]()
+      obj.toIterable.foreach { case (k, v) => m.put(k, jsonToJavaObject(v)) }
+      m
+    }
+  )
+
   private def disambiguateKey(baseKey: String, used: scala.collection.mutable.Set[String]): String = {
     if (!used.contains(baseKey)) {
       used += baseKey
@@ -403,7 +425,7 @@ object BaklavaDslFormatterOpenAPIWorker {
       schema.addProperty(name, baklavaSchemaToOpenAPISchema(bs))
     }
     baklavaSchema.`enum`.foreach(e => schema.setEnum(e.toList.asJava))
-    baklavaSchema.default.flatMap(jsonToJavaDefault).foreach(schema.setDefault)
+    baklavaSchema.default.map(jsonToJavaObject).foreach(schema.setDefault)
     schema.setRequired(baklavaSchema.properties.toList.filter(_._2.required).map(_._1).asJava)
     baklavaSchema.additionalPropertiesSchema match {
       case Some(bs) => schema.setAdditionalProperties(baklavaSchemaToOpenAPISchema(bs))
@@ -412,25 +434,6 @@ object BaklavaDslFormatterOpenAPIWorker {
 
     schema
   }
-
-  /** Convert a captured JSON default (circe) into the Java/Scala `Object` shape that swagger's `Schema.setDefault` accepts. Swagger
-    * serializes the value back out via its own YAML encoder, so handing it the natural Java type produces correct YAML (e.g. an `Integer`
-    * becomes `42`, not `"42"`). Fixes issue #61.
-    */
-  private def jsonToJavaDefault(j: io.circe.Json): Option[Object] = j.fold(
-    jsonNull = Some(null: Object),
-    jsonBoolean = b => Some(java.lang.Boolean.valueOf(b)),
-    jsonNumber = n =>
-      n.toLong
-        .map(java.lang.Long.valueOf(_): Object)
-        .orElse(Some(n.toBigDecimal.getOrElse(BigDecimal(n.toString)).bigDecimal: Object)),
-    jsonString = s => Some(s),
-    jsonArray = arr => Some(arr.map(v => jsonToJavaDefault(v).orNull).asJava),
-    jsonObject = obj =>
-      Some(
-        obj.toIterable.map { case (k, v) => k -> jsonToJavaDefault(v).orNull }.toMap.asJava
-      )
-  )
 
   // OpenAPI keys `content` by media type only, so drop any `;charset=…` / `;boundary=…` parameters before grouping.
   private def stripMediaTypeParams(contentType: String): String =

--- a/openapi/src/test/resources/gold/openapi/openapi.yml
+++ b/openapi/src/test/resources/gold/openapi/openapi.yml
@@ -34,11 +34,9 @@ paths:
                 x-class: HealthResponse
               examples:
                 Current configuration:
-                  value: |-
-                    {
-                      "status" : "ok",
-                      "uptimeSeconds" : 1
-                    }
+                  value:
+                    status: ok
+                    uptimeSeconds: 1
       security:
       - basicAuth: []
   /admin/loggers/{name}:
@@ -77,11 +75,9 @@ paths:
                 x-class: HealthResponse
               examples:
                 Logger level:
-                  value: |-
-                    {
-                      "status" : "DEBUG",
-                      "uptimeSeconds" : 1
-                    }
+                  value:
+                    status: DEBUG
+                    uptimeSeconds: 1
       security:
       - basicAuth: []
   /auth/login:
@@ -149,16 +145,13 @@ paths:
                 x-class: LoginResponse
               examples:
                 Successful login:
-                  value: |-
-                    {
-                      "token" : "jwt.token.xyz",
-                      "user" : {
-                        "id" : "00000000-0000-0000-0000-000000000001",
-                        "email" : "alice@example.com",
-                        "name" : "Alice",
-                        "role" : "admin"
-                      }
-                    }
+                  value:
+                    token: jwt.token.xyz
+                    user:
+                      id: 00000000-0000-0000-0000-000000000001
+                      email: alice@example.com
+                      name: Alice
+                      role: admin
         "401":
           description: Invalid credentials
           content:
@@ -181,12 +174,10 @@ paths:
                 x-class: ErrorResponse
               examples:
                 Invalid credentials:
-                  value: |-
-                    {
-                      "code" : "unauthorized",
-                      "message" : "Bad credentials",
-                      "details" : null
-                    }
+                  value:
+                    code: unauthorized
+                    message: Bad credentials
+                    details: null
       security:
       - basicAuth: []
   /health:
@@ -217,11 +208,9 @@ paths:
                 x-class: HealthResponse
               examples:
                 Service is alive:
-                  value: |-
-                    {
-                      "status" : "ok",
-                      "uptimeSeconds" : 12345
-                    }
+                  value:
+                    status: ok
+                    uptimeSeconds: 12345
       security: []
   /me:
     summary: Current user
@@ -262,13 +251,11 @@ paths:
                 x-class: User
               examples:
                 Authenticated user profile:
-                  value: |-
-                    {
-                      "id" : "00000000-0000-0000-0000-000000000001",
-                      "email" : "alice@example.com",
-                      "name" : "Alice",
-                      "role" : "admin"
-                    }
+                  value:
+                    id: 00000000-0000-0000-0000-000000000001
+                    email: alice@example.com
+                    name: Alice
+                    role: admin
       security:
       - bearerAuth: []
   /projects:
@@ -338,29 +325,21 @@ paths:
                   x-class: Project
               examples:
                 All active projects:
-                  value: |-
-                    [
-                      {
-                        "id" : 42,
-                        "name" : "Apollo",
-                        "description" : "Mission control",
-                        "status" : "active",
-                        "ownerId" : "00000000-0000-0000-0000-000000000001",
-                        "createdAt" : "2026-01-01T00:00:00Z"
-                      }
-                    ]
+                  value:
+                  - id: 42
+                    name: Apollo
+                    description: Mission control
+                    status: active
+                    ownerId: 00000000-0000-0000-0000-000000000001
+                    createdAt: 2026-01-01T00:00:00Z
                 All archived projects:
-                  value: |-
-                    [
-                      {
-                        "id" : 7,
-                        "name" : "Gemini",
-                        "description" : null,
-                        "status" : "archived",
-                        "ownerId" : "00000000-0000-0000-0000-000000000001",
-                        "createdAt" : "2025-06-01T00:00:00Z"
-                      }
-                    ]
+                  value:
+                  - id: 7
+                    name: Gemini
+                    description: null
+                    status: archived
+                    ownerId: 00000000-0000-0000-0000-000000000001
+                    createdAt: 2025-06-01T00:00:00Z
       security:
       - oauth2:
         - projects:read
@@ -395,12 +374,10 @@ paths:
               x-class: CreateProjectRequest
             examples:
               Project created:
-                value: |-
-                  {
-                    "name" : "Apollo",
-                    "description" : "Mission control",
-                    "status" : "active"
-                  }
+                value:
+                  name: Apollo
+                  description: Mission control
+                  status: active
       responses:
         "201":
           description: Project created
@@ -438,15 +415,13 @@ paths:
                 x-class: Project
               examples:
                 Project created:
-                  value: |-
-                    {
-                      "id" : 42,
-                      "name" : "Apollo",
-                      "description" : "Mission control",
-                      "status" : "active",
-                      "ownerId" : "00000000-0000-0000-0000-000000000001",
-                      "createdAt" : "2026-01-01T00:00:00Z"
-                    }
+                  value:
+                    id: 42
+                    name: Apollo
+                    description: Mission control
+                    status: active
+                    ownerId: 00000000-0000-0000-0000-000000000001
+                    createdAt: 2026-01-01T00:00:00Z
         "400":
           description: Validation failed
           content:
@@ -469,14 +444,11 @@ paths:
                 x-class: ErrorResponse
               examples:
                 Validation failed:
-                  value: |-
-                    {
-                      "code" : "validation",
-                      "message" : "One or more fields are invalid",
-                      "details" : [
-                        "name: must not be blank"
-                      ]
-                    }
+                  value:
+                    code: validation
+                    message: One or more fields are invalid
+                    details:
+                    - "name: must not be blank"
       security:
       - oauth2:
         - projects:read
@@ -522,12 +494,10 @@ paths:
               x-class: PatchProjectRequest
             examples:
               Project updated:
-                value: |-
-                  {
-                    "name" : null,
-                    "description" : "Updated desc",
-                    "status" : null
-                  }
+                value:
+                  name: null
+                  description: Updated desc
+                  status: null
       responses:
         "200":
           description: Project updated
@@ -565,15 +535,13 @@ paths:
                 x-class: Project
               examples:
                 Project updated:
-                  value: |-
-                    {
-                      "id" : 42,
-                      "name" : "Apollo",
-                      "description" : "Updated desc",
-                      "status" : "active",
-                      "ownerId" : "00000000-0000-0000-0000-000000000001",
-                      "createdAt" : "2026-01-01T00:00:00Z"
-                    }
+                  value:
+                    id: 42
+                    name: Apollo
+                    description: Updated desc
+                    status: active
+                    ownerId: 00000000-0000-0000-0000-000000000001
+                    createdAt: 2026-01-01T00:00:00Z
       security:
       - oauth2:
         - projects:read
@@ -631,23 +599,17 @@ paths:
                   x-class: Task
               examples:
                 All tasks in the project:
-                  value: |-
-                    [
-                      {
-                        "id" : 101,
-                        "title" : "Wire up telemetry",
-                        "description" : "Prometheus + Grafana",
-                        "done" : false,
-                        "priority" : "high"
-                      },
-                      {
-                        "id" : 102,
-                        "title" : "Write docs",
-                        "description" : null,
-                        "done" : true,
-                        "priority" : "low"
-                      }
-                    ]
+                  value:
+                  - id: 101
+                    title: Wire up telemetry
+                    description: Prometheus + Grafana
+                    done: false
+                    priority: high
+                  - id: 102
+                    title: Write docs
+                    description: null
+                    done: true
+                    priority: low
       security:
       - oauth2:
         - projects:read
@@ -691,12 +653,10 @@ paths:
               x-class: CreateTaskRequest
             examples:
               Task created:
-                value: |-
-                  {
-                    "title" : "New task",
-                    "description" : null,
-                    "priority" : "medium"
-                  }
+                value:
+                  title: New task
+                  description: null
+                  priority: medium
       responses:
         "201":
           description: Task created
@@ -737,14 +697,12 @@ paths:
                 x-class: Task
               examples:
                 Task created:
-                  value: |-
-                    {
-                      "id" : 101,
-                      "title" : "Wire up telemetry",
-                      "description" : "Prometheus + Grafana",
-                      "done" : false,
-                      "priority" : "high"
-                    }
+                  value:
+                    id: 101
+                    title: Wire up telemetry
+                    description: Prometheus + Grafana
+                    done: false
+                    priority: high
       security:
       - oauth2:
         - projects:read
@@ -851,26 +809,19 @@ paths:
                 x-class: PaginatedUsers
               examples:
                 First page of users:
-                  value: |-
-                    {
-                      "users" : [
-                        {
-                          "id" : "00000000-0000-0000-0000-000000000001",
-                          "email" : "alice@example.com",
-                          "name" : "Alice",
-                          "role" : "admin"
-                        },
-                        {
-                          "id" : "00000000-0000-0000-0000-000000000002",
-                          "email" : "bob@example.com",
-                          "name" : "Bob",
-                          "role" : "member"
-                        }
-                      ],
-                      "total" : 2,
-                      "page" : 1,
-                      "limit" : 20
-                    }
+                  value:
+                    users:
+                    - id: 00000000-0000-0000-0000-000000000001
+                      email: alice@example.com
+                      name: Alice
+                      role: admin
+                    - id: 00000000-0000-0000-0000-000000000002
+                      email: bob@example.com
+                      name: Bob
+                      role: member
+                    total: 2
+                    page: 1
+                    limit: 20
       security:
       - bearerAuth: []
   /users/{userId}:
@@ -925,13 +876,11 @@ paths:
                 x-class: User
               examples:
                 User found:
-                  value: |-
-                    {
-                      "id" : "00000000-0000-0000-0000-000000000001",
-                      "email" : "alice@example.com",
-                      "name" : "Alice",
-                      "role" : "admin"
-                    }
+                  value:
+                    id: 00000000-0000-0000-0000-000000000001
+                    email: alice@example.com
+                    name: Alice
+                    role: admin
         "404":
           description: User not found
           content:
@@ -954,12 +903,10 @@ paths:
                 x-class: ErrorResponse
               examples:
                 User not found:
-                  value: |-
-                    {
-                      "code" : "not_found",
-                      "message" : "No such user",
-                      "details" : null
-                    }
+                  value:
+                    code: not_found
+                    message: No such user
+                    details: null
       security:
       - bearerAuth: []
     put:
@@ -998,11 +945,9 @@ paths:
               x-class: UpdateUserRequest
             examples:
               User updated:
-                value: |-
-                  {
-                    "name" : "Alice Updated",
-                    "role" : "admin"
-                  }
+                value:
+                  name: Alice Updated
+                  role: admin
       responses:
         "200":
           description: User updated
@@ -1033,13 +978,11 @@ paths:
                 x-class: User
               examples:
                 User updated:
-                  value: |-
-                    {
-                      "id" : "00000000-0000-0000-0000-000000000001",
-                      "email" : "alice@example.com",
-                      "name" : "Alice Updated",
-                      "role" : "admin"
-                    }
+                  value:
+                    id: 00000000-0000-0000-0000-000000000001
+                    email: alice@example.com
+                    name: Alice Updated
+                    role: admin
       security:
       - bearerAuth: []
     delete:
@@ -1132,24 +1075,19 @@ paths:
                 x-class: PhotoUpload
               examples:
                 Photo uploaded; rendered variants returned keyed by name:
-                  value: |-
-                    {
-                      "id" : "00000000-0000-0000-0000-000000000010",
-                      "variants" : {
-                        "thumbnail" : {
-                          "url" : "https://cdn.example.com/photo_thumb.png",
-                          "width" : 64,
-                          "height" : 64,
-                          "format" : "png"
-                        },
-                        "full" : {
-                          "url" : "https://cdn.example.com/photo.png",
-                          "width" : 1024,
-                          "height" : 768,
-                          "format" : "png"
-                        }
-                      }
-                    }
+                  value:
+                    id: 00000000-0000-0000-0000-000000000010
+                    variants:
+                      thumbnail:
+                        url: https://cdn.example.com/photo_thumb.png
+                        width: 64
+                        height: 64
+                        format: png
+                      full:
+                        url: https://cdn.example.com/photo.png
+                        width: 1024
+                        height: 768
+                        format: png
       security:
       - bearerAuth: []
   /webhooks:
@@ -1177,17 +1115,13 @@ paths:
               x-class: WebhookPayload
             examples:
               Legacy plain-text ack:
-                value: |-
-                  {
-                    "event" : "order.created",
-                    "data" : "{\"id\":1}"
-                  }
+                value:
+                  event: order.created
+                  data: "{\"id\":1}"
               Webhook accepted:
-                value: |-
-                  {
-                    "event" : "order.created",
-                    "data" : "{\"id\":1}"
-                  }
+                value:
+                  event: order.created
+                  data: "{\"id\":1}"
       responses:
         "202":
           description: Legacy plain-text ack / Webhook accepted
@@ -1203,10 +1137,8 @@ paths:
                 x-class: WebhookAck
               examples:
                 Webhook accepted:
-                  value: |-
-                    {
-                      "received" : true
-                    }
+                  value:
+                    received: true
             text/plain:
               schema:
                 type: string

--- a/openapi/src/test/resources/gold/openapi/openapi.yml
+++ b/openapi/src/test/resources/gold/openapi/openapi.yml
@@ -470,7 +470,7 @@ paths:
         schema:
           type: integer
           format: int64
-        example: "42"
+        example: 42
       requestBody:
         content:
           application/json:
@@ -563,7 +563,7 @@ paths:
         schema:
           type: integer
           format: int64
-        example: "42"
+        example: 42
       responses:
         "200":
           description: All tasks in the project
@@ -628,7 +628,7 @@ paths:
         schema:
           type: integer
           format: int64
-        example: "42"
+        example: 42
       requestBody:
         content:
           application/json:
@@ -726,7 +726,7 @@ paths:
           type: integer
           format: int32
           default: null
-        example: "20"
+        example: 20
       - name: page
         in: query
         description: Page number (1-indexed)
@@ -736,7 +736,7 @@ paths:
           type: integer
           format: int32
           default: null
-        example: "1"
+        example: 1
       - name: role
         in: query
         description: Filter by role
@@ -761,7 +761,7 @@ paths:
               schema:
                 type: integer
                 format: int32
-              example: "59"
+              example: 59
           content:
             application/json:
               schema:

--- a/openapi/src/test/scala/pl/iterators/baklava/openapi/BaklavaScalatestInMemory.scala
+++ b/openapi/src/test/scala/pl/iterators/baklava/openapi/BaklavaScalatestInMemory.scala
@@ -20,6 +20,7 @@ trait BaklavaScalatestInMemory[
   override def afterAll(): Unit = {
     val openAPI = new OpenAPI()
     BaklavaDslFormatterOpenAPIWorker.generateForCalls(openAPI, listCalls)
+    OpenAPIInvariants.assertJsonExamplesAreStructured(openAPI)
     println(Yaml.pretty(openAPI))
   }
 }

--- a/openapi/src/test/scala/pl/iterators/baklava/openapi/JsonExampleObjectSpec.scala
+++ b/openapi/src/test/scala/pl/iterators/baklava/openapi/JsonExampleObjectSpec.scala
@@ -1,0 +1,155 @@
+package pl.iterators.baklava.openapi
+
+import io.swagger.v3.core.util.Yaml
+import io.swagger.v3.oas.models.OpenAPI
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
+import pl.iterators.baklava.*
+import sttp.model.{Method, StatusCode}
+
+import scala.jdk.CollectionConverters.*
+
+// Regression for #120: JSON examples must be structured objects, not re-printed strings.
+class JsonExampleObjectSpec extends AnyFunSpec with Matchers {
+
+  describe("OpenAPI example values for application/json bodies") {
+
+    it("emits response examples as structured objects, preserving key order and value types") {
+      val openAPI = new OpenAPI()
+      val body    =
+        """{"message":"Not Found","documentation_url":"https://docs.github.com/rest","status":"404","count":3,"active":true,"tags":["a","b"],"nested":{"x":1.5}}"""
+      BaklavaDslFormatterOpenAPIWorker.generateForCalls(openAPI, Seq(responseCall(desc = "User not found", body = body)))
+
+      val example = openAPI.getPaths
+        .get("/items")
+        .getGet
+        .getResponses
+        .get("200")
+        .getContent
+        .get("application/json")
+        .getExamples
+        .get("User not found")
+
+      example.getValue shouldBe a[java.util.Map[?, ?]]
+      val map = example.getValue.asInstanceOf[java.util.Map[String, Object]]
+      map.keySet.asScala.toList shouldBe List("message", "documentation_url", "status", "count", "active", "tags", "nested")
+      map.get("message") shouldBe "Not Found"
+      map.get("status") shouldBe "404"
+      map.get("count") shouldBe java.lang.Long.valueOf(3)
+      map.get("active") shouldBe java.lang.Boolean.TRUE
+      map.get("tags").asInstanceOf[java.util.List[Object]].asScala.toList shouldBe List("a", "b")
+      map.get("nested").asInstanceOf[java.util.Map[String, Object]].get("x") shouldBe new java.math.BigDecimal("1.5")
+    }
+
+    it("serializes response examples structurally in YAML, not as an escaped string blob") {
+      val openAPI = new OpenAPI()
+      BaklavaDslFormatterOpenAPIWorker.generateForCalls(
+        openAPI,
+        Seq(responseCall(desc = "User not found", body = """{"message":"Not Found"}"""))
+      )
+
+      val yaml = Yaml.pretty(openAPI)
+      yaml should include("message: Not Found")
+      yaml should not include "\"message\""
+    }
+
+    it("emits request body examples as structured objects") {
+      val openAPI = new OpenAPI()
+      BaklavaDslFormatterOpenAPIWorker.generateForCalls(
+        openAPI,
+        Seq(requestBodyCall(desc = "Create user", requestBody = """{"name":"John","age":42}"""))
+      )
+
+      val example = openAPI.getPaths
+        .get("/items")
+        .getPost
+        .getRequestBody
+        .getContent
+        .get("application/json")
+        .getExamples
+        .get("Create user")
+
+      example.getValue shouldBe a[java.util.Map[?, ?]]
+      val map = example.getValue.asInstanceOf[java.util.Map[String, Object]]
+      map.get("name") shouldBe "John"
+      map.get("age") shouldBe java.lang.Long.valueOf(42)
+    }
+
+    it("keeps non-JSON content types as raw strings") {
+      val openAPI = new OpenAPI()
+      BaklavaDslFormatterOpenAPIWorker.generateForCalls(
+        openAPI,
+        Seq(responseCall(desc = "plain", body = "just text", contentType = Some("text/plain")))
+      )
+
+      val example =
+        openAPI.getPaths.get("/items").getGet.getResponses.get("200").getContent.get("text/plain").getExamples.get("plain")
+      example.getValue shouldBe "just text"
+    }
+
+    it("falls back to the raw string when an application/json body does not parse") {
+      val openAPI = new OpenAPI()
+      BaklavaDslFormatterOpenAPIWorker.generateForCalls(
+        openAPI,
+        Seq(responseCall(desc = "broken", body = "{not json"))
+      )
+
+      val example =
+        openAPI.getPaths.get("/items").getGet.getResponses.get("200").getContent.get("application/json").getExamples.get("broken")
+      example.getValue shouldBe "{not json"
+    }
+  }
+
+  private def responseCall(
+      desc: String,
+      body: String,
+      contentType: Option[String] = Some("application/json")
+  ): BaklavaSerializableCall =
+    BaklavaSerializableCall(
+      request = requestContext(desc, method = "GET"),
+      response = BaklavaResponseContextSerializable(
+        protocol = BaklavaHttpProtocol("HTTP/1.1"),
+        status = StatusCode(200),
+        headers = Seq.empty,
+        bodyString = body,
+        requestContentType = None,
+        responseContentType = contentType,
+        bodySchema = Some(BaklavaSchemaSerializable(Schema.stringSchema))
+      )
+    )
+
+  private def requestBodyCall(desc: String, requestBody: String): BaklavaSerializableCall =
+    BaklavaSerializableCall(
+      request = requestContext(desc, method = "POST", bodyString = requestBody),
+      response = BaklavaResponseContextSerializable(
+        protocol = BaklavaHttpProtocol("HTTP/1.1"),
+        status = StatusCode(200),
+        headers = Seq.empty,
+        bodyString = "",
+        requestContentType = Some("application/json"),
+        responseContentType = None,
+        bodySchema = None
+      )
+    )
+
+  private def requestContext(desc: String, method: String, bodyString: String = ""): BaklavaRequestContextSerializable =
+    BaklavaRequestContextSerializable(
+      symbolicPath = "/items",
+      path = "/items",
+      pathDescription = None,
+      pathSummary = None,
+      method = Some(Method(method)),
+      operationDescription = None,
+      operationSummary = None,
+      operationId = None,
+      operationTags = Nil,
+      securitySchemes = Nil,
+      bodySchema = None,
+      bodyString = bodyString,
+      headersSeq = Nil,
+      pathParametersSeq = Nil,
+      queryParametersSeq = Nil,
+      responseDescription = Some(desc),
+      responseHeaders = Nil
+    )
+}

--- a/openapi/src/test/scala/pl/iterators/baklava/openapi/JsonExampleObjectSpec.scala
+++ b/openapi/src/test/scala/pl/iterators/baklava/openapi/JsonExampleObjectSpec.scala
@@ -75,6 +75,33 @@ class JsonExampleObjectSpec extends AnyFunSpec with Matchers {
       map.get("age") shouldBe java.lang.Long.valueOf(42)
     }
 
+    it("emits structured examples for +json structured-syntax suffix media types (regression for #129)") {
+      val openAPI = new OpenAPI()
+      BaklavaDslFormatterOpenAPIWorker.generateForCalls(
+        openAPI,
+        Seq(
+          responseCall(
+            desc = "Validation failed",
+            body = """{"title":"Invalid request"}""",
+            contentType = Some("application/problem+json")
+          )
+        )
+      )
+
+      val example = openAPI.getPaths
+        .get("/items")
+        .getGet
+        .getResponses
+        .get("200")
+        .getContent
+        .get("application/problem+json")
+        .getExamples
+        .get("Validation failed")
+
+      example.getValue shouldBe a[java.util.Map[?, ?]]
+      example.getValue.asInstanceOf[java.util.Map[String, Object]].get("title") shouldBe "Invalid request"
+    }
+
     it("keeps non-JSON content types as raw strings") {
       val openAPI = new OpenAPI()
       BaklavaDslFormatterOpenAPIWorker.generateForCalls(

--- a/openapi/src/test/scala/pl/iterators/baklava/openapi/OpenAPIInvariants.scala
+++ b/openapi/src/test/scala/pl/iterators/baklava/openapi/OpenAPIInvariants.scala
@@ -9,7 +9,7 @@ import scala.jdk.CollectionConverters.*
 // (e.g. the PetStore testcontainer suites, whose live responses vary between runs).
 object OpenAPIInvariants {
 
-  // Regression guard for #120 on end-to-end capture paths: application/json examples must be structured
+  // Regression guard for #120/#129 on end-to-end capture paths: JSON media-type examples must be structured
   // values, not re-printed strings. A String value is only an offender when its content parses to a JSON
   // object/array — scalar JSON bodies and unparseable-body fallbacks legitimately stay strings.
   def assertJsonExamplesAreStructured(openAPI: OpenAPI): Unit = {
@@ -20,7 +20,7 @@ object OpenAPIInvariants {
         content      <- Option(op.getRequestBody).flatMap(rb => Option(rb.getContent)).toList ++
           Option(op.getResponses).map(_.asScala.values.toList.flatMap(r => Option(r.getContent))).getOrElse(Nil)
         (mediaTypeName, mt) <- content.asScala.toList
-        if mediaTypeName == "application/json"
+        if mediaTypeName == "application/json" || mediaTypeName.endsWith("+json")
         (key, example) <- Option(mt.getExamples).map(_.asScala.toList).getOrElse(Nil)
         value          <- Option(example.getValue).toList
         if value.isInstanceOf[String] && parse(value.asInstanceOf[String]).exists(j => j.isObject || j.isArray)

--- a/openapi/src/test/scala/pl/iterators/baklava/openapi/OpenAPIInvariants.scala
+++ b/openapi/src/test/scala/pl/iterators/baklava/openapi/OpenAPIInvariants.scala
@@ -5,13 +5,10 @@ import io.swagger.v3.oas.models.OpenAPI
 
 import scala.jdk.CollectionConverters.*
 
-// Structural invariants asserted on generated specs by suites without a deterministic gold file
-// (e.g. the PetStore testcontainer suites, whose live responses vary between runs).
+// Structural checks for suites whose live responses preclude a deterministic gold file.
 object OpenAPIInvariants {
 
-  // Regression guard for #120/#129 on end-to-end capture paths: JSON media-type examples must be structured
-  // values, not re-printed strings. A String value is only an offender when its content parses to a JSON
-  // object/array — scalar JSON bodies and unparseable-body fallbacks legitimately stay strings.
+  // #120/#129 guard: a String example is an offender only when it parses to a JSON object/array
   def assertJsonExamplesAreStructured(openAPI: OpenAPI): Unit = {
     val offenders =
       for {

--- a/openapi/src/test/scala/pl/iterators/baklava/openapi/OpenAPIInvariants.scala
+++ b/openapi/src/test/scala/pl/iterators/baklava/openapi/OpenAPIInvariants.scala
@@ -1,0 +1,34 @@
+package pl.iterators.baklava.openapi
+
+import io.circe.parser.parse
+import io.swagger.v3.oas.models.OpenAPI
+
+import scala.jdk.CollectionConverters.*
+
+// Structural invariants asserted on generated specs by suites without a deterministic gold file
+// (e.g. the PetStore testcontainer suites, whose live responses vary between runs).
+object OpenAPIInvariants {
+
+  // Regression guard for #120 on end-to-end capture paths: application/json examples must be structured
+  // values, not re-printed strings. A String value is only an offender when its content parses to a JSON
+  // object/array — scalar JSON bodies and unparseable-body fallbacks legitimately stay strings.
+  def assertJsonExamplesAreStructured(openAPI: OpenAPI): Unit = {
+    val offenders =
+      for {
+        (path, item) <- Option(openAPI.getPaths).map(_.asScala.toList).getOrElse(Nil)
+        (method, op) <- item.readOperationsMap().asScala.toList
+        content      <- Option(op.getRequestBody).flatMap(rb => Option(rb.getContent)).toList ++
+          Option(op.getResponses).map(_.asScala.values.toList.flatMap(r => Option(r.getContent))).getOrElse(Nil)
+        (mediaTypeName, mt) <- content.asScala.toList
+        if mediaTypeName == "application/json"
+        (key, example) <- Option(mt.getExamples).map(_.asScala.toList).getOrElse(Nil)
+        value          <- Option(example.getValue).toList
+        if value.isInstanceOf[String] && parse(value.asInstanceOf[String]).exists(j => j.isObject || j.isArray)
+      } yield s"$method $path -> $mediaTypeName -> $key"
+
+    if (offenders.nonEmpty)
+      throw new AssertionError(
+        ("application/json examples emitted as strings instead of structured values (#120):" +: offenders).mkString("\n  ")
+      )
+  }
+}

--- a/openapi/src/test/scala/pl/iterators/baklava/openapi/ParameterExampleSpec.scala
+++ b/openapi/src/test/scala/pl/iterators/baklava/openapi/ParameterExampleSpec.scala
@@ -129,6 +129,108 @@ class ParameterExampleSpec extends AnyFunSpec with Matchers {
     }
   }
 
+  describe("parameter example coercion to the declared schema type (regression for #130)") {
+
+    it("emits integer query parameter examples as numbers") {
+      val call = synthCall(
+        symbolicPath = "/search",
+        resolvedPath = "/search?limit=10",
+        queryParams = Seq(("limit", "")),
+        paramSchema = intSchemaSerializable
+      )
+
+      val openAPI = new OpenAPI()
+      BaklavaDslFormatterOpenAPIWorker.generateForCalls(openAPI, Seq(call))
+
+      val limitParam = openAPI.getPaths.get("/search").getGet.getParameters.asScala.find(_.getName == "limit").get
+      limitParam.getExample shouldBe java.lang.Long.valueOf(10)
+    }
+
+    it("emits boolean query parameter examples as booleans") {
+      val call = synthCall(
+        symbolicPath = "/search",
+        resolvedPath = "/search?active=true",
+        queryParams = Seq(("active", "")),
+        paramSchema = BaklavaSchemaSerializable(Schema.booleanSchema)
+      )
+
+      val openAPI = new OpenAPI()
+      BaklavaDslFormatterOpenAPIWorker.generateForCalls(openAPI, Seq(call))
+
+      val activeParam = openAPI.getPaths.get("/search").getGet.getParameters.asScala.find(_.getName == "active").get
+      activeParam.getExample shouldBe java.lang.Boolean.TRUE
+    }
+
+    it("emits number path parameter examples as decimals") {
+      val call = synthCall(
+        symbolicPath = "/rates/{value}",
+        resolvedPath = "/rates/1.5",
+        pathParams = Seq(("value", "1.5")),
+        paramSchema = BaklavaSchemaSerializable(Schema.doubleSchema)
+      )
+
+      val openAPI = new OpenAPI()
+      BaklavaDslFormatterOpenAPIWorker.generateForCalls(openAPI, Seq(call))
+
+      val valueParam = openAPI.getPaths.get("/rates/{value}").getGet.getParameters.asScala.find(_.getName == "value").get
+      valueParam.getExample shouldBe new java.math.BigDecimal("1.5")
+    }
+
+    it("coerces named examples when calls captured different values") {
+      val call1 = synthCall(
+        symbolicPath = "/items/{id}",
+        resolvedPath = "/items/42",
+        pathParams = Seq(("id", "42")),
+        scenarioName = Some("found"),
+        paramSchema = intSchemaSerializable
+      )
+      val call2 = synthCall(
+        symbolicPath = "/items/{id}",
+        resolvedPath = "/items/7",
+        pathParams = Seq(("id", "7")),
+        scenarioName = Some("other"),
+        paramSchema = intSchemaSerializable
+      )
+
+      val openAPI = new OpenAPI()
+      BaklavaDslFormatterOpenAPIWorker.generateForCalls(openAPI, Seq(call1, call2))
+
+      val examples = openAPI.getPaths.get("/items/{id}").getGet.getParameters.asScala.find(_.getName == "id").get.getExamples.asScala
+      examples("found").getValue shouldBe java.lang.Long.valueOf(42)
+      examples("other").getValue shouldBe java.lang.Long.valueOf(7)
+    }
+
+    it("keeps the raw string when the captured value does not parse as the schema type") {
+      val call = synthCall(
+        symbolicPath = "/search",
+        resolvedPath = "/search?limit=abc",
+        queryParams = Seq(("limit", "")),
+        paramSchema = intSchemaSerializable
+      )
+
+      val openAPI = new OpenAPI()
+      BaklavaDslFormatterOpenAPIWorker.generateForCalls(openAPI, Seq(call))
+
+      val limitParam = openAPI.getPaths.get("/search").getGet.getParameters.asScala.find(_.getName == "limit").get
+      limitParam.getExample shouldBe "abc"
+    }
+
+    it("coerces response header examples to the declared schema type") {
+      val call = synthCall(
+        symbolicPath = "/counted",
+        resolvedPath = "/counted",
+        sentHeaders = Map("X-Count" -> "7"),
+        responseHeaders = Seq(BaklavaHeaderSerializable("X-Count", None, intSchemaSerializable, None))
+      )
+
+      val openAPI = new OpenAPI()
+      BaklavaDslFormatterOpenAPIWorker.generateForCalls(openAPI, Seq(call))
+
+      val header = openAPI.getPaths.get("/counted").getGet.getResponses.get("200").getHeaders.get("X-Count")
+      header.getExample shouldBe java.lang.Long.valueOf(7)
+    }
+  }
+
   describe("end-to-end extraction through BaklavaRequestContextSerializable.apply") {
     // These tests drive the real serializer — no duplicated extraction logic — to catch regressions
     // in the URL parsing that the synthCall-based tests above can't see.
@@ -215,7 +317,8 @@ class ParameterExampleSpec extends AnyFunSpec with Matchers {
       responseHeaders = Nil
     )
 
-  private val stringSchema = BaklavaSchemaSerializable(Schema.stringSchema)
+  private val stringSchema          = BaklavaSchemaSerializable(Schema.stringSchema)
+  private val intSchemaSerializable = BaklavaSchemaSerializable(Schema.intSchema)
 
   private def synthCall(
       symbolicPath: String,
@@ -224,7 +327,9 @@ class ParameterExampleSpec extends AnyFunSpec with Matchers {
       pathParams: Seq[(String, String)] = Nil,
       headers: Seq[(String, String)] = Nil,
       sentHeaders: Map[String, String] = Map.empty,
-      scenarioName: Option[String] = None
+      scenarioName: Option[String] = None,
+      paramSchema: BaklavaSchemaSerializable = stringSchema,
+      responseHeaders: Seq[BaklavaHeaderSerializable] = Nil
   ): BaklavaSerializableCall = {
     // The test directly constructs BaklavaSerializableCall bypassing the normal extraction path,
     // so we can exercise the generator-side emission independently. We still manually plug in
@@ -249,18 +354,18 @@ class ParameterExampleSpec extends AnyFunSpec with Matchers {
           BaklavaHeaderSerializable(
             name,
             None,
-            stringSchema,
+            paramSchema,
             sentHeaders.find(_._1.toLowerCase == name.toLowerCase).map(_._2)
           )
         },
         pathParametersSeq = pathParams.map { case (name, _) =>
-          BaklavaPathParamSerializable(name, None, stringSchema, path.get(name))
+          BaklavaPathParamSerializable(name, None, paramSchema, path.get(name))
         },
         queryParametersSeq = queryParams.map { case (name, _) =>
-          BaklavaQueryParamSerializable(name, None, stringSchema, query.get(name))
+          BaklavaQueryParamSerializable(name, None, paramSchema, query.get(name))
         },
         responseDescription = scenarioName.orElse(Some("ok")),
-        responseHeaders = Nil
+        responseHeaders = responseHeaders
       ),
       response = BaklavaResponseContextSerializable(
         protocol = BaklavaHttpProtocol("HTTP/1.1"),

--- a/openapi/src/test/scala/pl/iterators/baklava/openapi/ResponseContentTypeMergeSpec.scala
+++ b/openapi/src/test/scala/pl/iterators/baklava/openapi/ResponseContentTypeMergeSpec.scala
@@ -24,7 +24,10 @@ class ResponseContentTypeMergeSpec extends AnyFunSpec with Matchers {
 
       val content = openAPI.getPaths.get("/items").getGet.getResponses.get("200").getContent
       content.keySet.asScala.toList.sorted shouldBe List("application/json", "application/xml")
-      content.get("application/json").getExamples.get("JSON").getValue.toString should include("\"a\"")
+      content.get("application/json").getExamples.get("JSON").getValue match {
+        case m: java.util.Map[?, ?] => m.get("a") shouldBe java.lang.Long.valueOf(1)
+        case other                  => fail(s"expected structured JSON example, got: $other")
+      }
       content.get("application/xml").getExamples.get("XML").getValue shouldBe "<a>1</a>"
     }
 


### PR DESCRIPTION
## Summary

For `application/json` media types, `BaklavaDslFormatterOpenAPIWorker` now converts the parsed circe `Json` into a Java object tree (`LinkedHashMap`/`ArrayList`, preserving captured key order) and passes that to swagger-core's `Example.value(...)`, instead of re-printing it to a string. Serialized output goes from an escaped string blob:

```yaml
examples:
  User not found:
    value: |-
      {
        "message" : "Not Found"
      }
```

to a structural value that validates against `type: object` schemas (e.g. Redocly's `no-invalid-media-type-examples`) and renders as a browsable object in Swagger UI/Redoc:

```yaml
examples:
  User not found:
    value:
      message: Not Found
```

Applies to both response and request-body examples. Non-JSON content types and unparseable JSON bodies keep the raw-string behavior.

The `jsonToJavaDefault` helper from #61 is subsumed by the new `jsonToJavaObject` (same conversion), which also makes schema-default key order stable.

Fixes #120

## Test plan

- New `JsonExampleObjectSpec` covers: structured response examples (key order + value types), structured request-body examples, YAML structural serialization, raw-string preservation for non-JSON content types, and raw-string fallback for unparseable JSON
- `ResponseContentTypeMergeSpec` updated to assert on the structured value
- Gold file regenerated; diff is uniformly `value: |-` blobs → structural `value:` maps
- Full suite green on Scala 2.13.18 and 3.3.7

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019svHBC5nktCrBRp7x7eLJn