### PR TITLE
Mark Option schemas nullable so captured null values validate

### DIFF
--- a/core/src/main/scala/pl/iterators/baklava/BaklavaSerialize.scala
+++ b/core/src/main/scala/pl/iterators/baklava/BaklavaSerialize.scala
@@ -100,7 +100,7 @@ case class BaklavaSchemaSerializable(
     description: Option[String],
     // Value schema for a map-like object (`additionalProperties: <schema>`); `None` otherwise.
     additionalPropertiesSchema: Option[BaklavaSchemaSerializable] = None,
-    // True for Option-wrapped types (#131); default keeps old serialized call files decodable.
+    // default keeps pre-#131 serialized call files decodable
     nullable: Boolean = false
 ) extends Serializable
 

--- a/core/src/main/scala/pl/iterators/baklava/BaklavaSerialize.scala
+++ b/core/src/main/scala/pl/iterators/baklava/BaklavaSerialize.scala
@@ -99,7 +99,9 @@ case class BaklavaSchemaSerializable(
     default: Option[Json],
     description: Option[String],
     // Value schema for a map-like object (`additionalProperties: <schema>`); `None` otherwise.
-    additionalPropertiesSchema: Option[BaklavaSchemaSerializable] = None
+    additionalPropertiesSchema: Option[BaklavaSchemaSerializable] = None,
+    // True for Option-wrapped types (#131); default keeps old serialized call files decodable.
+    nullable: Boolean = false
 ) extends Serializable
 
 object BaklavaSchemaSerializable {
@@ -115,7 +117,8 @@ object BaklavaSchemaSerializable {
       additionalProperties = schema.additionalProperties,
       default = schema.default.flatMap(encodeDefault(schema.`type`)),
       description = schema.description,
-      additionalPropertiesSchema = schema.additionalPropertiesSchema.map(BaklavaSchemaSerializable(_))
+      additionalPropertiesSchema = schema.additionalPropertiesSchema.map(BaklavaSchemaSerializable(_)),
+      nullable = schema.nullable
     )
   }
 

