### PR TITLE
Add baklava-sttp adapter for documenting remote APIs (#121)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,11 +75,11 @@ jobs:
 
       - name: Make target directories
         if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main')
-        run: mkdir -p scalatest/target http4sroutes/target http4s/target postman/target openapi/target tsfetch/target pekkohttproutes/target simple/target orpc/target sbtplugin/target sttpclient/target munit/target core/target tsrest/target specs2/target pekkohttp/target tscommon/target project/target
+        run: mkdir -p sttp/target scalatest/target http4sroutes/target http4s/target postman/target openapi/target tsfetch/target pekkohttproutes/target simple/target orpc/target sbtplugin/target sttpclient/target munit/target core/target tsrest/target specs2/target pekkohttp/target tscommon/target project/target
 
       - name: Compress target directories
         if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main')
-        run: tar cf targets.tar scalatest/target http4sroutes/target http4s/target postman/target openapi/target tsfetch/target pekkohttproutes/target simple/target orpc/target sbtplugin/target sttpclient/target munit/target core/target tsrest/target specs2/target pekkohttp/target tscommon/target project/target
+        run: tar cf targets.tar sttp/target scalatest/target http4sroutes/target http4s/target postman/target openapi/target tsfetch/target pekkohttproutes/target simple/target orpc/target sbtplugin/target sttpclient/target munit/target core/target tsrest/target specs2/target pekkohttp/target tscommon/target project/target
 
       - name: Upload target directories
         if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main')

--- a/build.sbt
+++ b/build.sbt
@@ -99,6 +99,7 @@ lazy val baklava =
     pekkohttproutes,
     http4s,
     http4sroutes,
+    sttp,
     specs2,
     scalatest,
     munit,
@@ -128,6 +129,7 @@ val webjarsLocatorV = "0.52"
 val swaggerUiV      = "5.32.1"
 val typesafeConfigV = "1.4.6"
 val sttpModelV      = "1.7.17"
+val sttpClient4V    = "4.0.25"
 
 lazy val core = project
   .in(file("core"))
@@ -301,6 +303,16 @@ lazy val http4sroutes = project
       "io.swagger.parser.v3" % "swagger-parser"  % swaggerParserV,
       "org.webjars"          % "swagger-ui"      % swaggerUiV,
       "org.scalatest"       %% "scalatest"       % scalatestV % "test"
+    )
+  )
+
+lazy val sttp = project
+  .in(file("sttp"))
+  .dependsOn(core, scalatest % "test")
+  .settings(
+    name := "baklava-sttp",
+    libraryDependencies ++= Seq(
+      "com.softwaremill.sttp.client4" %% "core" % sttpClient4V
     )
   )
 

--- a/build.sbt
+++ b/build.sbt
@@ -222,6 +222,7 @@ lazy val openapi = project
     orpc       % "test",
     postman    % "test",
     sttpclient % "test",
