### PR TITLE
Skip generation when zero calls were captured; document sbt 2's cached test task

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,9 @@ sbt test
 # Output in target/baklava/openapi/openapi.yml, target/baklava/simple/, etc.
 ```
 
+> [!WARNING]
+> **On sbt 2, use `sbt testFull` to generate documentation.** sbt 2 redefined `test` as an incremental task cached in a global store (`~/.cache/sbt`) that survives `clean` — on a warm cache it may run only a subset of your suite, or nothing at all, and the generated documentation only covers the tests that actually ran. `testFull` is the uncached, run-everything task. (Baklava refuses to overwrite existing output when zero calls were captured, but a partial run still produces partial documentation.)
+
 ## Try It Without a Build
 
 Prefer to see it working first? A single [scala-cli](https://scala-cli.virtuslab.org/) script can test the **live GitHub REST API** and generate an OpenAPI spec plus a typed sttp client from verified responses — no sbt project needed:

--- a/core/src/main/scala/pl/iterators/baklava/BaklavaGenerate.scala
+++ b/core/src/main/scala/pl/iterators/baklava/BaklavaGenerate.scala
@@ -19,14 +19,37 @@ object BaklavaGenerate {
 
     BaklavaSerialize.listSerializedCalls() match {
       case Success(calls) =>
-        BaklavaDslFormatter.formatters.foreach(_.create(configMap, calls))
-        BaklavaSerialize.cleanSerializedCalls() match {
-          case Failure(exception) =>
-            System.err.println(s"Failed to clean serialized calls: $exception")
-          case Success(_) => // Success, no action needed
+        if (generate(configMap, calls, BaklavaDslFormatter.formatters)) {
+          BaklavaSerialize.cleanSerializedCalls() match {
+            case Failure(exception) =>
+              System.err.println(s"Failed to clean serialized calls: $exception")
+            case Success(_) => // Success, no action needed
+          }
         }
       case Failure(exception) =>
         System.err.println(s"Failed to list serialized calls: $exception")
+    }
+  }
+
+  /** Runs the formatters over the captured calls. With zero captured calls generation is skipped (returning false), so a previously
+    * generated spec is never overwritten by an empty one — zero calls almost always means the test suite didn't actually run, e.g. sbt 2's
+    * incremental `test` restoring a cached result (see issue #135).
+    */
+  private[baklava] def generate(
+      configMap: Map[String, String],
+      calls: Seq[BaklavaSerializableCall],
+      formatters: => Seq[BaklavaDslFormatter]
+  ): Boolean = {
+    if (calls.isEmpty) {
+      System.err.println(
+        "Baklava captured 0 calls — skipping generation so existing output is not overwritten. " +
+          "If your tests did run, make sure they use the Baklava DSL. " +
+          "If no tests ran, you may have hit sbt 2's incremental, cached `test` task; run `testFull` for a full run."
+      )
+      false
+    } else {
+      formatters.foreach(_.create(configMap, calls))
+      true
     }
   }
 }

--- a/core/src/test/scala/pl/iterators/baklava/BaklavaGenerateSpec.scala
+++ b/core/src/test/scala/pl/iterators/baklava/BaklavaGenerateSpec.scala
@@ -1,0 +1,77 @@
+package pl.iterators.baklava
+
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
+import sttp.model.StatusCode
+
+import java.io.{ByteArrayOutputStream, PrintStream}
+import java.nio.charset.StandardCharsets
+
+class BaklavaGenerateSpec extends AnyFunSpec with Matchers {
+
+  private class RecordingFormatter extends BaklavaDslFormatter {
+    var invocations: List[Seq[BaklavaSerializableCall]]                                         = Nil
+    override def create(config: Map[String, String], calls: Seq[BaklavaSerializableCall]): Unit =
+      invocations = invocations :+ calls
+  }
+
+  private val call = BaklavaSerializableCall(
+    BaklavaRequestContextSerializable(
+      symbolicPath = "/pets/{id}",
+      path = "/pets/1",
+      pathDescription = None,
+      pathSummary = None,
+      method = None,
+      operationDescription = None,
+      operationSummary = None,
+      operationId = None,
+      operationTags = Seq.empty,
+      securitySchemes = Seq.empty,
+      bodySchema = None,
+      headersSeq = Seq.empty,
+      pathParametersSeq = Seq.empty,
+      queryParametersSeq = Seq.empty,
+      responseDescription = None,
+      responseHeaders = Seq.empty
+    ),
+    BaklavaResponseContextSerializable(
+      protocol = BaklavaHttpProtocol("HTTP/1.1"),
+      status = StatusCode.Ok,
+      headers = Seq.empty,
+      requestContentType = None,
+      responseContentType = None,
+      bodySchema = None
+    )
+  )
+
+  private def captureStdErr[T](body: => T): (T, String) = {
+    val buffer   = new ByteArrayOutputStream()
+    val original = System.err
+    System.setErr(new PrintStream(buffer, true, "UTF-8"))
+    try {
+      val result = body
+      (result, new String(buffer.toByteArray, StandardCharsets.UTF_8))
+    } finally System.setErr(original)
+  }
+
+  describe("BaklavaGenerate.generate") {
+
+    it("skips formatters when zero calls were captured, so existing output is not overwritten") {
+      val formatter     = new RecordingFormatter
+      val (ran, stderr) = captureStdErr(BaklavaGenerate.generate(Map.empty, Seq.empty, Seq(formatter)))
+
+      ran shouldBe false
+      formatter.invocations shouldBe empty
+      stderr should include("0")
+      stderr should include("testFull")
+    }
+
+    it("runs formatters when calls were captured") {
+      val formatter = new RecordingFormatter
+      val ran       = BaklavaGenerate.generate(Map("k" -> "v"), Seq(call), Seq(formatter))
+
+      ran shouldBe true
+      formatter.invocations shouldBe List(Seq(call))
+    }
+  }
+}

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -290,6 +290,12 @@ The plugin provides several SBT tasks:
 - `baklavaGenerate` - Generate API documentation from your tests (executed automatically during `sbt test`)
 - `baklavaClean` - Clean generated documentation files
 
+:::warning[sbt 2: use `testFull` to generate documentation]
+
+sbt 2 redefined `test` as an incremental task cached in a global store (`~/.cache/sbt`) that survives `clean` — on a warm cache it may run only a subset of your suite, or nothing at all, and the generated documentation only covers the tests that actually ran. Run `sbt testFull` (the uncached, run-everything task) whenever you want complete documentation. Baklava refuses to overwrite existing output when zero calls were captured, but a partial run still produces partial documentation.
+
+:::
+
 The documentation will be generated in `target/baklava/` directory after running your tests:
 - Simple format: `target/baklava/simple/`
 - OpenAPI format: `target/baklava/openapi/openapi.yml`

--- a/docs/intro.md
+++ b/docs/intro.md
@@ -21,6 +21,12 @@ Baklava is a Scala library that generates API documentation directly from your H
 2. Run your tests with `sbt test` — Baklava serializes each test case to JSON in `target/baklava/calls/`
 3. The SBT plugin automatically generates documentation from the collected test cases
 
+:::warning[sbt 2: use `testFull` to generate documentation]
+
+sbt 2 redefined `test` as an incremental task cached in a global store (`~/.cache/sbt`) that survives `clean` — on a warm cache it may run only a subset of your suite, or nothing at all, and the generated documentation only covers the tests that actually ran. Run `sbt testFull` (the uncached, run-everything task) whenever you want complete documentation. Baklava refuses to overwrite existing output when zero calls were captured, but a partial run still produces partial documentation.
+
+:::
+
 ### Quick links
 
 - [Installation](installation.md)

--- a/docs/output-formats.md
+++ b/docs/output-formats.md
@@ -29,6 +29,14 @@ The generation pipeline:
 3. Every formatter found on the classpath processes the calls and writes its output
 4. The call files are cleaned up
 
+Because generation only sees the calls captured in the current run, the output is only as complete as the test run itself. If zero calls were captured, generation is skipped with a warning so existing output is not overwritten by an empty spec.
+
+:::warning[sbt 2: use `testFull` to generate documentation]
+
+sbt 2 redefined `test` as an incremental task cached in a global store (`~/.cache/sbt`) that survives `clean` — on a warm cache it may run only a subset of your suite, or nothing at all, and the generated documentation only covers the tests that actually ran. Run `sbt testFull` (the uncached, run-everything task) whenever you want complete documentation.
+
+:::
+
 ## Simple Format
 
 **Dependency:** `"pl.iterators" %% "baklava-simple" % "VERSION" % Test`


### PR DESCRIPTION
Closes #135.

## Problem

Baklava generation runs as a post-`test` side effect (`Tests.Cleanup`). It formatted whatever serialized calls were in `target/baklava/calls/` — even **zero** — and overwrote the previous output. Under sbt 2, bare `test` is an incremental task cached in a global store (`~/.cache/sbt/v2`) that survives `clean`; on a warm cache it runs 0 tests (exit 0) while the cleanup hook still fires, so a complete `openapi.yml` got replaced by an empty stub. Reported downstream in luksow/madrileno#113 / fixed on their side in luksow/madrileno#114 by switching to `testFull`, with the structural fix explicitly left to Baklava.

## Changes

- **Empty-capture guard** (`BaklavaGenerate`): when zero calls were captured, skip the formatters entirely — existing output stays intact — and print a warning explaining the likely cause and pointing sbt 2 users at `testFull`. Serialized-call cleanup is also skipped in that case (there is nothing to clean). Covered by a new `BaklavaGenerateSpec` (guard skips formatters + warns; non-empty path still runs formatters).
- **Docs**: prominent sbt 2 warning everywhere `sbt test` is prescribed for generation (README, intro, installation, output-formats): use `sbt testFull` for complete documentation, because incremental `test` may run a subset or nothing and the output only covers tests that actually ran.

A partial incremental run (subset of the suite) still produces a partial spec — that can't be detected mechanically (partial output via `testOnly` is a feature), so it's covered by the documentation warning only.

## Verification

- TDD: watched the guard test fail against the extracted always-run behavior, then implemented the guard.
- `sbt +core/test` green on Scala 2.13.18 (53 tests) and 3.3.7 (60 tests); `core/scalafmtCheckAll` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)