--- a/core/src/main/scala/pl/iterators/baklava/Schema.scala
+++ b/core/src/main/scala/pl/iterators/baklava/Schema.scala
@@ -33,7 +33,7 @@ trait Schema[T] {
   // OpenAPI `additionalProperties: <schema>`). `None` for ordinary objects and primitives.
   def additionalPropertiesSchema: Option[Schema[?]] = None
 
-  // True for Option-wrapped types: the value may be explicitly null, not just absent (#131).
+  // may be explicitly null, not just absent — set by optionSchema (#131)
   def nullable: Boolean = false
 
   def withDescription(_description: String): Schema[T] = new Schema[T] {

--- a/core/src/main/scala/pl/iterators/baklava/Schema.scala
+++ b/core/src/main/scala/pl/iterators/baklava/Schema.scala
@@ -33,6 +33,9 @@ trait Schema[T] {
   // OpenAPI `additionalProperties: <schema>`). `None` for ordinary objects and primitives.
   def additionalPropertiesSchema: Option[Schema[?]] = None
 
+  // True for Option-wrapped types: the value may be explicitly null, not just absent (#131).
+  def nullable: Boolean = false
+
   def withDescription(_description: String): Schema[T] = new Schema[T] {
     val className: String                                      = Schema.this.className
     val `type`: SchemaType                                     = Schema.this.`type`
@@ -43,6 +46,7 @@ trait Schema[T] {
     val required: Boolean                                      = Schema.this.required
     val additionalProperties: Boolean                          = Schema.this.additionalProperties
     override val additionalPropertiesSchema: Option[Schema[?]] = Schema.this.additionalPropertiesSchema
+    override val nullable: Boolean                             = Schema.this.nullable
     val default: Option[T]                                     = Schema.this.default
     val description: Option[String]                            = Some(_description)
   }
@@ -57,6 +61,7 @@ trait Schema[T] {
     val required: Boolean                                      = Schema.this.required
     val additionalProperties: Boolean                          = Schema.this.additionalProperties
     override val additionalPropertiesSchema: Option[Schema[?]] = Schema.this.additionalPropertiesSchema
+    override val nullable: Boolean                             = Schema.this.nullable
     val default: Option[T]                                     = Some(_default)
     val description: Option[String]                            = Schema.this.description
   }
@@ -137,6 +142,7 @@ trait SchemaDefaults {
     val required: Boolean                                      = false
     val additionalProperties: Boolean                          = schema.additionalProperties
     override val additionalPropertiesSchema: Option[Schema[?]] = schema.additionalPropertiesSchema
+    override val nullable: Boolean                             = true
     val default: Option[Option[T]]                             = Some(None)
     val description: Option[String]                            = schema.description
   }

--- a/core/src/test/scala/pl/iterators/baklava/SchemaCompare.scala
+++ b/core/src/test/scala/pl/iterators/baklava/SchemaCompare.scala
@@ -14,6 +14,7 @@ object SchemaCompare {
       // aProp.className shouldEqual bProp.className
       aProp.format shouldEqual bProp.format
       aProp.`type` shouldEqual bProp.`type`
+      aProp.nullable shouldEqual bProp.nullable
     }
     a.items shouldEqual b.items
     a.`enum` shouldEqual b.`enum`
@@ -23,6 +24,7 @@ object SchemaCompare {
     a.additionalPropertiesSchema.flatMap(_.format) shouldEqual b.additionalPropertiesSchema.flatMap(_.format)
     a.description shouldEqual b.description
     a.default shouldEqual b.default
+    a.nullable shouldEqual b.nullable
     ()
   }
 }

--- a/core/src/test/scala/pl/iterators/baklava/SchemaSpec.scala
+++ b/core/src/test/scala/pl/iterators/baklava/SchemaSpec.scala
@@ -102,4 +102,30 @@ class SchemaSpec extends AnyFunSpec with Matchers {
       derived.additionalPropertiesSchema.map(_.`type`) shouldBe Some(SchemaType.IntegerType)
     }
   }
+
+  describe("nullable flag (regression for #131)") {
+
+    case class WithOptional(id: Int, note: Option[String])
+
+    it("marks Option schemas nullable and plain schemas not") {
+      implicitly[Schema[Option[String]]].nullable shouldBe true
+      implicitly[Schema[String]].nullable shouldBe false
+    }
+
+    it("marks Option fields of a derived case class nullable") {
+      val derived = implicitly[Schema[WithOptional]]
+      derived.properties("note").nullable shouldBe true
+      derived.properties("id").nullable shouldBe false
+    }
+
+    it("survives withDescription and withDefault copies") {
+      Schema.optionSchema(Schema.stringSchema).withDescription("d").nullable shouldBe true
+      Schema.optionSchema(Schema.stringSchema).withDefault(Some("x")).nullable shouldBe true
+    }
+
+    it("flows into BaklavaSchemaSerializable") {
+      BaklavaSchemaSerializable(Schema.optionSchema(Schema.stringSchema)).nullable shouldBe true
+      BaklavaSchemaSerializable(Schema.stringSchema).nullable shouldBe false
+    }
+  }
 }

--- a/openapi/src/main/scala/pl/iterators/baklava/openapi/BaklavaDslFormatterOpenAPIWorker.scala
+++ b/openapi/src/main/scala/pl/iterators/baklava/openapi/BaklavaDslFormatterOpenAPIWorker.scala
@@ -433,13 +433,12 @@ object BaklavaDslFormatterOpenAPIWorker {
     }
     baklavaSchema.description.foreach(schema.setDescription)
     baklavaSchema.format.foreach(schema.setFormat)
-    // OAS 3.0: explicit-null values only validate with nullable: true; `required` alone covers absence (#131)
     if (baklavaSchema.nullable) schema.setNullable(true)
     baklavaSchema.items.foreach(bs => schema.setItems(baklavaSchemaToOpenAPISchema(bs)))
     baklavaSchema.properties.foreach { case (name, bs) =>
       schema.addProperty(name, baklavaSchemaToOpenAPISchema(bs))
     }
-    // OAS 3.0: nullable alone doesn't let null pass enum validation — null must be listed among the values
+    // OAS 3.0: null must also be listed among enum values to pass validation
     baklavaSchema.`enum`.foreach { e =>
       val values = if (baklavaSchema.nullable) e.toList :+ (null: String) else e.toList
       schema.setEnum(values.asJava)

--- a/openapi/src/main/scala/pl/iterators/baklava/openapi/BaklavaDslFormatterOpenAPIWorker.scala
+++ b/openapi/src/main/scala/pl/iterators/baklava/openapi/BaklavaDslFormatterOpenAPIWorker.scala
@@ -433,11 +433,17 @@ object BaklavaDslFormatterOpenAPIWorker {
     }
     baklavaSchema.description.foreach(schema.setDescription)
     baklavaSchema.format.foreach(schema.setFormat)
+    // OAS 3.0: explicit-null values only validate with nullable: true; `required` alone covers absence (#131)
+    if (baklavaSchema.nullable) schema.setNullable(true)
     baklavaSchema.items.foreach(bs => schema.setItems(baklavaSchemaToOpenAPISchema(bs)))
     baklavaSchema.properties.foreach { case (name, bs) =>
       schema.addProperty(name, baklavaSchemaToOpenAPISchema(bs))
     }
-    baklavaSchema.`enum`.foreach(e => schema.setEnum(e.toList.asJava))
+    // OAS 3.0: nullable alone doesn't let null pass enum validation — null must be listed among the values
+    baklavaSchema.`enum`.foreach { e =>
+      val values = if (baklavaSchema.nullable) e.toList :+ (null: String) else e.toList
+      schema.setEnum(values.asJava)
+    }
     baklavaSchema.default.map(jsonToJavaObject).foreach(schema.setDefault)
     schema.setRequired(baklavaSchema.properties.toList.filter(_._2.required).map(_._1).asJava)
     baklavaSchema.additionalPropertiesSchema match {

--- a/openapi/src/test/resources/gold/openapi/openapi.yml
+++ b/openapi/src/test/resources/gold/openapi/openapi.yml
@@ -168,6 +168,7 @@ paths:
                     type: string
                   details:
                     type: array
+                    nullable: true
                     items:
                       type: string
                     default: null
@@ -276,10 +277,12 @@ paths:
         schema:
           type: string
           description: Lifecycle state of a project
+          nullable: true
           enum:
           - active
           - archived
           - draft
+          - null
           default: null
         examples:
           All active projects:
@@ -306,6 +309,7 @@ paths:
                       type: string
                     description:
                       type: string
+                      nullable: true
                       default: null
                     id:
                       type: integer
@@ -363,6 +367,7 @@ paths:
                   type: string
                 description:
                   type: string
+                  nullable: true
                   default: null
                 status:
                   type: string
@@ -396,6 +401,7 @@ paths:
                     type: string
                   description:
                     type: string
+                    nullable: true
                     default: null
                   id:
                     type: integer
@@ -438,6 +444,7 @@ paths:
                     type: string
                   details:
                     type: array
+                    nullable: true
                     items:
                       type: string
                     default: null
@@ -479,17 +486,21 @@ paths:
               properties:
                 name:
                   type: string
+                  nullable: true
                   default: null
                 description:
                   type: string
+                  nullable: true
                   default: null
                 status:
                   type: string
                   description: Lifecycle state of a project
+                  nullable: true
                   enum:
                   - active
                   - archived
                   - draft
+                  - null
                   default: null
               x-class: PatchProjectRequest
             examples:
@@ -516,6 +527,7 @@ paths:
                     type: string
                   description:
                     type: string
+                    nullable: true
                     default: null
                   id:
                     type: integer
@@ -588,6 +600,7 @@ paths:
                       - high
                     description:
                       type: string
+                      nullable: true
                       default: null
                     id:
                       type: integer
@@ -642,6 +655,7 @@ paths:
                   type: string
                 description:
                   type: string
+                  nullable: true
                   default: null
                 priority:
                   type: string
@@ -686,6 +700,7 @@ paths:
                     - high
                   description:
                     type: string
+                    nullable: true
                     default: null
                   id:
                     type: integer
@@ -725,6 +740,7 @@ paths:
         schema:
           type: integer
           format: int32
+          nullable: true
           default: null
         example: 20
       - name: page
@@ -735,6 +751,7 @@ paths:
         schema:
           type: integer
           format: int32
+          nullable: true
           default: null
         example: 1
       - name: role
@@ -745,10 +762,12 @@ paths:
         schema:
           type: string
           description: User role within the system
+          nullable: true
           enum:
           - admin
           - member
           - guest
+          - null
           default: null
         example: admin
       responses:
@@ -897,6 +916,7 @@ paths:
                     type: string
                   details:
                     type: array
+                    nullable: true
                     items:
                       type: string
                     default: null

--- a/openapi/src/test/resources/gold/tsfetch/src/common/types.ts
+++ b/openapi/src/test/resources/gold/tsfetch/src/common/types.ts
@@ -1,6 +1,6 @@
 export interface ErrorResponse {
   code: string;
-  details?: string[];
+  details?: string[] | null;
   message: string;
 }
 

--- a/openapi/src/test/resources/gold/tsfetch/src/projects/types.ts
+++ b/openapi/src/test/resources/gold/tsfetch/src/projects/types.ts
@@ -1,24 +1,24 @@
 export interface CreateProjectRequest {
-  description?: string;
+  description?: string | null;
   name: string;
   status: "active" | "archived" | "draft";
 }
 
 export interface CreateTaskRequest {
-  description?: string;
+  description?: string | null;
   priority: "high" | "low" | "medium";
   title: string;
 }
 
 export interface PatchProjectRequest {
-  description?: string;
-  name?: string;
-  status?: "active" | "archived" | "draft";
+  description?: string | null;
+  name?: string | null;
+  status?: "active" | "archived" | "draft" | null;
 }
 
 export interface Project {
   createdAt: string;
-  description?: string;
+  description?: string | null;
   id: number;
   name: string;
   ownerId: string;
@@ -26,7 +26,7 @@ export interface Project {
 }
 
 export interface Task {
-  description?: string;
+  description?: string | null;
   done: boolean;
   id: number;
   priority: "high" | "low" | "medium";

--- a/openapi/src/test/scala/pl/iterators/baklava/openapi/NullableOptionSchemaSpec.scala
+++ b/openapi/src/test/scala/pl/iterators/baklava/openapi/NullableOptionSchemaSpec.scala
@@ -1,0 +1,99 @@
+package pl.iterators.baklava.openapi
+
+import io.swagger.v3.core.util.Yaml
+import io.swagger.v3.oas.models.OpenAPI
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
+import pl.iterators.baklava.*
+import sttp.model.{Method, StatusCode}
+
+import scala.jdk.CollectionConverters.*
+
+// Regression for #131: Option fields must emit `nullable: true` so captured null values validate.
+class NullableOptionSchemaSpec extends AnyFunSpec with Matchers {
+
+  case class ErrorResponse(message: String, details: Option[String])
+
+  sealed trait Status
+  case object Active   extends Status
+  case object Archived extends Status
+  case class Project(name: String, status: Option[Status])
+
+  describe("OpenAPI schema emission for Option fields") {
+
+    it("emits nullable: true for Option properties and omits it for required ones") {
+      val openAPI = new OpenAPI()
+      BaklavaDslFormatterOpenAPIWorker.generateForCalls(openAPI, Seq(errorCall("""{"message":"boom","details":null}""")))
+
+      val schema =
+        openAPI.getPaths.get("/errors").getGet.getResponses.get("500").getContent.get("application/json").getSchema
+      schema.getProperties.get("details").getNullable shouldBe java.lang.Boolean.TRUE
+      Option(schema.getProperties.get("message").getNullable) shouldBe None
+    }
+
+    it("serializes nullable: true in YAML so null-valued examples validate against the schema") {
+      val openAPI = new OpenAPI()
+      BaklavaDslFormatterOpenAPIWorker.generateForCalls(openAPI, Seq(errorCall("""{"message":"boom","details":null}""")))
+
+      Yaml.pretty(openAPI) should include("nullable: true")
+    }
+
+    it("appends null to the enum values of a nullable enum schema (OAS 3.0 requires it to validate null)") {
+      val openAPI = new OpenAPI()
+      BaklavaDslFormatterOpenAPIWorker.generateForCalls(
+        openAPI,
+        Seq(errorCall("""{"name":"x","status":null}""", schema = BaklavaSchemaSerializable(implicitly[Schema[Project]])))
+      )
+
+      val statusSchema =
+        openAPI.getPaths
+          .get("/errors")
+          .getGet
+          .getResponses
+          .get("500")
+          .getContent
+          .get("application/json")
+          .getSchema
+          .getProperties
+          .get("status")
+      statusSchema.getNullable shouldBe java.lang.Boolean.TRUE
+      statusSchema.getEnum.asScala should contain(null)
+      statusSchema.getEnum.asScala should contain allOf ("Active", "Archived")
+    }
+  }
+
+  private def errorCall(
+      body: String,
+      schema: BaklavaSchemaSerializable = BaklavaSchemaSerializable(implicitly[Schema[ErrorResponse]])
+  ): BaklavaSerializableCall =
+    BaklavaSerializableCall(
+      request = BaklavaRequestContextSerializable(
+        symbolicPath = "/errors",
+        path = "/errors",
+        pathDescription = None,
+        pathSummary = None,
+        method = Some(Method("GET")),
+        operationDescription = None,
+        operationSummary = None,
+        operationId = None,
+        operationTags = Nil,
+        securitySchemes = Nil,
+        bodySchema = None,
+        bodyString = "",
+        headersSeq = Nil,
+        pathParametersSeq = Nil,
+        queryParametersSeq = Nil,
+        responseDescription = Some("Server error"),
+        responseHeaders = Nil
+      ),
+      response = BaklavaResponseContextSerializable(
+        protocol = BaklavaHttpProtocol("HTTP/1.1"),
+        status = StatusCode(500),
+        headers = Seq.empty,
+        bodyString = body,
+        requestContentType = None,
+        responseContentType = Some("application/json"),
+        bodySchema = Some(schema)
+      )
+    )
+}

--- a/orpc/src/test/scala/pl/iterators/baklava/orpc/BaklavaDslFormatterOrpcSpec.scala
+++ b/orpc/src/test/scala/pl/iterators/baklava/orpc/BaklavaDslFormatterOrpcSpec.scala
@@ -65,7 +65,13 @@ class BaklavaDslFormatterOrpcSpec extends AnyFunSpec with Matchers {
       val entry = endpoint(
         "GET",
         "/v1/auctions",
-        call("/v1/auctions", queryParams = Seq("limit" -> intSchema(required = false), "offset" -> intSchema(required = false)))
+        call(
+          "/v1/auctions",
+          queryParams = Seq(
+            "limit"  -> intSchema(required = false).copy(nullable = true),
+            "offset" -> intSchema(required = false).copy(nullable = true)
+          )
+        )
       )
       entry should include("      query: z.object({limit: z.number().int().nullish(), offset: z.number().int().nullish()}).optional()")
     }
@@ -84,7 +90,7 @@ class BaklavaDslFormatterOrpcSpec extends AnyFunSpec with Matchers {
       val entry = endpoint(
         "GET",
         "/v1/auctions",
-        call("/v1/auctions", queryParams = Seq("after-id" -> uuidSchema(required = false)))
+        call("/v1/auctions", queryParams = Seq("after-id" -> uuidSchema(required = false).copy(nullable = true)))
       )
       entry should include(""""after-id": z.uuid().nullish()""")
     }

--- a/tscommon/src/main/scala/pl/iterators/baklava/tscommon/TsZodRenderer.scala
+++ b/tscommon/src/main/scala/pl/iterators/baklava/tscommon/TsZodRenderer.scala
@@ -127,8 +127,7 @@ class TsZodRenderer(dialect: TsZodDialect, refs: BaklavaSchemaSerializable => Op
   def zod(schema: BaklavaSchemaSerializable): String =
     refs(schema).getOrElse(zodInline(schema))
 
-  // Absence (`.optional()`) comes from required=false on the field slot; explicit null (`.nullable()`)
-  // from the schema's nullable flag (#131). Option fields carry both -> `.nullish()`.
+  // required=false is absence, nullable is explicit null; Option fields are both (#131)
   private def modifierSuffix(schema: BaklavaSchemaSerializable): String =
     (schema.required, schema.nullable) match {
       case (true, false)  => ""
@@ -137,7 +136,7 @@ class TsZodRenderer(dialect: TsZodDialect, refs: BaklavaSchemaSerializable => Op
       case (false, false) => ".optional()"
     }
 
-  // Inside arrays and records absence is meaningless — only nullability applies.
+  // inside arrays and records absence is meaningless — only nullability applies
   private def nullableSuffix(schema: BaklavaSchemaSerializable): String =
     if (schema.nullable) ".nullable()" else ""
 

--- a/tscommon/src/main/scala/pl/iterators/baklava/tscommon/TsZodRenderer.scala
+++ b/tscommon/src/main/scala/pl/iterators/baklava/tscommon/TsZodRenderer.scala
@@ -99,8 +99,7 @@ class TsZodRenderer(dialect: TsZodDialect, refs: BaklavaSchemaSerializable => Op
     else {
       val zds = distinctSets.map { params =>
         val fields = params.map { p =>
-          val nullishMaybe = if (!schemaOf(p).required) ".nullish()" else ""
-          s"${tsObjectKey(nameOf(p))}: ${zod(schemaOf(p))}$nullishMaybe"
+          s"${tsObjectKey(nameOf(p))}: ${zod(schemaOf(p))}${modifierSuffix(schemaOf(p))}"
         }
         "z.object({" + fields.mkString(", ") + "})"
       }
@@ -128,6 +127,20 @@ class TsZodRenderer(dialect: TsZodDialect, refs: BaklavaSchemaSerializable => Op
   def zod(schema: BaklavaSchemaSerializable): String =
     refs(schema).getOrElse(zodInline(schema))
 
+  // Absence (`.optional()`) comes from required=false on the field slot; explicit null (`.nullable()`)
+  // from the schema's nullable flag (#131). Option fields carry both -> `.nullish()`.
+  private def modifierSuffix(schema: BaklavaSchemaSerializable): String =
+    (schema.required, schema.nullable) match {
+      case (true, false)  => ""
+      case (true, true)   => ".nullable()"
+      case (false, true)  => ".nullish()"
+      case (false, false) => ".optional()"
+    }
+
+  // Inside arrays and records absence is meaningless — only nullability applies.
+  private def nullableSuffix(schema: BaklavaSchemaSerializable): String =
+    if (schema.nullable) ".nullable()" else ""
+
   private def zodInline(schema: BaklavaSchemaSerializable): String = {
     val desc = schema.description.map(d => s""".describe("${escapeTsDoubleQuoted(d)}")""").getOrElse("")
     schema.`type` match {
@@ -144,7 +157,7 @@ class TsZodRenderer(dialect: TsZodDialect, refs: BaklavaSchemaSerializable => Op
       case SchemaType.IntegerType => s"z.number().int()$desc"
       case SchemaType.NumberType  => s"z.number()$desc"
       case SchemaType.ArrayType   =>
-        val item = schema.items.map(zod).getOrElse("z.any()")
+        val item = schema.items.map(i => zod(i) + nullableSuffix(i)).getOrElse("z.any()")
         s"z.array($item)$desc"
       case SchemaType.ObjectType =>
         val objectBody =
@@ -153,15 +166,15 @@ class TsZodRenderer(dialect: TsZodDialect, refs: BaklavaSchemaSerializable => Op
             val props = schema.properties.toSeq
               .sortBy(_._1)
               .map { case (k, v) =>
-                s""""${escapeTsDoubleQuoted(k)}": ${zod(v)}${if (!v.required) ".nullish()" else ""}"""
+                s""""${escapeTsDoubleQuoted(k)}": ${zod(v)}${modifierSuffix(v)}"""
               }
               .mkString("\n        ", ",\n        ", "")
             s"z.object({$props})"
           }
         schema.additionalPropertiesSchema match {
           // A map-like object: all values conform to one schema -> z.record (keys are strings in JSON).
-          case Some(v) if schema.properties.isEmpty => s"z.record(z.string(), ${zod(v)})$desc"
-          case Some(v)                              => s"$objectBody.catchall(${zod(v)})$desc"
+          case Some(v) if schema.properties.isEmpty => s"z.record(z.string(), ${zod(v)}${nullableSuffix(v)})$desc"
+          case Some(v)                              => s"$objectBody.catchall(${zod(v)}${nullableSuffix(v)})$desc"
           case None                                 => s"$objectBody$desc"
         }
       case SchemaType.NullType => s"z.null()$desc"

--- a/tsfetch/src/main/scala/pl/iterators/baklava/tsfetch/BaklavaTsFetchGenerator.scala
+++ b/tsfetch/src/main/scala/pl/iterators/baklava/tsfetch/BaklavaTsFetchGenerator.scala
@@ -486,10 +486,14 @@ private[tsfetch] class BaklavaTsFetchGenerator(calls: Seq[BaklavaSerializableCal
   private def renderInterfaceBody(schema: BaklavaSchemaSerializable): String = {
     val fields = schema.properties.toSeq.sortBy(_._1).map { case (name, s) =>
       val q = if (s.required) "" else "?"
-      s"  ${tsFieldKey(name)}$q: ${tsType(s)};"
+      s"  ${tsFieldKey(name)}$q: ${tsType(s)}${nullUnion(s)};"
     }
     "{\n" + fields.mkString("\n") + "\n}"
   }
+
+  // `?` only covers absence; an Option field captured as explicit null needs `| null` in the type (#131)
+  private def nullUnion(schema: BaklavaSchemaSerializable): String =
+    if (schema.nullable) " | null" else ""
 
   private def tsType(schema: BaklavaSchemaSerializable): String = schema.`type` match {
     case SchemaType.NullType    => "null"
@@ -501,13 +505,13 @@ private[tsfetch] class BaklavaTsFetchGenerator(calls: Seq[BaklavaSerializableCal
         schema.`enum`.get.toList.sorted.map(v => "\"" + v.replace("\"", "\\\"") + "\"").mkString(" | ")
       else "string"
     case SchemaType.ArrayType =>
-      val inner = schema.items.map(tsType).getOrElse("unknown")
+      val inner = schema.items.map(i => tsType(i) + nullUnion(i)).getOrElse("unknown")
       if (inner.contains(" | ") || inner.contains(" & ")) s"($inner)[]" else s"$inner[]"
     case SchemaType.ObjectType =>
       if (isNamedInterface(schema)) tsSafeIdent(schema.className)
       else
         schema.additionalPropertiesSchema match {
-          case Some(v) => s"Record<string, ${tsType(v)}>"
+          case Some(v) => s"Record<string, ${tsType(v)}${nullUnion(v)}>"
           case None    => if (schema.properties.isEmpty) "Record<string, unknown>" else renderInterfaceBody(schema)
         }
   }

--- a/tsfetch/src/test/scala/pl/iterators/baklava/tsfetch/BaklavaTsFetchGeneratorSpec.scala
+++ b/tsfetch/src/test/scala/pl/iterators/baklava/tsfetch/BaklavaTsFetchGeneratorSpec.scala
@@ -232,8 +232,34 @@ class BaklavaTsFetchGeneratorSpec extends AnyFunSpec with Matchers {
     }
   }
 
+  describe("nullable (Option) fields in generated TypeScript (regression for #131)") {
+
+    def widgetTypesTs(): String = {
+      cleanSrc()
+      val base = getCall("/widgets", tag = Some("Widgets"))
+      val call =
+        base.let(c => c.copy(response = c.response.copy(bodySchema = Some(BaklavaSchemaSerializable(implicitly[Schema[NullableWidget]])))))
+      generateAndRead("src/widgets/types.ts", Seq(call))
+    }
+
+    it("renders Option fields as `field?: T | null`") {
+      val typesTs = widgetTypesTs()
+      typesTs should include("note?: string | null;")
+      typesTs should include("id: number;")
+    }
+
+    it("renders arrays of Option elements as `(T | null)[]`") {
+      widgetTypesTs() should include("tags: (string | null)[];")
+    }
+
+    it("renders map values of Option type as `Record<string, T | null>`") {
+      widgetTypesTs() should include("counts: Record<string, number | null>;")
+    }
+  }
+
   case class Variant(url: String, width: Int)
   case class ImageDto(id: String, variants: Map[String, Variant])
+  case class NullableWidget(id: Int, note: Option[String], tags: Seq[Option[String]], counts: Map[String, Option[Int]])
 
   private def namedObject(name: String, props: Map[String, PrimitiveSchema[?]]): BaklavaSchemaSerializable =
     BaklavaSchemaSerializable(

--- a/tsrest/src/test/scala/pl/iterators/baklava/tsrest/BaklavaDslFormatterTsRestSpec.scala
+++ b/tsrest/src/test/scala/pl/iterators/baklava/tsrest/BaklavaDslFormatterTsRestSpec.scala
@@ -177,7 +177,12 @@ class BaklavaDslFormatterTsRestSpec extends AnyFunSpec with Matchers {
     it("quotes a kebab-case query-parameter key so the generated z.object is valid TypeScript (issue #105)") {
       val out = generator
         .buildParamsZod[BaklavaQueryParamSerializable](
-          Seq(Seq(queryParam("seller-id", uuidSchema(required = false)), queryParam("status", stringSchema().copy(required = false)))),
+          Seq(
+            Seq(
+              queryParam("seller-id", uuidSchema(required = false).copy(nullable = true)),
+              queryParam("status", stringSchema().copy(required = false, nullable = true))
+            )
+          ),
           _.name,
           _.schema
         )
@@ -232,7 +237,10 @@ class BaklavaDslFormatterTsRestSpec extends AnyFunSpec with Matchers {
         "/v1/auctions",
         getCall(
           "/v1/auctions",
-          queryParams = Seq("status" -> stringSchema().copy(required = false), "seller-id" -> uuidSchema(required = false))
+          queryParams = Seq(
+            "status"    -> stringSchema().copy(required = false, nullable = true),
+            "seller-id" -> uuidSchema(required = false).copy(nullable = true)
+          )
         )
       )
       entry should include("""query: z.object({status: z.string().nullish(), "seller-id": z.string().uuid().nullish()}),""")

--- a/tsrest/src/test/scala/pl/iterators/baklava/tsrest/TsZodRendererNullableSpec.scala
+++ b/tsrest/src/test/scala/pl/iterators/baklava/tsrest/TsZodRendererNullableSpec.scala
@@ -1,0 +1,47 @@
+package pl.iterators.baklava.tsrest
+
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
+import pl.iterators.baklava.*
+import pl.iterators.baklava.tscommon.{TsZodDialect, TsZodRenderer}
+
+// Regression for #131 in the zod renderers: nullability must survive into zod modifiers,
+// including nested positions (array elements, record values) that `required` never covered.
+class TsZodRendererNullableSpec extends AnyFunSpec with Matchers {
+
+  private val renderer = new TsZodRenderer(TsZodDialect.tsRest)
+
+  case class Widget(id: Int, note: Option[String])
+
+  describe("nullable flag in zod rendering") {
+
+    it("renders Option-derived properties as .nullish()") {
+      val zod = renderer.zodDefinition(BaklavaSchemaSerializable(implicitly[Schema[Widget]]))
+      zod should include(""""note": z.string().nullish()""")
+      zod should include(""""id": z.number().int()""")
+      zod should not include """"id": z.number().int().nullish()"""
+    }
+
+    it("renders optional-but-not-nullable properties as .optional()") {
+      val schema = BaklavaSchemaSerializable(implicitly[Schema[Widget]])
+        .copy(properties = Map("x" -> BaklavaSchemaSerializable(Schema.stringSchema).copy(required = false)))
+      renderer.zodDefinition(schema) should include(""""x": z.string().optional()""")
+    }
+
+    it("renders required-but-nullable properties as .nullable()") {
+      val schema = BaklavaSchemaSerializable(implicitly[Schema[Widget]])
+        .copy(properties = Map("x" -> BaklavaSchemaSerializable(Schema.stringSchema).copy(nullable = true)))
+      renderer.zodDefinition(schema) should include(""""x": z.string().nullable()""")
+    }
+
+    it("renders nullable array elements as z.array(inner.nullable())") {
+      val zod = renderer.zodDefinition(BaklavaSchemaSerializable(implicitly[Schema[Seq[Option[String]]]]))
+      zod should include("z.array(z.string().nullable())")
+    }
+
+    it("renders nullable record values as z.record(z.string(), inner.nullable())") {
+      val zod = renderer.zodDefinition(BaklavaSchemaSerializable(implicitly[Schema[Map[String, Option[Int]]]]))
+      zod should include("z.record(z.string(), z.number().int().nullable())")
+    }
+  }
+}

--- a/tsrest/src/test/scala/pl/iterators/baklava/tsrest/TsZodRendererNullableSpec.scala
+++ b/tsrest/src/test/scala/pl/iterators/baklava/tsrest/TsZodRendererNullableSpec.scala
@@ -5,8 +5,7 @@ import org.scalatest.matchers.should.Matchers
 import pl.iterators.baklava.*
 import pl.iterators.baklava.tscommon.{TsZodDialect, TsZodRenderer}
 
-// Regression for #131 in the zod renderers: nullability must survive into zod modifiers,
-// including nested positions (array elements, record values) that `required` never covered.
+// Regression for #131: nullability must reach zod modifiers, including array elements and record values.
 class TsZodRendererNullableSpec extends AnyFunSpec with Matchers {
 
   private val renderer = new TsZodRenderer(TsZodDialect.tsRest)


### PR DESCRIPTION
## Summary

Fixes #131. Builds on #126, which made JSON examples structured and thereby exposed that captured `null` field values fail schema validation — nothing carried Option-ness past `required: false`.

- `Schema` gains a `nullable` flag (default `false`); `optionSchema` sets it, `withDescription`/`withDefault` preserve it, and magnolia derivation picks it up automatically since Option fields resolve through `optionSchema`.
- `BaklavaSchemaSerializable` carries the flag as a trailing field with a default, so previously serialized call files still decode.
- The OpenAPI formatter emits `nullable: true` (OAS 3.0), and for nullable enum schemas appends `null` to the enum values — OAS 3.0 requires that for `null` to pass enum validation.

## Test plan

- New `NullableOptionSchemaSpec` (formatter: nullable property emission, YAML serialization, nullable-enum null entry) and a new `SchemaSpec` describe block (core: optionSchema/derivation/copy-preservation/serializable flow), all watched failing first
- `SchemaCompare` now asserts `nullable`, strengthening all existing derivation tests
- Gold regenerated: 17 `nullable: true` insertions + `- null` enum entries, nothing else
- `redocly lint` on the gold spec: the 10 captured-null `no-invalid-media-type-examples` warnings are gone (46 → 16 across the whole PR stack; remaining: fixture-design 4xx/license warnings and 2 form-urlencoded/multipart string-example warnings, which are a separate issue class)
- Full `+test` green on Scala 2.13.18 and 3.3.7 with `tlFatalWarnings := true`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019svHBC5nktCrBRp7x7eLJn