+    sttp       % "test",
     tsfetch    % "test"
   )
   .settings(

--- a/core/src/main/scala/pl/iterators/baklava/BaklavaSerialize.scala
+++ b/core/src/main/scala/pl/iterators/baklava/BaklavaSerialize.scala
@@ -261,7 +261,7 @@ object BaklavaRequestContextSerializable {
       operationId = c.operationId,
       operationTags = c.operationTags,
       securitySchemes = c.securitySchemes.map(s => BaklavaSecuritySchemaSerializable(s)),
-      bodySchema = c.bodySchema.filter(_ != Schema.emptyBodySchema).map(s => BaklavaSchemaSerializable(s)),
+      bodySchema = c.bodySchema.filterNot(Schema.isEmptyBody).map(s => BaklavaSchemaSerializable(s)),
       bodyString = bodyString,
       headersSeq = c.headersSeq.map { h =>
         BaklavaHeaderSerializable(h, caseInsensitiveHeaderValue(c.headers, h.name))
@@ -359,7 +359,7 @@ object BaklavaResponseContextSerializable {
       bodyString = c.responseBodyString,
       requestContentType = c.requestContentType,
       responseContentType = c.responseContentType,
-      bodySchema = c.bodySchema.filter(_ != Schema.emptyBodySchema).map(s => BaklavaSchemaSerializable(s))
+      bodySchema = c.bodySchema.filterNot(Schema.isEmptyBody).map(s => BaklavaSchemaSerializable(s))
     )
 }
 

--- a/core/src/main/scala/pl/iterators/baklava/BaklavaTestFrameworkDsl.scala
+++ b/core/src/main/scala/pl/iterators/baklava/BaklavaTestFrameworkDsl.scala
@@ -261,7 +261,7 @@ trait BaklavaTestFrameworkDsl[RouteType, ToRequestBodyType[_], FromResponseBodyT
       )
     }
 
-    if (responseContext.responseBodyString.nonEmpty && responseBodySchema == Schema.emptyBodySchema) {
+    if (responseContext.responseBodyString.nonEmpty && Schema.isEmptyBody(responseBodySchema)) {
       throw new BaklavaAssertionException(
         "Expected empty response body, but got: " + responseContext.responseBodyString.take(maxBodyLengthInAssertion)
       )
@@ -378,8 +378,7 @@ trait BaklavaTestFrameworkDsl[RouteType, ToRequestBodyType[_], FromResponseBodyT
                       ],
                       route: RouteType
                   ) => {
-                    // count the attempt, not the completion — decode failures throw from inside
-                    // baklavaPerformRequest and would otherwise report "was not called" (issue #128)
+                    // count the attempt, not the completion — decode failures throw from inside (#128)
                     timesCalled += 1
                     val responseContext =
                       baklavaPerformRequest[
@@ -659,8 +658,7 @@ trait BaklavaTestFrameworkDsl[RouteType, ToRequestBodyType[_], FromResponseBodyT
                 ],
                 route: RouteType
             ) => {
-              // count the attempt, not the completion — decode failures throw from inside
-              // baklavaPerformRequest and would otherwise report "was not called" (issue #128)
+              // count the attempt, not the completion — decode failures throw from inside (#128)
               timesCalled += 1
               val responseContext =
                 baklavaPerformRequest[

--- a/core/src/main/scala/pl/iterators/baklava/BaklavaTestFrameworkDsl.scala
+++ b/core/src/main/scala/pl/iterators/baklava/BaklavaTestFrameworkDsl.scala
@@ -378,6 +378,9 @@ trait BaklavaTestFrameworkDsl[RouteType, ToRequestBodyType[_], FromResponseBodyT
                       ],
                       route: RouteType
                   ) => {
+                    // count the attempt, not the completion — decode failures throw from inside
+                    // baklavaPerformRequest and would otherwise report "was not called" (issue #128)
+                    timesCalled += 1
                     val responseContext =
                       baklavaPerformRequest[
                         RequestBody,
@@ -392,7 +395,6 @@ trait BaklavaTestFrameworkDsl[RouteType, ToRequestBodyType[_], FromResponseBodyT
                         requestContext,
                         route
                       )
-                    timesCalled += 1
 
                     validateResponseAndStore[
                       RequestBody,
@@ -657,6 +659,9 @@ trait BaklavaTestFrameworkDsl[RouteType, ToRequestBodyType[_], FromResponseBodyT
                 ],
                 route: RouteType
             ) => {
+              // count the attempt, not the completion — decode failures throw from inside
+              // baklavaPerformRequest and would otherwise report "was not called" (issue #128)
+              timesCalled += 1
               val responseContext =
                 baklavaPerformRequest[
                   RequestBody,
@@ -671,7 +676,6 @@ trait BaklavaTestFrameworkDsl[RouteType, ToRequestBodyType[_], FromResponseBodyT
                   requestContext,
                   route
                 )
-              timesCalled += 1
 
               validateResponseAndStore[
                 RequestBody,

--- a/core/src/main/scala/pl/iterators/baklava/Schema.scala
+++ b/core/src/main/scala/pl/iterators/baklava/Schema.scala
@@ -232,4 +232,7 @@ trait SchemaDefaults {
 
 }
 
-object Schema extends SchemaDerivation with SchemaDefaults {}
+object Schema extends SchemaDerivation with SchemaDefaults {
+  // every SchemaDefaults mixin carries its own emptyBodySchema instance, so identity checks miss
+  def isEmptyBody(schema: Schema[?]): Boolean = schema.`type` == SchemaType.NullType && schema.className == "EmptyBody"
+}

--- a/core/src/test/scala/pl/iterators/baklava/EmptyBodySchemaIdentitySpec.scala
+++ b/core/src/test/scala/pl/iterators/baklava/EmptyBodySchemaIdentitySpec.scala
@@ -1,0 +1,70 @@
+package pl.iterators.baklava
+
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
+import sttp.model.{Method, StatusCode}
+
+// a spec mixing SchemaDefaults (e.g. the naming-strategy pattern) resolves its own
+// emptyBodySchema instance, so identity comparisons against Schema.emptyBodySchema miss
+class EmptyBodySchemaIdentitySpec extends AnyFunSpec with Matchers {
+
+  private val mixinEmptyBodySchema = new SchemaDefaults {}.emptyBodySchema
+
+  it("recognizes any SchemaDefaults instance's EmptyBody schema") {
+    Schema.isEmptyBody(Schema.emptyBodySchema) shouldBe true
+    Schema.isEmptyBody(mixinEmptyBodySchema) shouldBe true
+    Schema.isEmptyBody(Schema.stringSchema) shouldBe false
+  }
+
+  it("drops a mixin-resolved EmptyBody schema from serialized requests") {
+    BaklavaRequestContextSerializable(requestContext(Some(mixinEmptyBodySchema)), "").bodySchema shouldBe None
+  }
+
+  it("drops a mixin-resolved EmptyBody schema from serialized responses") {
+    val response = BaklavaResponseContext[EmptyBody, Unit, Unit](
+      protocol = BaklavaHttpProtocol("HTTP/1.1"),
+      status = StatusCode.Ok,
+      headers = Seq.empty,
+      body = EmptyBodyInstance,
+      rawRequest = (),
+      requestBodyString = "",
+      rawResponse = (),
+      responseBodyString = "",
+      requestContentType = None,
+      responseContentType = None,
+      bodySchema = Some(mixinEmptyBodySchema)
+    )
+    BaklavaResponseContextSerializable(response).bodySchema shouldBe None
+  }
+
+  private def requestContext(
+      bodySchema: Option[Schema[EmptyBody]]
+  ): BaklavaRequestContext[EmptyBody, Unit, Unit, Unit, Unit, Unit, Unit] =
+    BaklavaRequestContext[EmptyBody, Unit, Unit, Unit, Unit, Unit, Unit](
+      symbolicPath = "/x",
+      path = "/x",
+      pathDescription = None,
+      pathSummary = None,
+      method = Some(Method.GET),
+      operationDescription = None,
+      operationSummary = None,
+      operationId = None,
+      operationTags = Seq.empty,
+      securitySchemes = Seq.empty,
+      body = None,
+      bodySchema = bodySchema,
+      headers = Seq.empty,
+      headersDefinition = (),
+      headersProvided = (),
+      headersSeq = Seq.empty,
+      security = AppliedSecurity(NoopSecurity, Map.empty),
+      pathParameters = (),
+      pathParametersProvided = (),
+      pathParametersSeq = Seq.empty,
+      queryParameters = (),
+      queryParametersProvided = (),
+      queryParametersSeq = Seq.empty,
+      responseDescription = None,
+      responseHeaders = Seq.empty
+    )
+}

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 7
+sidebar_position: 8
 title: Configuration
 ---
 

--- a/docs/dsl-reference.md
+++ b/docs/dsl-reference.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 5
+sidebar_position: 6
 title: DSL Reference
 ---
 

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 8
+sidebar_position: 9
 title: Examples
 ---
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -7,7 +7,7 @@ title: Installation
 
 To use Baklava, you need to choose:
 
-1. **HTTP Server**: Pekko HTTP or HTTP4s
+1. **HTTP Integration**: Pekko HTTP, HTTP4s (for routes you serve), or sttp (for remote APIs you consume)
 2. **Test Framework**: Specs2, ScalaTest, or MUnit
 3. **Output Format**: Simple, OpenAPI, or TS-REST
 
@@ -31,13 +31,16 @@ Add the required dependencies to your `build.sbt` based on your choices:
 
 #### Core Dependencies (Required)
 
-**HTTP Server Integration** - Choose one:
+**HTTP Integration** - Choose one:
 ```scala
 // For Pekko HTTP
 libraryDependencies += "pl.iterators" %% "baklava-pekko-http" % "VERSION" % Test
 
 // For HTTP4s
 libraryDependencies += "pl.iterators" %% "baklava-http4s" % "VERSION" % Test
+
+// For remote/third-party APIs via sttp-client
+libraryDependencies += "pl.iterators" %% "baklava-sttp" % "VERSION" % Test
 ```
 
 **Test Framework Integration** - Choose one:

--- a/docs/intro.md
+++ b/docs/intro.md
@@ -9,7 +9,7 @@ Baklava is a Scala library that generates API documentation directly from your H
 
 ### Supported stacks
 
-- **HTTP Servers**: Pekko HTTP, http4s
+- **HTTP Integration**: Pekko HTTP, http4s (for routes you serve), or sttp (for remote APIs you consume)
 - **Test Frameworks**: ScalaTest, Specs2, MUnit
 - **Output Formats**: OpenAPI (with optional SwaggerUI), Simple, TS-REST
 - **Scala Versions**: 2.13 and 3 (LTS)
@@ -26,6 +26,7 @@ Baklava is a Scala library that generates API documentation directly from your H
 - [Installation](installation.md)
 - [Pekko HTTP Integration](pekko-http.md)
 - [http4s Integration](http4s.md)
+- [Remote APIs (sttp)](sttp.md)
 - [DSL Reference](dsl-reference.md)
 - [Examples](examples.md)
 - [Configuration](configuration.md)

--- a/docs/output-formats.md
+++ b/docs/output-formats.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 6
+sidebar_position: 7
 title: Output Formats
 ---
 

--- a/docs/scala-cli.md
+++ b/docs/scala-cli.md
@@ -10,7 +10,7 @@ You don't need an sbt project to use Baklava. With [scala-cli](https://scala-cli
 - **Trying Baklava in two minutes**, with zero build setup.
 - **Documenting a third-party API**: point Baklava at any HTTP service, assert on its real responses, and get an OpenAPI spec plus typed clients from behavior you have verified.
 
-The script below tests two endpoints of the **live GitHub REST API** and produces an OpenAPI spec and an [sttp-client4](https://sttp.softwaremill.com) source tree.
+The script below tests two endpoints of the **live GitHub REST API** through the [`baklava-sttp` remote-API adapter](sttp.md) and produces an OpenAPI spec and an [sttp-client4](https://sttp.softwaremill.com) source tree.
 
 ## The script
 
@@ -18,54 +18,31 @@ Save as `github-api-docs.test.scala`:
 
 ```scala
 //> using scala 3.3.8
-//> using dep pl.iterators::baklava-http4s:2.0.0
-//> using dep pl.iterators::baklava-munit:2.0.0
-//> using dep pl.iterators::baklava-openapi:2.0.0
-//> using dep pl.iterators::baklava-sttpclient:2.0.0
-//> using dep org.http4s::http4s-ember-client:0.23.36
-//> using dep org.http4s::http4s-circe:0.23.36
+//> using dep pl.iterators::baklava-sttp:2.1.0
+//> using dep pl.iterators::baklava-munit:2.1.0
+//> using dep pl.iterators::baklava-openapi:2.1.0
+//> using dep pl.iterators::baklava-sttpclient:2.1.0
 //> using dep io.circe::circe-generic:0.14.16
 
-import cats.effect.IO
-import cats.effect.unsafe.IORuntime
 import io.circe.generic.auto.*
-import org.http4s.circe.CirceEntityDecoder.*
-import org.http4s.ember.client.EmberClientBuilder
-import org.http4s.{Header, HttpRoutes, Request, Response, Uri}
-import org.http4s.Method.*
-import org.http4s.Status.*
-import org.typelevel.ci.CIString
 import pl.iterators.baklava.BaklavaGenerate
-import pl.iterators.baklava.http4s.BaklavaHttp4s
 import pl.iterators.baklava.munit.{BaklavaMunit, MunitAsExecution}
+import pl.iterators.baklava.sttp4.{BaklavaSttp, FromSttpBody, ToSttpBody}
+import sttp.client4.SyncBackend
+import sttp.model.Method.*
+import sttp.model.StatusCode.*
+import sttp.model.{Header, Uri}
 
 case class GitHubUser(login: String, id: Long, name: Option[String], company: Option[String], public_repos: Int, followers: Int)
 case class GitHubRepo(name: String, full_name: String, description: Option[String], stargazers_count: Int, language: Option[String])
 case class GitHubError(message: String, documentation_url: Option[String])
 
 class GitHubApiSpec
-    extends BaklavaMunit[HttpRoutes[IO], BaklavaHttp4s.ToEntityMarshaller, BaklavaHttp4s.FromEntityUnmarshaller]
-    with BaklavaHttp4s[Unit, Unit, MunitAsExecution] {
+    extends BaklavaMunit[SyncBackend, ToSttpBody, FromSttpBody]
+    with BaklavaSttp[Unit, Unit, MunitAsExecution] {
 
-  implicit val runtime: IORuntime                = IORuntime.global
-  override def strictHeaderCheckDefault: Boolean = false
-
-  // baklava normally tests local routes; for a remote API we send each request with a real client
-  val routes: HttpRoutes[IO] = HttpRoutes.empty[IO]
-
-  override def performRequest(routes: HttpRoutes[IO], request: Request[IO]): Response[IO] =
-    EmberClientBuilder
-      .default[IO]
-      .build
-      .use { client =>
-        val remote = request
-          .withUri(Uri.unsafeFromString(s"https://api.github.com${request.uri}"))
-          .putHeaders(Header.Raw(CIString("User-Agent"), "baklava-demo"))
-        client.run(remote).use { response =>
-          response.body.compile.toList.map(bytes => response.copy(body = fs2.Stream.emits(bytes)))
-        }
-      }
-      .unsafeRunSync()
+  override def baseUri: Uri                = Uri.unsafeParse("https://api.github.com")
+  override def defaultHeaders: Seq[Header] = Seq(Header("User-Agent", "baklava-demo"))
 
   path("/users/{username}")(
     supports(
@@ -78,13 +55,13 @@ class GitHubApiSpec
       onRequest(pathParameters = "octocat")
         .respondsWith[GitHubUser](Ok, description = "User found")
         .assert { ctx =>
-          val response = ctx.performRequest(routes)
+          val response = ctx.performRequest(defaultBackend)
           assertEquals(response.body.login, "octocat")
         },
       onRequest(pathParameters = "no-such-user-baklava-4711")
         .respondsWith[GitHubError](NotFound, description = "User not found")
         .assert { ctx =>
-          ctx.performRequest(routes)
+          ctx.performRequest(defaultBackend)
         }
     )
   )
@@ -100,7 +77,7 @@ class GitHubApiSpec
       onRequest(pathParameters = ("theiterators", "baklava"))
         .respondsWith[GitHubRepo](Ok, description = "Repository found")
         .assert { ctx =>
-          val response = ctx.performRequest(routes)
+          val response = ctx.performRequest(defaultBackend)
           assertEquals(response.body.full_name, "theiterators/baklava")
         }
     )
@@ -136,7 +113,7 @@ scala-cli test github-api-docs.test.scala
 
 ```
 Test run GitHubApiSpec started
-GitHubApiSpec: finished 7.61s
+GitHubApiSpec: finished 1.77s
 Test run GitHubApiSpec finished: 0 failed, 0 ignored, 3 total
 ```
 
@@ -216,6 +193,6 @@ final case class GitHubUser(company: Option[String] = None, followers: Int, id: 
 
 ## How it works
 
-- **Remote APIs via `performRequest`**: Baklava's DSL builds an `http4s` `Request[IO]` and hands it to `performRequest`, which normally runs it against local routes. Overriding it to send the request with a real client (Ember here) turns Baklava into a documentation-generating integration test for any HTTP service. The response body is compiled to memory so it can be read both by your assertions and by the serializer.
+- **Remote APIs via `baklava-sttp`**: the [sttp adapter](sttp.md) sends every request over the network with sttp-client4, resolved against `baseUri` — no HTTP server stack, no effect runtime, no `performRequest` override. Strict header checking is off by default (remote services always send undeclared headers), and response bodies are read fully into memory so both your assertions and the serializer can consume them. JSON codecs come from plain circe `Encoder`/`Decoder` instances — `circe-generic`'s auto derivation is enough here.
 - **Generation in `afterAll`**: the sbt plugin normally runs `BaklavaGenerate` after `sbt test`. In a standalone script we call it from `afterAll` instead, so a single `scala-cli test` invocation runs the tests and generates output. Config entries use the `key|<base64 value>` argument format; formatters are auto-discovered from the classpath, so which outputs you get is controlled purely by the `//> using dep` lines — swap in `baklava-tsrest`, `baklava-orpc`, `baklava-simple`, or `baklava-postman` to taste.
-- **Rate limits**: unauthenticated GitHub API calls are limited to 60/hour per IP; this script makes 3 per run. If you document an API that needs auth, add the header in `performRequest` (e.g. a bearer token from an environment variable) or document it properly with Baklava's `security` DSL — see [DSL Reference](dsl-reference.md).
+- **Rate limits**: unauthenticated GitHub API calls are limited to 60/hour per IP; this script makes 3 per run. If you document an API that needs auth, add the header to `defaultHeaders` (e.g. a bearer token from an environment variable) or document it properly with Baklava's `security` DSL — see [DSL Reference](dsl-reference.md).

--- a/docs/scala-cli.md
+++ b/docs/scala-cli.md
@@ -168,7 +168,7 @@ paths:
                 properties:
                   login: { type: string }
                   id: { type: integer, format: int64 }
-                  name: { type: string }
+                  name: { type: string, nullable: true }
                   # ...
         "404":
           description: User not found

--- a/docs/scala-cli.md
+++ b/docs/scala-cli.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 9
+sidebar_position: 10
 title: Standalone Scripts (scala-cli)
 ---
 

--- a/docs/sttp.md
+++ b/docs/sttp.md
@@ -72,6 +72,7 @@ used in `respondsWith[T]`.
   proxies, TLS, timeouts, or to wrap the backend (e.g. logging).
 - `defaultHeaders` are added to every request; headers declared in a test win on
   name conflict. Good for `User-Agent` or auth tokens from the environment.
+  `Content-Type` is rejected here — declare it per request in the test's headers.
 - Response bodies are read fully into memory, so assertions and the documentation
   serializer can both consume them.
 

--- a/docs/sttp.md
+++ b/docs/sttp.md
@@ -1,0 +1,82 @@
+---
+sidebar_position: 5
+title: Remote APIs (sttp)
+---
+
+# Documenting Remote APIs with sttp
+
+`baklava-sttp` documents APIs you *consume* rather than routes you serve. It sends each
+test request over the network with [sttp-client4](https://sttp.softwaremill.com/) — no
+HTTP server stack, no effect runtime, no `performRequest` overrides.
+
+## Installation
+
+```scala
+libraryDependencies ++= Seq(
+  "pl.iterators" %% "baklava-sttp" % "VERSION" % Test,
+  "pl.iterators" %% "baklava-scalatest" % "VERSION" % Test, // or -specs2 / -munit
+  "pl.iterators" %% "baklava-openapi" % "VERSION" % Test    // or any other output format
+)
+```
+
+## Usage
+
+The only thing you must provide is `baseUri`:
+
+```scala
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
+import pl.iterators.baklava.scalatest.{BaklavaScalatest, ScalatestAsExecution}
+import pl.iterators.baklava.sttp4.{BaklavaSttp, FromSttpBody, ToSttpBody}
+import sttp.client4.SyncBackend
+import sttp.model.{Header, Method, StatusCode, Uri}
+
+class GitHubApiSpec
+    extends AnyFunSpec
+    with Matchers
+    with BaklavaSttp[Unit, Unit, ScalatestAsExecution]
+    with BaklavaScalatest[SyncBackend, ToSttpBody, FromSttpBody] {
+
+  override def baseUri: Uri = Uri.unsafeParse("https://api.github.com")
+  override def defaultHeaders: Seq[Header] = Seq(Header("User-Agent", "baklava-demo"))
+
+  path("/orgs/{org}")(
+    supports(
+      Method.GET,
+      pathParameters = p[String]("org"),
+      summary = "Get an organization",
+      operationId = "getOrg",
+      tags = Seq("orgs")
+    )(
+      onRequest(pathParameters = "theiterators")
+        .respondsWith[String](StatusCode.Ok, description = "organization profile")
+        .assert { ctx =>
+          ctx.performRequest(defaultBackend)
+        }
+    )
+  )
+}
+```
+
+JSON request and response bodies work with plain circe codecs — any type with an
+`io.circe.Encoder` can be a request body, any type with an `io.circe.Decoder` can be
+used in `respondsWith[T]`.
+
+## Adapter defaults
+
+- `strictHeaderCheckDefault` is `false` — remote services always send headers your test
+  does not declare. Opt back in per request with `strictHeaderCheck = true`.
+- `defaultBackend` is sttp's `DefaultSyncBackend()`; override the `lazy val` to configure
+  proxies, TLS, timeouts, or to wrap the backend (e.g. logging).
+- `defaultHeaders` are added to every request; headers declared in a test win on
+  name conflict. Good for `User-Agent` or auth tokens from the environment.
+- Response bodies are read fully into memory, so assertions and the documentation
+  serializer can both consume them.
+
+## Notes
+
+- The DSL (`path`/`supports`/`onRequest`), schema derivation, and every output format
+  work exactly as with the server adapters — see the [DSL Reference](dsl-reference.md).
+- For authenticated APIs prefer documenting security with the `security` DSL; secrets
+  can go into `defaultHeaders` from environment variables.
+- Mind the target API's rate limits: every `onRequest` case performs a real HTTP call.

--- a/docs/sttp.md
+++ b/docs/sttp.md
@@ -64,6 +64,8 @@ used in `respondsWith[T]`.
 
 ## Adapter defaults
 
+- `baseUri` may include a path prefix (e.g. `https://api.example.com/api/v3`) but must not
+  carry a query string or fragment — `resolveUri` rejects those with an `IllegalArgumentException`.
 - `strictHeaderCheckDefault` is `false` — remote services always send headers your test
   does not declare. Opt back in per request with `strictHeaderCheck = true`.
 - `defaultBackend` is sttp's `DefaultSyncBackend()`; override the `lazy val` to configure

--- a/openapi/src/test/scala/pl/iterators/baklava/openapi/PetStoreSttpItSpec.scala
+++ b/openapi/src/test/scala/pl/iterators/baklava/openapi/PetStoreSttpItSpec.scala
@@ -10,7 +10,7 @@ import pl.iterators.baklava.sttp4.{BaklavaSttp, FromSttpBody, ToSttpBody}
 import sttp.client4.SyncBackend
 import sttp.model.Uri
 
-// the whole remote-API setup the sttp adapter replaces boilerplate with: a base URI
+// remote-API setup reduces to the base URI
 trait PetStoreSttpItSpec
     extends AnyFunSpec
     with Matchers

--- a/openapi/src/test/scala/pl/iterators/baklava/openapi/PetStoreSttpItSpec.scala
+++ b/openapi/src/test/scala/pl/iterators/baklava/openapi/PetStoreSttpItSpec.scala
@@ -1,0 +1,30 @@
+package pl.iterators.baklava.openapi
+
+import com.dimafeng.testcontainers.GenericContainer
+import com.dimafeng.testcontainers.scalatest.TestContainerForAll
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
+import org.testcontainers.containers.wait.strategy.Wait
+import pl.iterators.baklava.scalatest.ScalatestAsExecution
+import pl.iterators.baklava.sttp4.{BaklavaSttp, FromSttpBody, ToSttpBody}
+import sttp.client4.SyncBackend
+import sttp.model.Uri
+
+// the whole remote-API setup the sttp adapter replaces boilerplate with: a base URI
+trait PetStoreSttpItSpec
+    extends AnyFunSpec
+    with Matchers
+    with BaklavaScalatestInMemory[SyncBackend, ToSttpBody, FromSttpBody]
+    with BaklavaSttp[Unit, Unit, ScalatestAsExecution]
+    with TestContainerForAll {
+
+  override val containerDef: GenericContainer.Def[GenericContainer] = GenericContainer.Def(
+    "swaggerapi/petstore3:unstable",
+    exposedPorts = Seq(8080),
+    waitStrategy = Wait.forHttp("/")
+  )
+
+  override def baseUri: Uri = withContainers { petstore =>
+    Uri.unsafeParse(s"http://${petstore.containerIpAddress}:${petstore.mappedPort(8080)}/api/v3")
+  }
+}

--- a/openapi/src/test/scala/pl/iterators/baklava/openapi/PetStoreSttpUserSpec.scala
+++ b/openapi/src/test/scala/pl/iterators/baklava/openapi/PetStoreSttpUserSpec.scala
@@ -1,0 +1,78 @@
+package pl.iterators.baklava.openapi
+
+import io.circe.{Decoder, Encoder}
+import pl.iterators.baklava.FormOf
+import sttp.model.{Method, StatusCode}
+
+case class SttpUser(
+    id: Int,
+    username: Option[String],
+    firstName: Option[String],
+    lastName: Option[String],
+    email: Option[String],
+    password: Option[String],
+    phone: Option[String],
+    userStatus: Int
+)
+
+object SttpUser {
+  implicit val encoder: Encoder[SttpUser] =
+    Encoder.forProduct8("id", "username", "firstName", "lastName", "email", "password", "phone", "userStatus")(u =>
+      (u.id, u.username, u.firstName, u.lastName, u.email, u.password, u.phone, u.userStatus)
+    )
+  implicit val decoder: Decoder[SttpUser] =
+    Decoder.forProduct8("id", "username", "firstName", "lastName", "email", "password", "phone", "userStatus")(SttpUser.apply)
+}
+
+class PetStoreSttpUserSpec extends PetStoreSttpItSpec {
+  private val exampleUser = SttpUser(
+    id = 20,
+    username = Some("sttpUser"),
+    firstName = Some("John"),
+    lastName = Some("James"),
+    email = Some("john@email.com"),
+    password = Some("12345"),
+    phone = Some("12345"),
+    userStatus = 1
+  )
+
+  path("/user")(
+    supports(
+      Method.POST,
+      summary = "Create user",
+      description = "This can only be done by the logged in user.",
+      operationId = "createUser",
+      tags = Seq("user")
+    )(
+      onRequest(body = exampleUser).respondsWith[SttpUser](StatusCode.Ok, description = "successful operation").assert { ctx =>
+        ctx.performRequest(defaultBackend)
+      },
+      onRequest(body =
+        FormOf[SttpUser](
+          "id"         -> "21",
+          "userStatus" -> "1"
+        )
+      )
+        .respondsWith[SttpUser](StatusCode.Ok, description = "successful operation but with form")
+        .assert { ctx =>
+          ctx.performRequest(defaultBackend)
+        }
+    )
+  )
+
+  path("/user/login")(
+    supports(
+      Method.GET,
+      summary = "Logs user into the system",
+      queryParameters = (q[Option[String]]("username"), q[Option[String]]("password")),
+      operationId = "loginUser",
+      tags = Seq("user")
+    )(
+      onRequest(queryParameters = (Option("username"), Option("password")))
+        .respondsWith[String](StatusCode.Ok, description = "successful operation")
+        .assert { ctx =>
+          ctx.performRequest(defaultBackend)
+        }
+    )
+  )
+}

--- a/sttp/src/main/scala/pl/iterators/baklava/sttp4/BaklavaSttp.scala
+++ b/sttp/src/main/scala/pl/iterators/baklava/sttp4/BaklavaSttp.scala
@@ -59,8 +59,8 @@ trait BaklavaSttp[TestFrameworkFragmentType, TestFrameworkFragmentsType, TestFra
   def baseUri: Uri
 
   // added to every request; per-test declared headers win on (case-insensitive) name conflict.
-  // Content-Type does not belong here — it bypasses findContentTypeOverride and gets silently
-  // replaced by the body's content type when a request has a body; override it per-test instead
+  // Content-Type is rejected here — it would be silently replaced by the body's content type
+  // whenever a request has a body; declare it per test in the request's headers instead
   def defaultHeaders: Seq[SttpHeader] = Seq.empty
 
   // override to customize the client (proxies, TLS, auth wrappers)
@@ -153,9 +153,14 @@ trait BaklavaSttp[TestFrameworkFragmentType, TestFrameworkFragmentsType, TestFra
   )(implicit
       requestBody: ToSttpBody[RequestBody]
   ): HttpRequest = {
-    val parsedOverride             = findContentTypeOverride(ctx.headers)
-    val declared                   = if (parsedOverride.isDefined) dropContentType(ctx.headers) else ctx.headers
-    val merged                     = declared ++ defaultHeaders.filterNot(d => declared.exists(_.name.equalsIgnoreCase(d.name)))
+    val parsedOverride = findContentTypeOverride(ctx.headers)
+    val declared       = if (parsedOverride.isDefined) dropContentType(ctx.headers) else ctx.headers
+    val defaults       = defaultHeaders
+    if (defaults.exists(_.name.equalsIgnoreCase("Content-Type")))
+      throw new IllegalArgumentException(
+        "Content-Type must not be set in defaultHeaders — declare it per request in the test's headers instead"
+      )
+    val merged                     = declared ++ defaults.filterNot(d => declared.exists(_.name.equalsIgnoreCase(d.name)))
     val base: Request[Array[Byte]] = emptyRequest
       .method(ctx.method.get, BaklavaSttp.resolveUri(baseUri, ctx.path))
       .headers(merged*)

--- a/sttp/src/main/scala/pl/iterators/baklava/sttp4/BaklavaSttp.scala
+++ b/sttp/src/main/scala/pl/iterators/baklava/sttp4/BaklavaSttp.scala
@@ -19,8 +19,7 @@ import sttp.model.{Header => SttpHeader, MediaType, Method, StatusCode, Uri}
 import java.nio.charset.StandardCharsets.UTF_8
 import scala.reflect.ClassTag
 
-// lower priority than the specific instances in BaklavaSttp, so e.g. ToSttpBody[String]
-// beats Encoder[String]-derived JSON
+// lower priority than BaklavaSttp's specific instances, so ToSttpBody[String] beats Encoder[String]-derived JSON
 trait BaklavaSttpLowPriorityBodies {
   implicit def circeEncoderToSttpBody[T](implicit encoder: Encoder[T]): ToSttpBody[T] =
     t => Some(SttpBodyContent(Printer.noSpaces.print(encoder(t)).getBytes(UTF_8), "application/json"))
@@ -58,9 +57,7 @@ trait BaklavaSttp[TestFrameworkFragmentType, TestFrameworkFragmentsType, TestFra
   // root of the documented API; ctx.path is appended to it on every request
   def baseUri: Uri
 
-  // added to every request; per-test declared headers win on (case-insensitive) name conflict.
-  // Content-Type is rejected here — it would be silently replaced by the body's content type
-  // whenever a request has a body; declare it per test in the request's headers instead
+  // added to every request; per-test headers win on name conflict; Content-Type is rejected — declare it per request
   def defaultHeaders: Seq[SttpHeader] = Seq.empty
 
   // override to customize the client (proxies, TLS, auth wrappers)

--- a/sttp/src/main/scala/pl/iterators/baklava/sttp4/BaklavaSttp.scala
+++ b/sttp/src/main/scala/pl/iterators/baklava/sttp4/BaklavaSttp.scala
@@ -1,0 +1,198 @@
+package pl.iterators.baklava.sttp4
+
+import io.circe.{Decoder, Encoder, Printer}
+import pl.iterators.baklava.{
+  BaklavaAssertionException,
+  BaklavaHttpDsl,
+  BaklavaHttpProtocol,
+  BaklavaRequestContext,
+  BaklavaResponseContext,
+  BaklavaTestFrameworkDsl,
+  EmptyBody,
+  EmptyBodyInstance,
+  FormOf,
+  Multipart => BaklavaMultipart
+}
+import sttp.client4.{asByteArrayAlways, emptyRequest, ByteArrayBody, DefaultSyncBackend, Request, Response, StringBody, SyncBackend}
+import sttp.model.{Header => SttpHeader, MediaType, Method, StatusCode, Uri}
+
+import java.nio.charset.StandardCharsets.UTF_8
+import scala.reflect.ClassTag
+
+// lower priority than the specific instances in BaklavaSttp, so e.g. ToSttpBody[String]
+// beats Encoder[String]-derived JSON
+trait BaklavaSttpLowPriorityBodies {
+  implicit def circeEncoderToSttpBody[T](implicit encoder: Encoder[T]): ToSttpBody[T] =
+    t => Some(SttpBodyContent(Printer.noSpaces.print(encoder(t)).getBytes(UTF_8), "application/json"))
+
+  implicit def circeDecoderFromSttpBody[T](implicit decoder: Decoder[T]): FromSttpBody[T] =
+    bytes => io.circe.parser.decode[T](new String(bytes, UTF_8))
+}
+
+trait BaklavaSttp[TestFrameworkFragmentType, TestFrameworkFragmentsType, TestFrameworkExecutionType[_]]
+    extends BaklavaSttpLowPriorityBodies
+    with BaklavaHttpDsl[
+      SyncBackend,
+      ToSttpBody,
+      FromSttpBody,
+      TestFrameworkFragmentType,
+      TestFrameworkFragmentsType,
+      TestFrameworkExecutionType
+    ] {
+  this: BaklavaTestFrameworkDsl[
+    SyncBackend,
+    ToSttpBody,
+    FromSttpBody,
+    TestFrameworkFragmentType,
+    TestFrameworkFragmentsType,
+    TestFrameworkExecutionType
+  ] =>
+
+  override type HttpResponse   = Response[Array[Byte]]
+  override type HttpRequest    = Request[Array[Byte]]
+  override type HttpProtocol   = BaklavaHttpProtocol
+  override type HttpStatusCode = StatusCode
+  override type HttpMethod     = Method
+  override type HttpHeaders    = Seq[SttpHeader]
+
+  // root of the documented API; ctx.path is appended to it on every request
+  def baseUri: Uri
+
+  // added to every request; per-test declared headers win on (case-insensitive) name conflict
+  def defaultHeaders: Seq[SttpHeader] = Seq.empty
+
+  // override to customize the client (proxies, TLS, auth wrappers)
+  lazy val defaultBackend: SyncBackend = DefaultSyncBackend()
+
+  // remote services always send undeclared headers, so strict mode would never pass
+  def strictHeaderCheckDefault: Boolean = false
+
+  override implicit protected def emptyToRequestBodyType: ToSttpBody[EmptyBody] = _ => None
+
+  override implicit protected def formUrlencodedToRequestBodyType[T]: ToSttpBody[FormOf[T]] =
+    form => Some(SttpBodyContent(SttpBodies.urlEncodeForm(form.fields).getBytes(UTF_8), "application/x-www-form-urlencoded"))
+
+  override implicit protected def multipartToRequestBodyType: ToSttpBody[BaklavaMultipart] =
+    multipart => Some(SttpBodyContent(SttpBodies.renderMultipart(multipart), SttpBodies.multipartContentType))
+
+  implicit def stringToSttpBody: ToSttpBody[String] =
+    s => Some(SttpBodyContent(s.getBytes(UTF_8), "text/plain; charset=UTF-8"))
+
+  implicit def byteArrayToSttpBody: ToSttpBody[Array[Byte]] =
+    bytes => Some(SttpBodyContent(bytes, "application/octet-stream"))
+
+  // core itself asserts emptiness when EmptyBody is the expected response
+  override implicit protected def emptyToResponseBodyType: FromSttpBody[EmptyBody] = _ => Right(EmptyBodyInstance)
+
+  implicit def stringFromSttpBody: FromSttpBody[String] = bytes => Right(new String(bytes, UTF_8))
+
+  implicit def byteArrayFromSttpBody: FromSttpBody[Array[Byte]] = bytes => Right(bytes)
+
+  // wire types already are the sttp.model types core speaks — all conversions are identities
+  override implicit def statusCodeToBaklavaStatusCodes(statusCode: StatusCode): StatusCode                    = statusCode
+  override implicit def baklavaStatusCodeToStatusCode(status: StatusCode): StatusCode                         = status
+  override implicit def httpMethodToBaklavaHttpMethod(method: Method): Method                                 = method
+  override implicit def baklavaHttpMethodToHttpMethod(method: Method): Method                                 = method
+  override implicit def baklavaHttpProtocolToHttpProtocol(protocol: BaklavaHttpProtocol): BaklavaHttpProtocol = protocol
+  override implicit def httpProtocolToBaklavaHttpProtocol(protocol: BaklavaHttpProtocol): BaklavaHttpProtocol = protocol
+  override implicit def baklavaHeadersToHttpHeaders(headers: Seq[SttpHeader]): Seq[SttpHeader]                = headers
+  override implicit def httpHeadersToBaklavaHeaders(headers: Seq[SttpHeader]): Seq[SttpHeader]                = headers
+
+  override def httpResponseToBaklavaResponseContext[T: FromSttpBody: ClassTag](
+      request: HttpRequest,
+      response: HttpResponse
+  ): BaklavaResponseContext[T, HttpRequest, HttpResponse] = {
+    val responseString = new String(response.body, UTF_8)
+    val requestString  = request.body match {
+      case ByteArrayBody(bytes, _) => new String(bytes, UTF_8)
+      case StringBody(s, _, _)     => s
+      case _                       => ""
+    }
+    BaklavaResponseContext(
+      // sttp does not expose the negotiated protocol version
+      BaklavaHttpProtocol("HTTP/1.1"),
+      response.code,
+      response.headers,
+      implicitly[FromSttpBody[T]].apply(response.body) match {
+        case Right(value)    => value
+        case Left(exception) =>
+          throw new BaklavaAssertionException(
+            s"Failed to decode response body: ${exception.getMessage}\n" +
+              s"Expected: ${implicitly[ClassTag[T]].runtimeClass.getSimpleName}, but got: ${response.code.code} -> ${responseString.take(maxBodyLengthInAssertion)}"
+          )
+      },
+      request,
+      requestString,
+      response,
+      responseString,
+      request.headers.find(_.name.equalsIgnoreCase("Content-Type")).map(_.value),
+      response.contentType
+    )
+  }
+
+  override def baklavaContextToHttpRequest[
+      RequestBody,
+      PathParameters,
+      PathParametersProvided,
+      QueryParameters,
+      QueryParametersProvided,
+      Headers_,
+      HeadersProvided
+  ](
+      ctx: BaklavaRequestContext[
+        RequestBody,
+        PathParameters,
+        PathParametersProvided,
+        QueryParameters,
+        QueryParametersProvided,
+        Headers_,
+        HeadersProvided
+      ]
+  )(implicit
+      requestBody: ToSttpBody[RequestBody]
+  ): HttpRequest = {
+    val parsedOverride             = findContentTypeOverride(ctx.headers)
+    val declared                   = if (parsedOverride.isDefined) dropContentType(ctx.headers) else ctx.headers
+    val merged                     = declared ++ defaultHeaders.filterNot(d => declared.exists(_.name.equalsIgnoreCase(d.name)))
+    val base: Request[Array[Byte]] = emptyRequest
+      .method(ctx.method.get, BaklavaSttp.resolveUri(baseUri, ctx.path))
+      .headers(merged*)
+      .response(asByteArrayAlways)
+    ctx.body.flatMap(requestBody(_)) match {
+      case Some(SttpBodyContent(bytes, contentType)) => base.body(bytes).contentType(parsedOverride.getOrElse(contentType))
+      case None                                      => parsedOverride.fold(base)(ct => base.contentType(ct))
+    }
+  }
+
+  // Throws on either multiple declarations or an unparseable value — both are test-authoring bugs.
+  private def findContentTypeOverride(hs: Seq[SttpHeader]): Option[String] = {
+    val cts = hs.filter(_.name.toLowerCase(java.util.Locale.ROOT) == "content-type")
+    cts match {
+      case Seq()       => None
+      case Seq(single) =>
+        MediaType.parse(single.value) match {
+          case Right(_)    => Some(single.value)
+          case Left(error) =>
+            throw new IllegalArgumentException(s"Could not parse declared Content-Type header '${single.value}': $error")
+        }
+      case multiple =>
+        throw new IllegalArgumentException(
+          s"Multiple Content-Type headers declared on one request: [${multiple.map(_.value).mkString(", ")}]. " +
+            "Declare a single Content-Type or none at all."
+        )
+    }
+  }
+
+  private def dropContentType(hs: Seq[SttpHeader]): Seq[SttpHeader] =
+    hs.filterNot(_.name.toLowerCase(java.util.Locale.ROOT) == "content-type")
+
+  override def performRequest(backend: SyncBackend, request: HttpRequest): HttpResponse =
+    request.send(backend)
+}
+
+object BaklavaSttp {
+  def resolveUri(baseUri: Uri, path: String): Uri =
+    Uri
+      .parse(baseUri.toString.stripSuffix("/") + path)
+      .fold(error => throw new IllegalArgumentException(s"Could not build request URI: $error"), identity)
+}

--- a/sttp/src/main/scala/pl/iterators/baklava/sttp4/BaklavaSttp.scala
+++ b/sttp/src/main/scala/pl/iterators/baklava/sttp4/BaklavaSttp.scala
@@ -58,7 +58,9 @@ trait BaklavaSttp[TestFrameworkFragmentType, TestFrameworkFragmentsType, TestFra
   // root of the documented API; ctx.path is appended to it on every request
   def baseUri: Uri
 
-  // added to every request; per-test declared headers win on (case-insensitive) name conflict
+  // added to every request; per-test declared headers win on (case-insensitive) name conflict.
+  // Content-Type does not belong here — it bypasses findContentTypeOverride and gets silently
+  // replaced by the body's content type when a request has a body; override it per-test instead
   def defaultHeaders: Seq[SttpHeader] = Seq.empty
 
   // override to customize the client (proxies, TLS, auth wrappers)
@@ -191,8 +193,12 @@ trait BaklavaSttp[TestFrameworkFragmentType, TestFrameworkFragmentsType, TestFra
 }
 
 object BaklavaSttp {
-  def resolveUri(baseUri: Uri, path: String): Uri =
+  def resolveUri(baseUri: Uri, path: String): Uri = {
+    // a query/fragment on the base would end up embedded mid-URI — always a spec-authoring bug
+    if (baseUri.querySegments.nonEmpty || baseUri.fragmentSegment.isDefined)
+      throw new IllegalArgumentException(s"baseUri must not carry a query or fragment: $baseUri")
     Uri
       .parse(baseUri.toString.stripSuffix("/") + path)
       .fold(error => throw new IllegalArgumentException(s"Could not build request URI: $error"), identity)
+  }
 }

--- a/sttp/src/main/scala/pl/iterators/baklava/sttp4/SttpBody.scala
+++ b/sttp/src/main/scala/pl/iterators/baklava/sttp4/SttpBody.scala
@@ -8,7 +8,14 @@ import java.nio.charset.StandardCharsets.UTF_8
 
 // bytes + the Content-Type they were rendered with; bodies are rendered eagerly so
 // assertions and the serializer can both read them
-final case class SttpBodyContent(bytes: Array[Byte], contentType: String)
+final case class SttpBodyContent(bytes: Array[Byte], contentType: String) {
+  // Array[Byte] would otherwise degrade the case-class equals/hashCode to reference semantics
+  override def equals(other: Any): Boolean = other match {
+    case that: SttpBodyContent => java.util.Arrays.equals(bytes, that.bytes) && contentType == that.contentType
+    case _                     => false
+  }
+  override def hashCode(): Int = 31 * java.util.Arrays.hashCode(bytes) + contentType.hashCode
+}
 
 trait ToSttpBody[T] {
   // None = no body on the wire
@@ -27,20 +34,24 @@ object SttpBodies {
   def urlEncodeForm(fields: Seq[(String, String)]): String =
     fields.map { case (k, v) => s"${URLEncoder.encode(k, "UTF-8")}=${URLEncoder.encode(v, "UTF-8")}" }.mkString("&")
 
+  // quotes and CR/LF would corrupt the Content-Disposition line; percent-encode them like browsers do (WHATWG)
+  private def escapeDispositionValue(value: String): String =
+    value.replace("\"", "%22").replace("\r", "%0D").replace("\n", "%0A")
+
   def renderMultipart(multipart: Multipart): Array[Byte] = {
     val out                    = new ByteArrayOutputStream()
     def write(s: String): Unit = out.write(s.getBytes(UTF_8))
     multipart.parts.foreach {
       case FilePart(name, contentType, filename, bytes) =>
         write(s"--$multipartBoundary\r\n")
-        val filenameSuffix = if (filename.isEmpty) "" else s"""; filename="$filename""""
-        write(s"""Content-Disposition: form-data; name="$name"$filenameSuffix\r\n""")
+        val filenameSuffix = if (filename.isEmpty) "" else s"""; filename="${escapeDispositionValue(filename)}""""
+        write(s"""Content-Disposition: form-data; name="${escapeDispositionValue(name)}"$filenameSuffix\r\n""")
         write(s"Content-Type: $contentType\r\n\r\n")
         out.write(bytes)
         write("\r\n")
       case TextPart(name, value) =>
         write(s"--$multipartBoundary\r\n")
-        write(s"""Content-Disposition: form-data; name="$name"\r\n\r\n""")
+        write(s"""Content-Disposition: form-data; name="${escapeDispositionValue(name)}"\r\n\r\n""")
         write(value)
         write("\r\n")
     }

--- a/sttp/src/main/scala/pl/iterators/baklava/sttp4/SttpBody.scala
+++ b/sttp/src/main/scala/pl/iterators/baklava/sttp4/SttpBody.scala
@@ -1,0 +1,50 @@
+package pl.iterators.baklava.sttp4
+
+import pl.iterators.baklava.{FilePart, Multipart, TextPart}
+
+import java.io.ByteArrayOutputStream
+import java.net.URLEncoder
+import java.nio.charset.StandardCharsets.UTF_8
+
+// bytes + the Content-Type they were rendered with; bodies are rendered eagerly so
+// assertions and the serializer can both read them
+final case class SttpBodyContent(bytes: Array[Byte], contentType: String)
+
+trait ToSttpBody[T] {
+  // None = no body on the wire
+  def apply(t: T): Option[SttpBodyContent]
+}
+
+trait FromSttpBody[T] {
+  def apply(bytes: Array[Byte]): Either[Throwable, T]
+}
+
+object SttpBodies {
+  // Fixed boundary keeps the captured request body byte-stable across gold-test runs.
+  val multipartBoundary    = "baklava-multipart-boundary"
+  val multipartContentType = s"multipart/form-data; boundary=$multipartBoundary"
+
+  def urlEncodeForm(fields: Seq[(String, String)]): String =
+    fields.map { case (k, v) => s"${URLEncoder.encode(k, "UTF-8")}=${URLEncoder.encode(v, "UTF-8")}" }.mkString("&")
+
+  def renderMultipart(multipart: Multipart): Array[Byte] = {
+    val out                    = new ByteArrayOutputStream()
+    def write(s: String): Unit = out.write(s.getBytes(UTF_8))
+    multipart.parts.foreach {
+      case FilePart(name, contentType, filename, bytes) =>
+        write(s"--$multipartBoundary\r\n")
+        val filenameSuffix = if (filename.isEmpty) "" else s"""; filename="$filename""""
+        write(s"""Content-Disposition: form-data; name="$name"$filenameSuffix\r\n""")
+        write(s"Content-Type: $contentType\r\n\r\n")
+        out.write(bytes)
+        write("\r\n")
+      case TextPart(name, value) =>
+        write(s"--$multipartBoundary\r\n")
+        write(s"""Content-Disposition: form-data; name="$name"\r\n\r\n""")
+        write(value)
+        write("\r\n")
+    }
+    write(s"--$multipartBoundary--\r\n")
+    out.toByteArray
+  }
+}

--- a/sttp/src/main/scala/pl/iterators/baklava/sttp4/SttpBody.scala
+++ b/sttp/src/main/scala/pl/iterators/baklava/sttp4/SttpBody.scala
@@ -6,8 +6,7 @@ import java.io.ByteArrayOutputStream
 import java.net.URLEncoder
 import java.nio.charset.StandardCharsets.UTF_8
 
-// bytes + the Content-Type they were rendered with; bodies are rendered eagerly so
-// assertions and the serializer can both read them
+// a body rendered eagerly to bytes, plus the Content-Type it was rendered with
 final case class SttpBodyContent(bytes: Array[Byte], contentType: String) {
   // Array[Byte] would otherwise degrade the case-class equals/hashCode to reference semantics
   override def equals(other: Any): Boolean = other match {

--- a/sttp/src/test/scala/pl/iterators/baklava/sttp4/BaklavaSttpDslSpec.scala
+++ b/sttp/src/test/scala/pl/iterators/baklava/sttp4/BaklavaSttpDslSpec.scala
@@ -127,17 +127,10 @@ class BaklavaSttpDslSpec
           response.body should include("--baklava-multipart-boundary")
           findHeader(response.headers, "X-Req-Content-Type") shouldBe Some(SttpBodies.multipartContentType)
         },
-      // core's "performRequest called exactly once" tracking only counts a call that returns, so a
-      // decode failure (which throws before that point) can't be observed via intercept(ctx.performRequest(...))
-      // without also tripping that check; decode as String (always succeeds) and invoke the adapter's own
-      // decoding step directly on the same raw request/response to exercise the failure path instead
       onRequest(body = "not json")
-        .respondsWith[String](StatusCode.Ok, description = "decode failure raises BaklavaAssertionException")
+        .respondsWith[Greeting](StatusCode.Ok, description = "decode failure raises BaklavaAssertionException")
         .assert { ctx =>
-          val response = ctx.performRequest(defaultBackend)
-          val ex       = intercept[BaklavaAssertionException] {
-            httpResponseToBaklavaResponseContext[Greeting](response.rawRequest, response.rawResponse)
-          }
+          val ex = intercept[BaklavaAssertionException](ctx.performRequest(defaultBackend))
           ex.getMessage should include("Failed to decode response body")
         }
     )

--- a/sttp/src/test/scala/pl/iterators/baklava/sttp4/BaklavaSttpDslSpec.scala
+++ b/sttp/src/test/scala/pl/iterators/baklava/sttp4/BaklavaSttpDslSpec.scala
@@ -1,0 +1,153 @@
+package pl.iterators.baklava.sttp4
+
+import com.sun.net.httpserver.{HttpExchange, HttpServer}
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
+import pl.iterators.baklava.scalatest.{BaklavaScalatest, ScalatestAsExecution}
+import pl.iterators.baklava.{BaklavaAssertionException, EmptyBody, FormOf, Multipart, TextPart}
+import sttp.client4.SyncBackend
+import sttp.model.{Header => SttpHeader, Method, StatusCode, Uri}
+
+import java.net.InetSocketAddress
+import java.nio.charset.StandardCharsets.UTF_8
+import scala.jdk.CollectionConverters._
+
+// Greeting (with its circe codecs) is defined in BaklavaSttpRequestBuildingSpec.scala — same package
+
+class BaklavaSttpDslSpec
+    extends AnyFunSpec
+    with Matchers
+    with BaklavaSttp[Unit, Unit, ScalatestAsExecution]
+    with BaklavaScalatest[SyncBackend, ToSttpBody, FromSttpBody] {
+
+  // InputStream.readAllBytes is Java 9+; the build targets an older release, so read manually
+  private def readAllBytes(in: java.io.InputStream): Array[Byte] = {
+    val out = new java.io.ByteArrayOutputStream()
+    val buf = new Array[Byte](4096)
+    var n   = in.read(buf)
+    while (n != -1) {
+      out.write(buf, 0, n)
+      n = in.read(buf)
+    }
+    out.toByteArray
+  }
+
+  // com.sun.net.httpserver.Headers only normalizes the leading char of a header name, so a
+  // client sending lower-case names (e.g. over h2c) needs a case-insensitive lookup here
+  private def firstHeaderCI(headers: com.sun.net.httpserver.Headers, name: String): Option[String] =
+    headers.entrySet.asScala.find(_.getKey.equalsIgnoreCase(name)).flatMap(_.getValue.asScala.headOption)
+
+  // HTTP header names are case-insensitive; the sttp client backend normalizes response headers to lower-case
+  private def findHeader(headers: Seq[SttpHeader], name: String): Option[String] =
+    headers.find(_.name.equalsIgnoreCase(name)).map(_.value)
+
+  // echoes the request back: body verbatim, request metadata in X-Req-* response headers
+  private val server: HttpServer = {
+    val s = HttpServer.create(new InetSocketAddress("localhost", 0), 0)
+    s.createContext(
+      "/echo",
+      (exchange: HttpExchange) => {
+        val body    = readAllBytes(exchange.getRequestBody)
+        val headers = exchange.getResponseHeaders
+        headers.set("X-Req-Method", exchange.getRequestMethod)
+        headers.set("X-Req-Uri", exchange.getRequestURI.toString)
+        firstHeaderCI(exchange.getRequestHeaders, "Content-Type").foreach(headers.set("X-Req-Content-Type", _))
+        firstHeaderCI(exchange.getRequestHeaders, "X-Default").foreach(headers.set("X-Req-X-Default", _))
+        headers.set("Content-Type", "text/plain; charset=UTF-8")
+        exchange.sendResponseHeaders(200, if (body.isEmpty) -1 else body.length.toLong)
+        if (body.nonEmpty) exchange.getResponseBody.write(body)
+        exchange.close()
+      }
+    )
+    s.createContext(
+      "/greeting",
+      (exchange: HttpExchange) => {
+        val payload = """{"hello":"world"}""".getBytes(UTF_8)
+        exchange.getResponseHeaders.set("Content-Type", "application/json")
+        exchange.sendResponseHeaders(200, payload.length.toLong)
+        exchange.getResponseBody.write(payload)
+        exchange.close()
+      }
+    )
+    s.createContext(
+      "/no-content",
+      (exchange: HttpExchange) => {
+        exchange.sendResponseHeaders(204, -1)
+        exchange.close()
+      }
+    )
+    s.start()
+    s
+  }
+
+  override def baseUri: Uri                    = Uri.unsafeParse(s"http://localhost:${server.getAddress.getPort}")
+  override def defaultHeaders: Seq[SttpHeader] = Seq(SttpHeader("X-Default", "on"))
+
+  override def afterAll(): Unit = {
+    server.stop(0)
+    super.afterAll()
+  }
+
+  it("defaults strict header checking to off") {
+    strictHeaderCheckDefault shouldBe false
+  }
+
+  path("/greeting")(
+    supports(Method.GET, summary = "JSON greeting")(
+      onRequest.respondsWith[Greeting](StatusCode.Ok, description = "decodes JSON via circe").assert { ctx =>
+        val response = ctx.performRequest(defaultBackend)
+        response.body shouldBe Greeting("world")
+        response.responseContentType shouldBe Some("application/json")
+      }
+    )
+  )
+
+  path("/echo")(
+    supports(Method.POST, summary = "echo")(
+      onRequest(body = Greeting("hi")).respondsWith[String](StatusCode.Ok, description = "JSON request body").assert { ctx =>
+        val response = ctx.performRequest(defaultBackend)
+        response.body shouldBe """{"hello":"hi"}"""
+        // header names are case-insensitive over the wire; the JDK HttpClient backend normalizes to lower-case
+        findHeader(response.headers, "X-Req-Content-Type") shouldBe Some("application/json")
+        findHeader(response.headers, "X-Req-Method") shouldBe Some("POST")
+        findHeader(response.headers, "X-Req-X-Default") shouldBe Some("on")
+        response.requestBodyString shouldBe """{"hello":"hi"}"""
+      },
+      onRequest(body = FormOf[Greeting]("hello" -> "world"))
+        .respondsWith[String](StatusCode.Ok, description = "form request body")
+        .assert { ctx =>
+          val response = ctx.performRequest(defaultBackend)
+          response.body shouldBe "hello=world"
+          findHeader(response.headers, "X-Req-Content-Type") shouldBe Some("application/x-www-form-urlencoded")
+        },
+      onRequest(body = Multipart(TextPart("a", "b")))
+        .respondsWith[String](StatusCode.Ok, description = "multipart request body")
+        .assert { ctx =>
+          val response = ctx.performRequest(defaultBackend)
+          response.body should include("--baklava-multipart-boundary")
+          findHeader(response.headers, "X-Req-Content-Type") shouldBe Some(SttpBodies.multipartContentType)
+        },
+      // core's "performRequest called exactly once" tracking only counts a call that returns, so a
+      // decode failure (which throws before that point) can't be observed via intercept(ctx.performRequest(...))
+      // without also tripping that check; decode as String (always succeeds) and invoke the adapter's own
+      // decoding step directly on the same raw request/response to exercise the failure path instead
+      onRequest(body = "not json")
+        .respondsWith[String](StatusCode.Ok, description = "decode failure raises BaklavaAssertionException")
+        .assert { ctx =>
+          val response = ctx.performRequest(defaultBackend)
+          val ex       = intercept[BaklavaAssertionException] {
+            httpResponseToBaklavaResponseContext[Greeting](response.rawRequest, response.rawResponse)
+          }
+          ex.getMessage should include("Failed to decode response body")
+        }
+    )
+  )
+
+  path("/no-content")(
+    supports(Method.GET, summary = "no content")(
+      onRequest.respondsWith[EmptyBody](StatusCode.NoContent, description = "empty response body").assert { ctx =>
+        ctx.performRequest(defaultBackend)
+      }
+    )
+  )
+}

--- a/sttp/src/test/scala/pl/iterators/baklava/sttp4/BaklavaSttpRequestBuildingSpec.scala
+++ b/sttp/src/test/scala/pl/iterators/baklava/sttp4/BaklavaSttpRequestBuildingSpec.scala
@@ -1,0 +1,156 @@
+package pl.iterators.baklava.sttp4
+
+import io.circe.{Decoder, Encoder}
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
+import pl.iterators.baklava.scalatest.{BaklavaScalatest, ScalatestAsExecution}
+import pl.iterators.baklava.{
+  AppliedSecurity,
+  BaklavaRequestContext,
+  EmptyBody,
+  EmptyBodyInstance,
+  FormOf,
+  Multipart,
+  NoopSecurity,
+  TextPart
+}
+import sttp.client4.{ByteArrayBody, NoBody, SyncBackend}
+import sttp.model.{Header => SttpHeader, Method, Uri}
+
+import java.nio.charset.StandardCharsets.UTF_8
+
+case class Greeting(hello: String)
+
+object Greeting {
+  implicit val encoder: Encoder[Greeting] = Encoder.forProduct1("hello")(_.hello)
+  implicit val decoder: Decoder[Greeting] = Decoder.forProduct1("hello")(Greeting.apply)
+}
+
+class BaklavaSttpRequestBuildingSpec
+    extends AnyFunSpec
+    with Matchers
+    with org.scalatest.Inside
+    with BaklavaSttp[Unit, Unit, ScalatestAsExecution]
+    with BaklavaScalatest[SyncBackend, ToSttpBody, FromSttpBody] {
+
+  override def baseUri: Uri                    = Uri.unsafeParse("https://api.example.com")
+  override def defaultHeaders: Seq[SttpHeader] = Seq(SttpHeader("X-Default", "on"), SttpHeader("X-Both", "default"))
+
+  describe("resolveUri") {
+    it("appends the context path to the base URI") {
+      BaklavaSttp.resolveUri(Uri.unsafeParse("https://api.example.com"), "/x?y=1").toString shouldBe
+      "https://api.example.com/x?y=1"
+    }
+
+    it("tolerates a trailing slash on the base URI") {
+      BaklavaSttp.resolveUri(Uri.unsafeParse("https://api.example.com/"), "/x").toString shouldBe
+      "https://api.example.com/x"
+    }
+
+    it("preserves a path prefix on the base URI") {
+      BaklavaSttp.resolveUri(Uri.unsafeParse("https://api.example.com/api/v3"), "/pets").toString shouldBe
+      "https://api.example.com/api/v3/pets"
+    }
+  }
+
+  describe("baklavaContextToHttpRequest") {
+    it("builds method and URI from the context") {
+      val request = baklavaContextToHttpRequest(buildRequestContext[String](Seq.empty, None, path = "/pets?limit=10"))
+      request.method shouldBe Method.GET
+      request.uri.toString shouldBe "https://api.example.com/pets?limit=10"
+    }
+
+    it("adds default headers and lets declared headers win on name conflict") {
+      val request = baklavaContextToHttpRequest(buildRequestContext[String](Seq(SttpHeader("X-Both", "declared")), None))
+      request.headers.filter(_.name == "X-Both").map(_.value) shouldBe Seq("declared")
+      request.headers.find(_.name == "X-Default").map(_.value) shouldBe Some("on")
+    }
+
+    it("serializes a JSON body via a circe Encoder") {
+      val request = baklavaContextToHttpRequest(buildRequestContext(Seq.empty, Some(Greeting("hi"))))
+      inside(request.body) { case ByteArrayBody(bytes, _) => new String(bytes, UTF_8) shouldBe """{"hello":"hi"}""" }
+      contentTypesOf(request) shouldBe Seq("application/json")
+    }
+
+    it("serializes a String body as text/plain") {
+      val request = baklavaContextToHttpRequest(buildRequestContext(Seq.empty, Some("raw text")))
+      inside(request.body) { case ByteArrayBody(bytes, _) => new String(bytes, UTF_8) shouldBe "raw text" }
+      contentTypesOf(request) shouldBe Seq("text/plain; charset=UTF-8")
+    }
+
+    it("serializes a FormOf body as application/x-www-form-urlencoded") {
+      val request = baklavaContextToHttpRequest(buildRequestContext(Seq.empty, Some(FormOf[Greeting]("hello" -> "world"))))
+      inside(request.body) { case ByteArrayBody(bytes, _) => new String(bytes, UTF_8) shouldBe "hello=world" }
+      contentTypesOf(request) shouldBe Seq("application/x-www-form-urlencoded")
+    }
+
+    it("serializes a Multipart body with the fixed boundary") {
+      val multipart = Multipart(TextPart("a", "b"))
+      val request   = baklavaContextToHttpRequest(buildRequestContext(Seq.empty, Some(multipart)))
+      inside(request.body) { case ByteArrayBody(bytes, _) => bytes shouldBe SttpBodies.renderMultipart(multipart) }
+      contentTypesOf(request) shouldBe Seq(SttpBodies.multipartContentType)
+    }
+
+    it("sends no body and no Content-Type for EmptyBody") {
+      val request = baklavaContextToHttpRequest(buildRequestContext[EmptyBody](Seq.empty, Some(EmptyBodyInstance)))
+      request.body shouldBe NoBody
+      contentTypesOf(request) shouldBe Seq.empty
+    }
+
+    it("overrides the body's Content-Type when one is declared among the headers") {
+      val request = baklavaContextToHttpRequest(buildRequestContext(Seq(SttpHeader("Content-Type", "image/png")), Some("raw bytes")))
+      contentTypesOf(request) shouldBe Seq("image/png")
+    }
+
+    it("throws on an unparseable declared Content-Type") {
+      val ctx = buildRequestContext(Seq(SttpHeader("Content-Type", "this is not a content type")), Some("irrelevant"))
+      val ex  = intercept[IllegalArgumentException](baklavaContextToHttpRequest(ctx))
+      ex.getMessage should include("Could not parse declared Content-Type")
+    }
+
+    it("throws on multiple declared Content-Type headers") {
+      val ctx = buildRequestContext(Seq(SttpHeader("Content-Type", "image/png"), SttpHeader("content-type", "image/jpeg")), Some("x"))
+      val ex  = intercept[IllegalArgumentException](baklavaContextToHttpRequest(ctx))
+      ex.getMessage should include("Multiple Content-Type headers")
+    }
+  }
+
+  private def contentTypesOf(request: HttpRequest): Seq[String] =
+    request.headers.filter(_.name.equalsIgnoreCase("Content-Type")).map(_.value)
+
+  // Everything except headers/body/path is boilerplate the adapter ignores.
+  private def buildRequestContext[B: ToSttpBody](
+      hs: Seq[SttpHeader],
+      body: Option[B],
+      path: String = "/x"
+  ): BaklavaRequestContext[B, Unit, Unit, Unit, Unit, Unit, Unit] =
+    BaklavaRequestContext[B, Unit, Unit, Unit, Unit, Unit, Unit](
+      symbolicPath = path,
+      path = path,
+      pathDescription = None,
+      pathSummary = None,
+      method = Some(if (body.isDefined) Method.POST else Method.GET),
+      operationDescription = None,
+      operationSummary = None,
+      operationId = None,
+      operationTags = Seq.empty,
+      securitySchemes = Seq.empty,
+      body = body,
+      bodySchema = None,
+      headers = hs,
+      headersDefinition = (),
+      headersProvided = (),
+      headersSeq = Seq.empty,
+      security = AppliedSecurity(NoopSecurity, Map.empty),
+      pathParameters = (),
+      pathParametersProvided = (),
+      pathParametersSeq = Seq.empty,
+      queryParameters = (),
+      queryParametersProvided = (),
+      queryParametersSeq = Seq.empty,
+      responseDescription = None,
+      responseHeaders = Seq.empty
+    )
+
+  override def afterAll(): Unit = ()
+}

--- a/sttp/src/test/scala/pl/iterators/baklava/sttp4/BaklavaSttpRequestBuildingSpec.scala
+++ b/sttp/src/test/scala/pl/iterators/baklava/sttp4/BaklavaSttpRequestBuildingSpec.scala
@@ -51,6 +51,11 @@ class BaklavaSttpRequestBuildingSpec
       BaklavaSttp.resolveUri(Uri.unsafeParse("https://api.example.com/api/v3"), "/pets").toString shouldBe
       "https://api.example.com/api/v3/pets"
     }
+
+    it("rejects a base URI carrying a query or fragment") {
+      val ex = intercept[IllegalArgumentException](BaklavaSttp.resolveUri(Uri.unsafeParse("https://api.example.com?key=x"), "/pets"))
+      ex.getMessage should include("must not carry a query or fragment")
+    }
   }
 
   describe("baklavaContextToHttpRequest") {

--- a/sttp/src/test/scala/pl/iterators/baklava/sttp4/BaklavaSttpRequestBuildingSpec.scala
+++ b/sttp/src/test/scala/pl/iterators/baklava/sttp4/BaklavaSttpRequestBuildingSpec.scala
@@ -124,7 +124,7 @@ class BaklavaSttpRequestBuildingSpec
     request.headers.filter(_.name.equalsIgnoreCase("Content-Type")).map(_.value)
 
   // Everything except headers/body/path is boilerplate the adapter ignores.
-  private def buildRequestContext[B: ToSttpBody](
+  private def buildRequestContext[B](
       hs: Seq[SttpHeader],
       body: Option[B],
       path: String = "/x"

--- a/sttp/src/test/scala/pl/iterators/baklava/sttp4/BaklavaSttpRequestBuildingSpec.scala
+++ b/sttp/src/test/scala/pl/iterators/baklava/sttp4/BaklavaSttpRequestBuildingSpec.scala
@@ -123,8 +123,41 @@ class BaklavaSttpRequestBuildingSpec
   private def contentTypesOf(request: HttpRequest): Seq[String] =
     request.headers.filter(_.name.equalsIgnoreCase("Content-Type")).map(_.value)
 
-  // Everything except headers/body/path is boilerplate the adapter ignores.
   private def buildRequestContext[B](
+      hs: Seq[SttpHeader],
+      body: Option[B],
+      path: String = "/x"
+  ): BaklavaRequestContext[B, Unit, Unit, Unit, Unit, Unit, Unit] =
+    SttpTestRequestContexts.build(hs, body, path)
+
+  override def afterAll(): Unit = ()
+}
+
+// separate spec because defaultHeaders is a spec-wide override
+class BaklavaSttpDefaultHeadersGuardSpec
+    extends AnyFunSpec
+    with Matchers
+    with BaklavaSttp[Unit, Unit, ScalatestAsExecution]
+    with BaklavaScalatest[SyncBackend, ToSttpBody, FromSttpBody] {
+
+  override def baseUri: Uri                    = Uri.unsafeParse("https://api.example.com")
+  override def defaultHeaders: Seq[SttpHeader] = Seq(SttpHeader("content-type", "application/json"))
+
+  describe("defaultHeaders") {
+    it("rejects a Content-Type declared in defaultHeaders") {
+      val ex = intercept[IllegalArgumentException](
+        baklavaContextToHttpRequest(SttpTestRequestContexts.build[String](Seq.empty, None))
+      )
+      ex.getMessage should include("Content-Type must not be set in defaultHeaders")
+    }
+  }
+
+  override def afterAll(): Unit = ()
+}
+
+object SttpTestRequestContexts {
+  // Everything except headers/body/path is boilerplate the adapter ignores.
+  def build[B](
       hs: Seq[SttpHeader],
       body: Option[B],
       path: String = "/x"
@@ -156,6 +189,4 @@ class BaklavaSttpRequestBuildingSpec
       responseDescription = None,
       responseHeaders = Seq.empty
     )
-
-  override def afterAll(): Unit = ()
 }

--- a/sttp/src/test/scala/pl/iterators/baklava/sttp4/SttpBodiesSpec.scala
+++ b/sttp/src/test/scala/pl/iterators/baklava/sttp4/SttpBodiesSpec.scala
@@ -53,5 +53,33 @@ class SttpBodiesSpec extends AnyFunSpec with Matchers {
     it("advertises the fixed boundary in the content type") {
       SttpBodies.multipartContentType shouldBe "multipart/form-data; boundary=baklava-multipart-boundary"
     }
+
+    it("escapes quotes and CRLF in part names") {
+      val rendered = new String(SttpBodies.renderMultipart(Multipart(TextPart("a\"b\r\nc", "v"))), UTF_8)
+      rendered should include("""Content-Disposition: form-data; name="a%22b%0D%0Ac"""")
+    }
+
+    it("escapes quotes and CRLF in filenames") {
+      val rendered = new String(
+        SttpBodies.renderMultipart(Multipart(FilePart("f", "text/plain", "evil\"file\r\n.txt", "X".getBytes(UTF_8)))),
+        UTF_8
+      )
+      rendered should include("""filename="evil%22file%0D%0A.txt"""")
+    }
+  }
+
+  describe("SttpBodyContent") {
+    it("compares bytes by value, not reference") {
+      val a = SttpBodyContent("payload".getBytes(UTF_8), "text/plain")
+      val b = SttpBodyContent("payload".getBytes(UTF_8), "text/plain")
+      a shouldBe b
+      a.hashCode shouldBe b.hashCode
+    }
+
+    it("distinguishes different bytes and different content types") {
+      val base = SttpBodyContent("payload".getBytes(UTF_8), "text/plain")
+      SttpBodyContent("other".getBytes(UTF_8), "text/plain") should not be base
+      SttpBodyContent("payload".getBytes(UTF_8), "application/json") should not be base
+    }
   }
 }

--- a/sttp/src/test/scala/pl/iterators/baklava/sttp4/SttpBodiesSpec.scala
+++ b/sttp/src/test/scala/pl/iterators/baklava/sttp4/SttpBodiesSpec.scala
@@ -1,0 +1,57 @@
+package pl.iterators.baklava.sttp4
+
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
+import pl.iterators.baklava.{FilePart, Multipart, TextPart}
+
+import java.nio.charset.StandardCharsets.UTF_8
+
+class SttpBodiesSpec extends AnyFunSpec with Matchers {
+
+  describe("urlEncodeForm") {
+    it("url-encodes keys and values and joins pairs with &") {
+      SttpBodies.urlEncodeForm(Seq("a b" -> "c&d", "ż" -> "x")) shouldBe "a+b=c%26d&%C5%BC=x"
+    }
+
+    it("renders an empty field list as an empty string") {
+      SttpBodies.urlEncodeForm(Seq.empty) shouldBe ""
+    }
+  }
+
+  describe("renderMultipart") {
+    it("renders text parts with the fixed boundary") {
+      val rendered = new String(SttpBodies.renderMultipart(Multipart(TextPart("greeting", "hello"))), UTF_8)
+      rendered shouldBe
+      "--baklava-multipart-boundary\r\n" +
+      "Content-Disposition: form-data; name=\"greeting\"\r\n\r\n" +
+      "hello\r\n" +
+      "--baklava-multipart-boundary--\r\n"
+    }
+
+    it("renders file parts with filename and content type") {
+      val rendered = new String(
+        SttpBodies.renderMultipart(Multipart(FilePart("logo", "image/png", "logo.png", "PNG".getBytes(UTF_8)))),
+        UTF_8
+      )
+      rendered shouldBe
+      "--baklava-multipart-boundary\r\n" +
+      "Content-Disposition: form-data; name=\"logo\"; filename=\"logo.png\"\r\n" +
+      "Content-Type: image/png\r\n\r\n" +
+      "PNG\r\n" +
+      "--baklava-multipart-boundary--\r\n"
+    }
+
+    it("omits filename from Content-Disposition when it is empty") {
+      val rendered = new String(
+        SttpBodies.renderMultipart(Multipart(FilePart("blob", "application/octet-stream", "BYTES".getBytes(UTF_8)))),
+        UTF_8
+      )
+      rendered should include("Content-Disposition: form-data; name=\"blob\"\r\n")
+      (rendered should not).include("filename")
+    }
+
+    it("advertises the fixed boundary in the content type") {
+      SttpBodies.multipartContentType shouldBe "multipart/form-data; boundary=baklava-multipart-boundary"
+    }
+  }
+}


### PR DESCRIPTION
Closes #121.

## What

A first-class `baklava-sttp` adapter so users can document remote/third-party APIs without depending on an HTTP **server** stack. The whole setup reduces to a `baseUri` override:

```scala
class GitHubApiSpec
    extends AnyFunSpec
    with Matchers
    with BaklavaSttp[Unit, Unit, ScalatestAsExecution]
    with BaklavaScalatest[SyncBackend, ToSttpBody, FromSttpBody] {

  override def baseUri: Uri = Uri.unsafeParse("https://api.github.com")
  override def defaultHeaders: Seq[Header] = Seq(Header("User-Agent", "baklava-demo"))
  // ...path/supports/onRequest as usual; ctx.performRequest(defaultBackend)
}
```

## How

- New `sttp/` module (`baklava-sttp`), built on **sttp-client4** (`SyncBackend`); package is `pl.iterators.baklava.sttp4` because a `...baklava.sttp` subpackage would shadow the top-level `sttp` package for every dependent module.
- Adapter type slots: `RouteType = SyncBackend`, `HttpRequest/HttpResponse = Request/Response[Array[Byte]]` — bodies are rendered eagerly to bytes so assertions and the doc serializer can both consume them. Method/status/header conversions are identities since core already speaks `sttp.model`.
- Small `ToSttpBody`/`FromSttpBody` typeclasses with instances for `EmptyBody`, `String`, `Array[Byte]`, `FormOf` (urlencoded), `Multipart` (fixed `baklava-multipart-boundary`, rendered manually for byte-stable captures), and circe `Encoder`/`Decoder`-derived JSON in a low-priority trait.
- Adapter defaults for the remote use case: `strictHeaderCheckDefault = false`, provided `DefaultSyncBackend()` with an override hook, `defaultHeaders` merged under per-test headers. Content-Type override semantics (single declared header wins; duplicates/unparseable throw) mirror the http4s/pekko adapters.

## Testing

- Unit tests for body rendering and request building (Content-Type override matrix, header merging, URI resolution incl. a guard rejecting query/fragment-carrying base URIs).
- Full-DSL spec against a JDK `com.sun.net.httpserver` stub — JSON/form/multipart round trips, default-header propagation, decode-failure error shape, 204/EmptyBody.
- `PetStoreSttpUserSpec` in the openapi module: testcontainers petstore, proving the DSL → OpenAPI pipeline end to end with none of the `performRequest`-override boilerplate the http4s twin needs.
- Docs: new `docs/sttp.md`, installation/intro updated.

## Notes

- While writing the decode-failure test we found a pre-existing core issue: `timesCalled` in `BaklavaTestFrameworkDsl` only increments after `baklavaPerformRequest` returns, so intercepting a decode-failure `BaklavaAssertionException` around `ctx.performRequest` yields a misleading "performRequest was not called" error (affects http4s/pekko adapters too). Worked around in the test; tracked in #128.
- The scala-cli example (docs/scala-cli.md) is converted to `baklava-sttp` in this PR (verified end to end against the live GitHub API via a local snapshot publish). Its `//> using dep` lines pin `2.1.0` — adjust if the release lands under a different version; the example only runs once that release is published.
